### PR TITLE
Return a list instead of a tuple

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
  # Bug fix
  - Missing " in Logstash log format #143 (cassianoleal)
  - Change non-master node test to exit code 0, log as info. #145 (untergeek)
+ - `find_overusage_indices` returns a list instead of a tuple. #147 (untergeek)
  
 1.2.2 (29 July 2014)
  # Bug fix

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -37,3 +37,4 @@ Contributors:
 * (digital-wonderland)
 * cassiano (cassianoleal)
 * Matt Dainty (bodgit)
+* Alex Philipp (alex-sf)

--- a/curator/curator.py
+++ b/curator/curator.py
@@ -400,7 +400,7 @@ def find_overusage_indices(client, disk_space=2097152.0, prefix='logstash-', **k
         disk_usage += index_size
 
         if disk_usage > disk_limit:
-            yield index_name, 0
+            yield index_name
         else:
             logger.info('skipping {0}, disk usage is {1:.3f} GB and disk limit is {2:.3f} GB.'.format(index_name, disk_usage/2**30, disk_limit/2**30))
 


### PR DESCRIPTION
This fix is described in #141, though an alternate solution was provided there.
