### PR TITLE
Snapshot command should get full index list

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -9,6 +9,7 @@ Changelog
 **Bug fixes**
 
  * Purge unneeded constants, and clean up config options for snapshot. Reported in #303 (untergeek)
+ * Don't split large index list if performing snapshots. Reported in #307 (untergeek)
 
 3.0.1 (16 Mar 2015)
 -------------------

--- a/curator/cli/index_selection.py
+++ b/curator/cli/index_selection.py
@@ -108,7 +108,9 @@ def indices(ctx, newer_than, older_than, prefix, suffix, time_unit,
                 logger.info("The following indices would have been altered:")
                 show(working_list)
             else:
-                if len(to_csv(working_list)) > 3072:
+                # The snapshot command should get the full list, otherwise
+                # the index list may need to be segmented.
+                if len(to_csv(working_list)) > 3072 and not ctx.parent.info_name == 'snapshot':
                     logger.warn('Very large list of indices.  Breaking it up into smaller chunks.')
                     index_lists = chunk_index_list(working_list)
                     success = True

--- a/test/integration/test_cli_commands.py
+++ b/test/integration/test_cli_commands.py
@@ -502,6 +502,30 @@ class TestCLISnapshot(CuratorTestCase):
                    )
         self.assertEqual(1, len(snapshot['snapshots']))
         self.assertEqual(snap_name, snapshot['snapshots'][0]['snapshot'])
+    def test_cli_snapshot_huge_list(self):
+        self.create_indices(365)
+        self.create_repository()
+        snap_name = 'snapshot1'
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'snapshot',
+                        '--repository', self.args['repository'],
+                        '--name', snap_name,
+                        'indices',
+                        '--all-indices',
+                    ],
+                    obj={"filters":[]})
+        snapshot = curator.get_snapshot(
+                    self.client, self.args['repository'], '_all'
+                   )
+        self.assertEqual(1, len(snapshot['snapshots']))
+        self.assertEqual(snap_name, snapshot['snapshots'][0]['snapshot'])
+        self.assertEqual(365, len(snapshot['snapshots'][0]['indices']))
 
 
 class TestCLISnapshotSelection(CuratorTestCase):


### PR DESCRIPTION
Integration test added to verify that the snapshot command will not split the index list.

fixes #307