### PR TITLE
Correctly handle 0 in --older_than, --most-recent and --delete-older-than

### DIFF
--- a/curator/curator.py
+++ b/curator/curator.py
@@ -1161,10 +1161,10 @@ def snapshot(client, dry_run=False, **kwargs):
         return
     # Preserving kwargs intact for passing to _op_loop is the game here...
     all_indices       = kwargs['all_indices'] if 'all_indices' in kwargs else False
-    delete_older_than = kwargs['delete_older_than'] if 'delete_older_than' in kwargs else False
-    older_than        = kwargs['older_than'] if 'older_than' in kwargs else False
-    most_recent       = kwargs['most_recent'] if 'most_recent' in kwargs else False
-    if delete_older_than:
+    delete_older_than = kwargs['delete_older_than'] if 'delete_older_than' in kwargs else None
+    older_than        = kwargs['older_than'] if 'older_than' in kwargs else None
+    most_recent       = kwargs['most_recent'] if 'most_recent' in kwargs else None
+    if delete_older_than is not None:
         logger.info(kwargs['prepend'] + "Deleting specified snapshots...")
         kwargs['older_than'] = kwargs['delete_older_than'] # Fix for delete in this case only.
         snapshot_list = client.snapshot.get(repository=kwargs['repository'], snapshot="_all")['snapshots']
@@ -1175,9 +1175,9 @@ def snapshot(client, dry_run=False, **kwargs):
         logger.info(kwargs['prepend'] + "Capturing snapshots of specified indices...")
         if not all_indices:
             index_list = get_object_list(client, **kwargs)
-            if most_recent:
+            if most_recent is not None:
                 matching_indices = index_list[-kwargs['most_recent']:]
-            elif older_than:
+            elif older_than is not None:
                 matching_indices = list(filter_by_timestamp(object_list=index_list, **kwargs))
             else:
                 logger.error(kwargs['prepend'] + 'Missing argument: Must provide one of: older_than, most_recent, all_indices, delete_older_than')

--- a/curator/curator_script.py
+++ b/curator/curator_script.py
@@ -296,7 +296,7 @@ def main():
             sys.exit(1)
 
     if arguments.command == 'snapshot':
-        if not arguments.older_than and not arguments.most_recent and not arguments.delete_older_than and not arguments.all_indices:
+        if arguments.older_than is None and arguments.most_recent is None and arguments.delete_older_than is None and not arguments.all_indices:
             print('{0} snapshot: error: expect one of --all-indices, --older-than, --most-recent, or --delete-older-than'.format(sys.argv[0]))
             sys.exit(1)
         if arguments.older_than or arguments.most_recent or arguments.all_indices:


### PR DESCRIPTION
This comes from #208.

Now previous month can be snapshotted as well as optimized (October is included in November):

```
curator λ ./curator/curator_script.py -n --host 127.0.0.1 snapshot --older-than 0 --time-unit months --prefix statistics-super-fast- --timestring %Y%m --repository ceph_s3 --snapshot-name whatever
2014-11-04 22:08:31,366 INFO      Job starting...
2014-11-04 22:08:31,366 INFO      DRY RUN MODE.  No changes will be made.
2014-11-04 22:08:31,391 INFO      DRY RUN: Capturing snapshots of specified indices...
2014-11-04 22:08:31,505 INFO      statistics-super-fast-201411 is within the threshold period (0 months).
2014-11-04 22:08:31,505 INFO      DRY RUN: Snapshot will capture indices: statistics-super-fast-201310, statistics-super-fast-201311, statistics-super-fast-201312, statistics-super-fast-201401, statistics-super-fast-201402, statistics-super-fast-201403, statistics-super-fast-201404, statistics-super-fast-201405, statistics-super-fast-201406, statistics-super-fast-201407, statistics-super-fast-201408, statistics-super-fast-201409, statistics-super-fast-201410
2014-11-04 22:08:31,506 INFO      DRY RUN: Snapshots captured for specified indices.
2014-11-04 22:08:31,506 INFO      Done in 0:00:00.162480.
```
