### PR TITLE
Updated to use the official Elasticsearch Python API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyes==0.20.1
+elasticsearch>=0.4.4


### PR DESCRIPTION
Updated to use the [official Elasticsearch Python API](http://www.elasticsearch.org/guide/en/elasticsearch/client/python-api/current/index.html)

Updated logging model to use external file (or STDERR), cleaner ISO8601 timestamp, reduce logging based on debug flag and not much else has changed.  Verified against Elasticsearch 0.90.9
