### PR TITLE
Reinstate the timeout override from v2

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -14,7 +14,10 @@ Changelog
 **Bug fixes**
 
  * Fix links to repository in setup.py. Reported in #318 (untergeek)
- * No more --delay with optimized indices. Reported in #319 (untergeek)
+ * No more ``--delay`` with optimized indices. Reported in #319 (untergeek)
+ * ``--request_timeout`` not working as expected.  Reinstate the version 2
+   timeout override feature to prevent default timeouts for ``optimize`` and
+   ``snapshot`` operations. Reported in #320 (untergeek)
 
 3.0.2 (23 Mar 2015)
 -------------------

--- a/curator/cli/index_selection.py
+++ b/curator/cli/index_selection.py
@@ -53,6 +53,7 @@ def indices(ctx, newer_than, older_than, prefix, suffix, time_unit,
     logger.info("Job starting...")
     logger.debug("Params: {0}".format(ctx.parent.parent.params))
     # Base and client args are in the grandparent tier of the context
+    override_timeout(ctx)
     client = get_client(**ctx.parent.parent.params)
     # Get a master-list of indices
     indices = get_indices(client)

--- a/curator/cli/utils.py
+++ b/curator/cli/utils.py
@@ -90,6 +90,17 @@ def get_client(**kwargs):
         click.echo(click.style('ERROR: Connection failure.', fg='red', bold=True))
         sys.exit(1)
 
+def override_timeout(ctx):
+    """
+    Override the default timeout for optimize and snapshot operations if the
+    default value of 30 is provided at the command-line.
+    """
+    timeout = 21600
+    if ctx.parent.info_name in ['optimize', 'snapshot']:
+        if ctx.parent.parent.params['timeout'] == 30:
+            logger.warn('Overriding default connection timeout.  New timeout: {0}'.format(timeout))
+            ctx.parent.parent.params['timeout'] = timeout
+
 def filter_callback(ctx, param, value):
     """
     Append a dict to ctx.obj['filters'] based on the arguments


### PR DESCRIPTION
The --request-timeout option wasn't working correctly.

The existing tests cover this.

fixes #320