### PR TITLE
Feature/130

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 1.x.x (? ? ?)
-
+ # General
+ - New! `--delay` after optimize to allow cluster to quiesce #131 (untergeek)
+ 
 1.2.2 (29 July 2014)
  # Bug fix
  - Updated README.md to briefly explain what curator does #117 (untergeek)

--- a/curator/curator.py
+++ b/curator/curator.py
@@ -135,6 +135,7 @@ def make_parser():
     add_common_args(parser_optimize)
     parser_optimize.add_argument('--older-than', required=True, help='Optimize indices older than n TIME_UNITs', type=int)
     parser_optimize.add_argument('--max_num_segments', help='Optimize segment count to n segments per shard.', default=DEFAULT_ARGS['max_num_segments'], type=int)
+    parser_optimize.add_argument('--delay', help='Number of seconds to delay after optimizing an index.', type=int, default=0)
 
     # Show indices
     parser_show = subparsers.add_parser('show', help='Show indices or snapshots')
@@ -589,6 +590,10 @@ def command_loop(client, dry_run=False, **kwargs):
 
         # if no error was raised and we got here that means the operation succeeded
         logger.info('{0}: Successfully {1}.'.format(index_name, words['verbed']))
+        if 'delay' in kwargs:
+            if kwargs['delay'] > 0:
+                logger.info('Pausing for {0} seconds to allow cluster to quiesce...'.format(kwargs['delay']))
+                time.sleep(kwargs['delay'])
     if 'for' in words['op']:
         w = words['op'][:-4]
     else:


### PR DESCRIPTION
This feature adds the `--delay` flag to the optimize command.  In #130 a user described his cluster as needing a 2 minute pause between optimize operations, that allowing the cluster to quiesce between optimize operations was beneficial.  This functionality should help anyone else facing that.
