### PR TITLE
Added argparse as a requirement to install on Python 2.6 based systems

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 elasticsearch>=0.4.4
+argparse>=1.2.1


### PR DESCRIPTION
- Added argparse as a requirement since it's not standard in Python 2.6 based systems.
