### PR TITLE
Catch concurrent snapshots

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -17,6 +17,8 @@ Changelog
  * Edge case where 1.4.0.Beta1-SNAPSHOT would break version check. Reported in #183 (untergeek)
  * Typo fixed. #193 (ferki)
  * Type fixed. #204 (gheppner)
+ * Shows proper error in the event of concurrent snapshots. #177 (untergeek)
+ 
 
 2.0.2 (8 October 2014)
 ----------------------

--- a/curator/curator.py
+++ b/curator/curator.py
@@ -673,7 +673,11 @@ def create_snapshot(client, indices='_all', snapshot_name=None,
         logger.info("Snapshot name: {0}".format(snapshot_name))
         all_snaps = get_snaplist(client, repository=repository, snapshot_prefix=snapshot_prefix)
         if not snapshot_name in all_snaps and len(indices) > 0:
-            client.snapshot.create(repository=repository, snapshot=snapshot_name, body=body, wait_for_completion=wait_for_completion)
+            try:
+                client.snapshot.create(repository=repository, snapshot=snapshot_name, body=body, wait_for_completion=wait_for_completion)
+            except elasticsearch.TransportError as e:
+                logger.error("Client raised a TransportError.  Error: {0}".format(e))
+                return True
         elif len(indices) == 0:
             logger.warn("No indices provided.")
             return True


### PR DESCRIPTION
Curator now shows a proper error in the event of concurrent snapshots

closes #177
