### PR TITLE
Fix off-by-one error when using the len(prefix) to do slicing.

### DIFF
--- a/logstash_index_cleaner.py
+++ b/logstash_index_cleaner.py
@@ -78,7 +78,7 @@ def find_expired_indices(connection, days_to_keep=None, hours_to_keep=None, sepa
             print >> out, 'Skipping index due to missing prefix {0}: {1}'.format(prefix, index_name)
             continue
         
-        unprefixed_index_name = index_name[len(prefix):]
+        unprefixed_index_name = index_name[len(prefix)+1:]
         
         # find the timestamp parts (i.e ['2011', '01', '05'] from '2011.01.05') using the configured separator
         parts = unprefixed_index_name.split(separator)


### PR DESCRIPTION
This fixes errors such as:

```
Could not find a valid timestamp from the index: logstash-2013.09.08
Could not find a valid timestamp from the index: logstash-2013.09.09
Could not find a valid timestamp from the index: logstash-2013.09.10
Could not find a valid timestamp from the index: logstash-2013.09.11
Could not find a valid timestamp from the index: logstash-2013.09.12
```

... even though the prefix and separator are correct.
