### PR TITLE
Time unit off-by-one fix for #65

### DIFF
--- a/curator/curator.py
+++ b/curator/curator.py
@@ -181,7 +181,7 @@ def find_expired_indices(client, time_unit, unit_count, separator='.', prefix='l
         required_parts = 3
         utc_now = utc_now.replace(hour=0)
 
-    cutoff = utc_now - timedelta(**{time_unit: unit_count})
+    cutoff = utc_now - timedelta(**{time_unit: (unit_count - 1)})
     sorted_indices = sorted(client.indices.get_settings(index=prefix+'*', params={'expand_wildcards': 'closed'}).keys())
 
     for index_name in sorted_indices:


### PR DESCRIPTION
```
2014-04-15T11:20:10.209 INFO                  index_loop:291  Would have attempted deleting index logstash-2014.04.13 because it is 2 days, 0:00:00 older than the calculated cutoff.
2014-04-15T11:20:10.209 INFO                  index_loop:291  Would have attempted deleting index logstash-2014.04.14 because it is 1 day, 0:00:00 older than the calculated cutoff.
2014-04-15T11:20:10.209 INFO        find_expired_indices:209  logstash-2014.04.15 is 0:00:00 above the cutoff.
```
