### PR TITLE
ENTRYPOINT Works Better for Execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ MAINTAINER Christian R. Vozar <christian@rogueethic.com>
 
 RUN pip install --quiet elasticsearch-curator
 
-CMD [ "/usr/local/bin/curator" ]
+ENTRYPOINT [ "/usr/local/bin/curator" ]


### PR DESCRIPTION
Running Curator via ENTRYPOINT will allow execution more in-line with how the Wiki examples are setup rather than needing to specify the ENTRYPOINT and args as would be necessary with CMD.
