### PR TITLE
If Jenkins is slow, timeouts can happen

### DIFF
--- a/test/integration/test_cli_commands.py
+++ b/test/integration/test_cli_commands.py
@@ -533,6 +533,7 @@ class TestCLISnapshot(CuratorTestCase):
                         '--logfile', os.devnull,
                         '--host', host,
                         '--port', str(port),
+                        '--timeout', 600,
                         'snapshot',
                         '--repository', self.args['repository'],
                         '--name', snap_name,


### PR DESCRIPTION
The big index list test for snapshots can take time, even with the
indices empty.  Timeout errors were seen.  This bump should help
fix that.