### PR TITLE
Change "above" to "younger than"

### DIFF
--- a/curator/curator.py
+++ b/curator/curator.py
@@ -293,7 +293,7 @@ def find_expired_data(client, object_list=[], utc_now=None, time_unit='days', ol
             yield object_name, cutoff-object_time
     
         else:
-            logger.info('{0} is {1} above the cutoff.'.format(object_name, object_time-cutoff))
+            logger.info('{0} is {1} newer than the cutoff.'.format(object_name, object_time-cutoff))
 
 def find_overusage_indices(client, disk_space=2097152.0, prefix='logstash-', **kwargs):
     """ Generator that yields over usage indices.


### PR DESCRIPTION
I'm suggesting using opposing verbs for describing indices. like **older** and **newer**, or **above** and **below**.  But using _older_ in contrast to **above** is confusing. At first, I thought that the indices that are `above the cutoff` were going to get deleted. I realized I don't understand what that means. Can we change **above** to **newer** to make the message more clear?

```
ubuntu@machine:~$ date
Wed Jul 23 03:34:00 UTC 2014
ubuntu@machine:~$ curator --dry-run delete --older-than 50
2014-07-23T03:34:33.398 INFO                        main:647  Job starting...
2014-07-23T03:34:33.398 INFO                        main:650  DRY RUN MODE.  No changes will be made.
2014-07-23T03:34:33.399 INFO                   _new_conn:188  Starting new HTTP connection (1): localhost
2014-07-23T03:34:33.401 INFO         log_request_success:57   GET http://localhost:9200/ [status:200 request:0.002s]
2014-07-23T03:34:33.401 INFO                command_loop:540  Beginning DELETE operations...
2014-07-23T03:34:33.405 INFO         log_request_success:57   GET http://localhost:9200/logstash-*/_settings?expand_wildcards=closed [status:200 request:0.003s]
2014-07-23T03:34:33.408 INFO                command_loop:560  Would have attempted deleting index logstash-2013.12.11 because it is 175 days, 0:00:00 older than the calculated cutoff.
2014-07-23T03:34:33.412 INFO           find_expired_data:308  logstash-2014.07.19 is 45 days, 0:00:00 above the cutoff.
2014-07-23T03:34:33.412 INFO           find_expired_data:308  logstash-2014.07.20 is 46 days, 0:00:00 above the cutoff.
2014-07-23T03:34:33.412 INFO           find_expired_data:308  logstash-2014.07.21 is 47 days, 0:00:00 above the cutoff.
2014-07-23T03:34:33.412 INFO           find_expired_data:308  logstash-2014.07.22 is 48 days, 0:00:00 above the cutoff.
2014-07-23T03:34:33.412 INFO           find_expired_data:308  logstash-2014.07.23 is 49 days, 0:00:00 above the cutoff.
2014-07-23T03:34:33.412 INFO                command_loop:582  DELETE index operations completed.
2014-07-23T03:34:33.412 INFO                        main:674  Done in 0:00:00.022450.
ubuntu@machine:~$
```
