### PR TITLE
bugfix to allow deletion by space to work

### DIFF
--- a/curator/curator.py
+++ b/curator/curator.py
@@ -576,6 +576,8 @@ def command_loop(client, dry_run=False, **kwargs):
         expired_indices = find_expired_data(object_list=index_list, **kwargs)
 
     for index_name in expired_indices:
+        if isinstance(index_name, tuple):
+            index_name = index_name[0]
         if not by_space:
             logger.info(prepend + 'Attempting to {0} index {1}.'.format(words['op'], index_name))
         else:


### PR DESCRIPTION
Deletion by space doesn't work, and hasn't worked since at least a [huge commit](https://github.com/elasticsearch/curator/commit/73dfa7c8068cdbe2085d732f3822379bf58145a4) in January.

There was a (now deleted) mention that `find_overusage_indices` needed to return a tuple for compatibility.  That was several versions ago and it was abandoned in `find_expired_data`, but I left it alone anyway and just added a tuple check that pulls out the index name.

Please don't add me to contributors.
