### PR TITLE
Fix for Issue #58 Added CURATOR_BUILD_NUMBER

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def fread(fname):
 
 def get_version():
     VERSION = fread("VERSION").strip()
-    build_number = os.environ.get('BUILD_NUMBER', None)
+    build_number = os.environ.get('CURATOR_BUILD_NUMBER', None)
     if build_number:
         return VERSION + "b{}".format(build_number)
     return VERSION


### PR DESCRIPTION
Fix for Issue #58
Changed BUILD_NUMBER to CURATOR_BUILD_NUMBER
To avoid conflicts with existing env var in any setup env (e.g. Jenkins CI)
