### PR TITLE
This turned out to not be needed.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-elasticsearch>=1.0.0,<2.0.0
-elasticsearch-curator


### PR DESCRIPTION
The `setup.py` itself was sufficient on rtfd.org.
