### PR TITLE
Allow ludicrous number of indices in single command (by chunking)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -54,3 +54,4 @@ Contributors:
 * Robin Kearney (rk295)
 * (cfeio)
 * (malagoli)
+* Dan Sheridan (djs52)

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -3,6 +3,19 @@
 Changelog
 =========
 
+3.0.1 (? ? ?)
+-------------
+
+**Bug fixes**
+
+ * Refactored to show `--dry-run` info for `--disk-space` calls. Reported in
+   #290 (untergeek)
+ * Added list chunking so acting on huge lists of indices won't result in a URL
+   bigger than 4096 bytes (Elasticsearch's default limit.)  Reported in
+   https://github.com/elastic/curator/issues/245#issuecomment-77916081
+ * Refactored `to_csv()` method to be simpler.
+ * Added and removed tests according to changes.  Code coverage still at 99%
+
 3.0.0 (9 March 2015)
 --------------------
 

--- a/curator/api/utils.py
+++ b/curator/api/utils.py
@@ -52,10 +52,7 @@ def to_csv(indices):
     """
     indices = ensure_list(indices) # in case of a single value passed
     if indices:
-        if len(indices) > 1:
-            return ','.join(sorted(indices))
-        elif len(indices) == 1:
-            return indices[0]
+        return ','.join(sorted(indices))
     else:
         return None
 

--- a/curator/cli/utils.py
+++ b/curator/cli/utils.py
@@ -150,6 +150,28 @@ def in_list(values, source_list):
             logger.warn('{0} not found!'.format(v))
     return retval
 
+def chunk_index_list(indices):
+    """
+    This utility chunks very large index lists into 3KB chunks
+    It measures the size as a csv string, then converts back into a list
+    for the return value.
+
+    :arg indices: A list of indices to act on.
+    """
+    chunks = []
+    chunk = ""
+    for index in indices:
+        if len(chunk) < 3072:
+            if not chunk:
+                chunk = index
+            else:
+                chunk += "," + index
+        else:
+            chunks.append(chunk.split(','))
+            chunk = index
+    chunks.append(chunk.split(','))
+    return chunks
+
 def do_command(client, command, indices, params=None):
     """
     Do the command.
@@ -165,10 +187,7 @@ def do_command(client, command, indices, params=None):
     if command == "close":
         return close(client, indices)
     if command == "delete":
-        return delete(
-                client, indices, disk_space=params['disk_space'],
-                reverse=params['reverse']
-               )
+        return delete(client, indices)
     if command == "open":
         return opener(client, indices)
     if command == "optimize":

--- a/test/integration/test_cli_commands.py
+++ b/test/integration/test_cli_commands.py
@@ -356,6 +356,24 @@ class TestCLIDelete(CuratorTestCase):
         self.assertEquals(9, len(l))
         output = sorted(result.output.splitlines(), reverse=True)[:9]
         self.assertEqual(sorted(l, reverse=True), output)
+    def test_delete_indices_huge_list(self):
+        self.create_indices(365)
+        pre = curator.get_indices(self.client)
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'delete',
+                        'indices',
+                        '--all-indices',
+                        '--exclude', pre[0],
+                    ],
+                    obj={"filters":[]})
+        post = curator.get_indices(self.client)
+        self.assertEquals(1, len(post))
 
 class TestCLIOpen(CuratorTestCase):
     def test_open_cli(self):

--- a/test/unit/test_api_commands.py
+++ b/test/unit/test_api_commands.py
@@ -240,12 +240,6 @@ class TestDelete(TestCase):
         client = Mock()
         client.indices.delete.side_effect = fake_fail
         self.assertFalse(curator.delete(client, named_indices))
-    def test_full_delete_with_disk_space(self):
-        client = Mock()
-        ds = 2.0
-        client.cluster.state.return_value = open_indices
-        client.indices.status.return_value = indices_space
-        self.assertTrue(curator.delete(client, named_indices, disk_space=ds))
 
 class TestOpen(TestCase):
     def test_opener_positive(self):


### PR DESCRIPTION
**Bug fixes**

 * Refactored to show `--dry-run` info for `--disk-space` calls. Reported in
   #290 (untergeek)
 * Added list chunking so acting on huge lists of indices won't result in a URL
   bigger than 4096 bytes (Elasticsearch's default limit.)  Reported in
   https://github.com/elastic/curator/issues/245#issuecomment-77916081
 * Refactored `to_csv()` method to be simpler.
 * Added and removed tests according to changes.  Code coverage still at 99%
