### PR TITLE
Fixes CI tests for Curator where bloom filters no longer exist

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -23,6 +23,7 @@ Changelog
  * Add 2-digit years as acceptable pattern (y vs. Y). Reported in #209 (untergeek)
  * Check if index is closed before adding to alias.  Reported in #214 (bt5e)
  * No longer force-install argparse if pre-installed #216 (whyscream)
+ * Bloom filters have been removed from Elasticsearch 1.5.0. Update methods and tests to act accordingly. #233 (untergeek)
  
 
 2.0.2 (8 October 2014)

--- a/curator/curator.py
+++ b/curator/curator.py
@@ -531,11 +531,16 @@ def disable_bloom_filter(client, index_name, **kwargs):
     :arg client: The Elasticsearch client connection
     :arg index_name: The index name
     """
+    no_more_bloom = (1, 5, 0)
+    version_number = get_version(client)
     if index_closed(client, index_name): # Don't try to disable bloom filter on a closed index.  It will re-open them
         logger.info('Skipping index {0}: Already closed.'.format(index_name))
         return True
     else:
-        client.indices.put_settings(index=index_name, body='index.codec.bloom.load=false')
+        if version_number >= no_more_bloom:
+            logger.info('Skipping index {0}: Bloom filters no longer exist in Elasticsearch since v1.5.0'.format(index_name))
+        else:
+            client.indices.put_settings(index=index_name, body='index.codec.bloom.load=false')
 
 ### Change Replica Count
 def change_replicas(client, index_name, replicas=None, **kwargs):

--- a/test_curator/integration/test_utils.py
+++ b/test_curator/integration/test_utils.py
@@ -55,9 +55,12 @@ class TestBloomIndex(CuratorTestCase):
     def test_bloom_filter_will_be_disabled(self):
         self.create_index('test_index')
         self.assertIsNone(curator.disable_bloom_filter(self.client, 'test_index'))
-
-        settings = self.client.indices.get_settings(index='test_index')
-        self.assertEquals('false', settings['test_index']['settings']['index']['codec']['bloom']['load'])
+        # Bloom filters have been removed from the 1.x branch after 1.5.0
+        no_more_bloom = (1, 5, 0)
+        version_number = curator.get_version(self.client)
+        if version_number < no_more_bloom:
+            settings = self.client.indices.get_settings(index='test_index')
+            self.assertEquals('false', settings['test_index']['settings']['index']['codec']['bloom']['load'])
 
     def test_closed_index_will_be_skipped(self):
         self.create_index('test_index')


### PR DESCRIPTION
Since bloom filters have been removed from 1.5, changes needed to
be added to test for this, otherwise we get grumpy test results.
