### PR TITLE
Add 2-digit years (lower-case y)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -46,3 +46,4 @@ Contributors:
 * George Heppner (gheppner)
 * Matt Hughes (matthughes)
 * Brian Lalor (blalor)
+* Paweł Krzaczkowski (krzaczek)

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -20,6 +20,7 @@ Changelog
  * Shows proper error in the event of concurrent snapshots. #177 (untergeek)
  * Fixes erroneous index display of ``_, a, l, l`` when --all-indices selected. Reported in #222 (untergeek)
  * Use json.dumps() to escape exceptions. Reported in #210 (untergeek)
+ * Add 2-digit years as acceptable pattern (y vs. Y). Reported in #209 (untergeek)
  
 
 2.0.2 (8 October 2014)

--- a/curator/curator.py
+++ b/curator/curator.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 DATE_REGEX = {
     'Y' : '4',
+    'y' : '2',
     'm' : '2',
     'W' : '2',
     'U' : '2',

--- a/test_curator/test_curator.py
+++ b/test_curator/test_curator.py
@@ -9,6 +9,7 @@ class TestUtils(TestCase):
     def test_get_index_time(self):
         for text, datestring, dt in [
             ('2014.01.19', '%Y.%m.%d', datetime(2014, 1, 19)),
+            ('14.01.19', '%y.%m.%d', datetime(2014, 1, 19)),
             ('2014-01-19', '%Y-%m-%d', datetime(2014, 1, 19)),
             ('2010-12-29', '%Y-%m-%d', datetime(2010, 12, 29)),
             ('2012-12', '%Y-%m', datetime(2012, 12, 1)),


### PR DESCRIPTION
This adds 2-digit years as an acceptable pattern.  This is lower-case 'y' vs. upper-case (4-digit).
closes #209
