### PR TITLE
Feature/134

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 2.x.x (? ? ?)
  # General
  - New! `--delay` after optimize to allow cluster to quiesce #131 (untergeek)
+ - New! `--suffix` option in addition to `--prefix` #136 (untergeek)
+ - New! Support for wildcards in prefix & suffix #136 (untergeek)
  
 1.2.2 (29 July 2014)
  # Bug fix

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -34,3 +34,4 @@ Contributors:
 * Markus Fischer (mfn)
 * Fabien Wernli (faxm0dem)
 * Michael Weiser (michaelweiser)
+* (digital-wonderland)

--- a/test_curator/integration/test_utils.py
+++ b/test_curator/integration/test_utils.py
@@ -103,7 +103,7 @@ class TestExcludeIndex(CuratorTestCase):
         self.create_index('logstash-2014.06.07')
         self.create_index('logstash-2014.06.08')
         self.create_index('logstash-2014.06.09')
-        object_list = curator.get_object_list(self.client, data_type='index', prefix='logstash-', repository=None, exclude_pattern='2014.06.08')
+        object_list = curator.get_object_list(self.client, data_type='index', prefix='logstash-', suffix='', repository=None, exclude_pattern='2014.06.08')
         self.assertEquals(
             [
                 u'logstash-2014.06.07',


### PR DESCRIPTION
This adds wildcards _and_ suffixes.  Now you can do time-series indices with prefixes, suffixes, both, or even neither!  Yes, tests have even been added that show you can do time-series index management on indices in `YYYY.MM.dd` format, or the other supported daily, hourly, weekly or monthly formats.
