### PR TITLE
Fix #309

### DIFF
--- a/curator/cli/utils.py
+++ b/curator/cli/utils.py
@@ -94,8 +94,10 @@ def filter_callback(ctx, param, value):
     """
     Append a dict to ctx.obj['filters'] based on the arguments
     """
-    # Stop here if None or empty value
-    if not value:
+    # Stop here if None or empty value, but zero values are okay
+    if value == 0:
+        argdict = {}
+    elif not value:
         return value
     else:
         argdict = {}

--- a/test/integration/test_cli_commands.py
+++ b/test/integration/test_cli_commands.py
@@ -461,6 +461,26 @@ class TestCLIShow(CuratorTestCase):
                     obj={"filters":[]})
         output = sorted(result.output.splitlines(), reverse=True)[:4]
         self.assertEqual(expected, output)
+    def test_cli_show_indices_older_than_zero(self):
+        self.create_indices(10)
+        indices = curator.get_indices(self.client)
+        expected = sorted(indices, reverse=True)
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'show',
+                        'indices',
+                        '--older-than', '0',
+                        '--timestring', '%Y.%m.%d',
+                        '--time-unit', 'days'
+                    ],
+                    obj={"filters":[]})
+        output = sorted(result.output.splitlines(), reverse=True)
+        self.assertEqual(expected, output)
 
 class TestCLISnapshot(CuratorTestCase):
     def test_snapshot_no_repository_param(self):

--- a/test/unit/test_api_filter.py
+++ b/test/unit/test_api_filter.py
@@ -88,6 +88,18 @@ class TestBuildFilter(TestCase):
                 timestring='%Y.%d.%m',
             ),
         )
+    def test_build_filter_newer_than_zero(self):
+        self.assertEqual(
+            {
+                'pattern': '(?P<date>\\d{4}\\.\\d{2}\\.\\d{2})', 'value': 0,
+                'groupname': 'date', 'time_unit': 'days',
+                'timestring': '%Y.%d.%m', 'method': 'newer_than'
+            },
+            curator.build_filter(
+                kindOf='newer_than', value=0, time_unit='days',
+                timestring='%Y.%d.%m',
+            ),
+        )
     def test_build_filter_regex_positive(self):
         self.assertEqual(
             {'pattern': '^logs'},
@@ -261,11 +273,17 @@ class TestGetTargetMonth(TestCase):
         before = datetime(2015, 2, 1, 2, 34, 56)
         after  = datetime(2016, 1, 1, 0, 0, 0)
         self.assertEqual(after, curator.get_target_month(-11, utc_now=before))
+    def test_month_bump_exception(self):
+        datestamp = datetime(2015, 2, 1, 2, 34, 56)
+        self.assertRaises(ValueError, curator.month_bump,datestamp, sign='foo')
+
 
 class TestGetCutoff(TestCase):
     def test_get_cutoff_param_check(self):
         # Testing for the omission of the unit_count param
         self.assertFalse(curator.get_cutoff())
+    def test_get_cutoff_non_integer(self):
+        self.assertFalse(curator.get_cutoff(unit_count='foo'))
     def test_get_cutoff_weeks(self):
         fakenow = datetime(2015, 2, 3, 4, 5, 6)
         cutoff  = datetime(2015, 2, 2, 0, 0, 0)


### PR DESCRIPTION
This corrects an issue where if a zero value were provided to `--newer-than` or `--older-than` it was caught by a boolean "is the variable present" test.

This also cleans up the get_target_month method with the addition of the month_bump method.

Unit and integration tests have been updated to catch these items.

fixes #309