### PR TITLE
Fix `format` call index issue for Python 2.6

### DIFF
--- a/curator/curator.py
+++ b/curator/curator.py
@@ -535,7 +535,7 @@ def alias_loop(client, dry_run=False, **kwargs):
 
 def command_loop(client, dry_run=False, **kwargs):
     command = kwargs['command']
-    logging.info("Beginning {} operations...".format(command.upper()))
+    logging.info("Beginning {0} operations...".format(command.upper()))
     op, words = OP_MAP[command]
     by_space = kwargs['disk_space'] if 'disk_space' in kwargs else False
     if command == 'delete' and by_space:
@@ -651,7 +651,7 @@ def main():
 
     # Override the timestamp in case the end-user doesn't.
     if timeout_override and arguments.timeout == 30:
-        logger.info('Default timeout of 30 seconds is too low for command {}.  Overriding to 21,600 seconds (6 hours).'.format(arguments.command.upper()))
+        logger.info('Default timeout of 30 seconds is too low for command {0}.  Overriding to 21,600 seconds (6 hours).'.format(arguments.command.upper()))
         arguments.timeout = 21600
 
     client = elasticsearch.Elasticsearch(host=arguments.host, port=arguments.port, url_prefix=arguments.url_prefix, timeout=arguments.timeout, use_ssl=arguments.ssl)
@@ -665,7 +665,7 @@ def main():
 
     # Execute the command specified in the arguments
     argdict = arguments.__dict__
-    logging.debug("argdict = {}".format(argdict))
+    logging.debug("argdict = {0}".format(argdict))
     arguments.func(client, **argdict)
 
     logger.info('Done in {0}.'.format(timedelta(seconds=time.time()-start)))

--- a/curator/es_repo_mgr.py
+++ b/curator/es_repo_mgr.py
@@ -168,7 +168,7 @@ def _create_repository(client, dry_run=False, **kwargs):
             logger.error("Repository {0} failed validation...".format(repo_name))
             return False
     else:
-        logger.info("Would have attempted to create repository {}".format(kwargs['repository']))
+        logger.info("Would have attempted to create repository {0}".format(kwargs['repository']))
 
 def _delete_repository(client, repository=None, dry_run=False, **kwargs):
     if not dry_run:
@@ -179,7 +179,7 @@ def _delete_repository(client, repository=None, dry_run=False, **kwargs):
             logger.error("Error: {0}".format(e))
             return False
     else:
-        logger.info("Would have attempted to delete repository {}".format(repository))
+        logger.info("Would have attempted to delete repository {0}".format(repository))
 
 def create_repo_body(repo_type='fs',
                      compress=True, concurrent_streams=None, chunk_size=None, max_restore_bytes_per_sec=None, max_snapshot_bytes_per_sec=None,
@@ -242,7 +242,7 @@ def main():
 
     # Execute the command specified in the arguments
     argdict = arguments.__dict__
-    logging.debug("argdict = {}".format(argdict))
+    logging.debug("argdict = {0}".format(argdict))
     arguments.func(client, **argdict)
     
     logger.info('Done in {0}.'.format(timedelta(seconds=time.time()-start)))


### PR DESCRIPTION
This was reported in #95.  

Since we don't test Python 2.6, but only 2.7 and 3.3, we missed this.

Calling `format` in python 2.6 requires that the index number be in the curly braces, even if there's only one value to format.
