### PR TITLE
Found a few holdouts still pointing at the wiki

### DIFF
--- a/curator/cli/cli.py
+++ b/curator/cli/cli.py
@@ -45,7 +45,10 @@ DEFAULT_ARGS = {
 @click.version_option(version=__version__)
 @click.pass_context
 def cli(ctx, host, url_prefix, port, use_ssl, http_auth, timeout, master_only, dry_run, debug, loglevel, logfile, logformat):
-    """Curator for Elasticsearch indices. See http://github.com/elastic/curator/wiki
+    """
+    Curator for Elasticsearch indices.
+    
+    See http://elastic.co/guide/en/elasticsearch/client/curator/current
     """
 
     # Setup logging

--- a/docs/asciidoc/flags/help.asciidoc
+++ b/docs/asciidoc/flags/help.asciidoc
@@ -31,8 +31,9 @@ The output of `curator --help`:
 $ curator --help
 Usage: curator [OPTIONS] COMMAND [ARGS]...
 
-  Curator for Elasticsearch indices. See
-  http://github.com/elasticsearch/curator/wiki
+  Curator for Elasticsearch indices.
+
+  See http://elastic.co/guide/en/elasticsearch/client/curator/current
 
 Options:
   --host TEXT        Elasticsearch host.

--- a/docs/asciidoc/misc/command-line.asciidoc
+++ b/docs/asciidoc/misc/command-line.asciidoc
@@ -44,8 +44,10 @@ The top-level help output looks like this:
 $ curator --help
 Usage: curator [OPTIONS] COMMAND [ARGS]...
 
-  Curator for Elasticsearch indices. See
-  http://github.com/elasticsearch/curator/wiki
+  Curator for Elasticsearch indices.
+
+  See http://elastic.co/guide/en/elasticsearch/client/curator/current
+
 
 Options:
   --host TEXT        Elasticsearch host.


### PR DESCRIPTION
Lots of doc updates, now that docs are at http://www.elastic.co/guide/en/elasticsearch/client/curator/current/index.html