### PR TITLE
Changing from fatal to info, exit code 0 for non-master node test

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
  
  # Bug fix
  - Missing " in Logstash log format #143 (cassianoleal)
+ - Change non-master node test to exit code 0, log as info. #145 (untergeek)
  
 1.2.2 (29 July 2014)
  # Bug fix

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -36,3 +36,4 @@ Contributors:
 * Michael Weiser (michaelweiser)
 * (digital-wonderland)
 * cassiano (cassianoleal)
+* Matt Dainty (bodgit)

--- a/curator/curator.py
+++ b/curator/curator.py
@@ -767,8 +767,8 @@ def main():
     check_version(client)
     
     if arguments.master_only and not is_master_node(client):
-        logger.fatal('Master-only flag detected. Connected to non-master node. Aborting.')
-        sys.exit(1)
+        logger.info('Master-only flag detected. Connected to non-master node. Aborting.')
+        sys.exit(0)
 
     if arguments.command != "show":
         if arguments.timestring:


### PR DESCRIPTION
This recommendation is discussed in #144.
