### PR TITLE
Improve logging and dry-run output

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -10,6 +10,10 @@ Changelog
 
  * Documentation for the CLI converted to Asciidoc and moved to
    http://www.elastic.co/guide/en/elasticsearch/client/curator/current/index.html
+ * Improved logging, and refactored a few methods to help with this.
+ * Dry-run output is now more like v2, with the index or snapshot in the log
+   line, along with the command.  Several tests needed refactoring with this
+   change, along with a bit of documentation.
 
 **Bug fixes**
 
@@ -22,6 +26,8 @@ Changelog
    test.integration.test_cli_commands.TestCLISnapshot.test_cli_snapshot_huge_list
    in order to reduce or eliminate Jenkins CI test timeouts.
    Reported in #324 (untergeek)
+ * ``--dry-run`` no longer calls ``show``, but will show output in the log, as
+   in v2. This was a recurring complaint.  See #328 (untergeek)
 
 
 3.0.2 (23 Mar 2015)

--- a/curator/cli/index_selection.py
+++ b/curator/cli/index_selection.py
@@ -50,7 +50,7 @@ def indices(ctx, newer_than, older_than, prefix, suffix, time_unit,
         click.echo(click.style('ERROR. At least one filter must be supplied.', fg='red', bold=True))
         sys.exit(1)
 
-    logger.info("Job starting...")
+    logger.info("Job starting: {0} indices".format(ctx.parent.info_name))
     logger.debug("Params: {0}".format(ctx.parent.parent.params))
     # Base and client args are in the grandparent tier of the context
     override_timeout(ctx)
@@ -105,9 +105,7 @@ def indices(ctx, newer_than, older_than, prefix, suffix, time_unit,
             show(working_list)
         else:
             if ctx.parent.parent.params['dry_run']:
-                logger.info("DRY RUN MODE.  No changes will be made.")
-                logger.info("The following indices would have been altered:")
-                show(working_list)
+                show_dry_run(working_list, ctx.parent.info_name)
             else:
                 # The snapshot command should get the full list, otherwise
                 # the index list may need to be segmented.
@@ -119,12 +117,12 @@ def indices(ctx, newer_than, older_than, prefix, suffix, time_unit,
                         retval = do_command(client, ctx.parent.info_name, l, ctx.parent.params)
                         if not retval:
                             success = False
-                    sys.exit(0) if success else sys.exit(1)
+                    exit_msg(success)
                 else:
                     retval = do_command(client, ctx.parent.info_name, working_list, ctx.parent.params)
-                    sys.exit(0) if retval else sys.exit(1)
+                    exit_msg(retval)
 
     else:
-        logger.warn('No indices matched provided args.')
+        logger.warn('No indices matched provided args: {0}'.format(ctx.params))
         click.echo(click.style('No indices matched provided args.', fg='red', bold=True))
         sys.exit(99)

--- a/curator/cli/snapshot_selection.py
+++ b/curator/cli/snapshot_selection.py
@@ -47,7 +47,7 @@ def snapshots(ctx, newer_than, older_than, prefix, suffix, time_unit,
         click.echo(click.style('Missing required --repository parameter.', fg='red', bold=True))
         sys.exit(1)
 
-    logging.info("Job starting...")
+    logger.info("Job starting: {0} snapshots".format(ctx.parent.info_name))
 
     # Base and client args are in the grandparent tier of the context
     if ctx.parent.parent.params['dry_run']:
@@ -83,8 +83,7 @@ def snapshots(ctx, newer_than, older_than, prefix, suffix, time_unit,
         if ctx.parent.info_name == 'show':
             show(working_list)
         elif ctx.parent.parent.params['dry_run']:
-            logger.warn('DRY RUN: Will not perform {0} action'.format(ctx.parent.info_name))
-            show(working_list)
+            show_dry_run(working_list, ctx.parent.info_name)
         elif ctx.parent.info_name == 'delete':
             success = True
             for snap in working_list:
@@ -92,7 +91,7 @@ def snapshots(ctx, newer_than, older_than, prefix, suffix, time_unit,
                 # If we fail once, we fail completely
                 if not retval:
                     success = False
-            sys.exit(0) if success else sys.exit(1)
+            exit_msg(success)
 
     else:
         logger.warn('No snapshots matched provided args.')

--- a/curator/cli/utils.py
+++ b/curator/cli/utils.py
@@ -51,6 +51,25 @@ class Whitelist(logging.Filter):
     def filter(self, record):
         return any(f.filter(record) for f in self.whitelist)
 
+def exit_msg(success):
+    """
+    Display a message corresponding to whether the job completed successfully or
+    not, then exit.
+    """
+    if success:
+        logger.info("Job completed successfully.")
+    else:
+        logger.warn("Job did not complete successfully.")
+    sys.exit(0) if success else sys.exit(1)
+
+def show_dry_run(items, command):
+    """
+    Log dry run output with the command which would have been executed.
+    """
+    logger.info("DRY RUN MODE.  No changes will be made.")
+    for item in items:
+        logger.info("DRY RUN: {0}: {1}".format(command, item))
+
 def check_version(client):
     """
     Verify version is within acceptable range.  Exit with error if it is not.

--- a/docs/asciidoc/flags/dry-run.asciidoc
+++ b/docs/asciidoc/flags/dry-run.asciidoc
@@ -9,9 +9,6 @@ This flag allows you to test your command-line options. It can help you see
 which indices will be caught by operations without actually performing those
 operations.
 
-NOTE: This command actually just calls <<show>>, and ends execution without
-performing the command.
-
 [float]
 Flags
 ~~~~~

--- a/test/integration/test_cli_commands.py
+++ b/test/integration/test_cli_commands.py
@@ -160,7 +160,6 @@ class TestCLIIndexSelection(CuratorTestCase):
                     curator.cli,
                     [
                         '--dry-run',
-                        '--logfile', os.devnull,
                         '--host', host,
                         '--port', str(port),
                         'alias', '--name', 'dummy_alias',
@@ -170,7 +169,11 @@ class TestCLIIndexSelection(CuratorTestCase):
                         '--time-unit', 'days'
                     ],
                     obj={"filters":[]})
-        output = sorted(result.output.splitlines(), reverse=True)[:4]
+        output = sorted(result.output.splitlines(), reverse=True)
+        # I tried doing a nested, double list comprehension here.
+        # It works in the interpreter, but not here for some reason.
+        output = [ x.split(' ')[-1:] for x in output ]
+        output = [ x[0] for x in output if x[0].startswith('logstash') ]
         self.assertEqual(expected, output)
     def test_cli_no_indices_after_filtering(self):
         self.create_indices(10)
@@ -320,7 +323,6 @@ class TestCLIDelete(CuratorTestCase):
                     curator.cli,
                     [
                         '--dry-run',
-                        '--logfile', os.devnull,
                         '--host', host,
                         '--port', str(port),
                         'delete',
@@ -330,7 +332,11 @@ class TestCLIDelete(CuratorTestCase):
                     obj={"filters":[]})
         l = curator.get_indices(self.client)
         self.assertEquals(9, len(l))
-        output = sorted(result.output.splitlines(), reverse=True)[:9]
+        output = sorted(result.output.splitlines(), reverse=True)
+        # I tried doing a nested, double list comprehension here.
+        # It works in the interpreter, but not here for some reason.
+        output = [ x.split(' ')[-1:] for x in output ]
+        output = [ x[0] for x in output if x[0].startswith('logstash') ]
         self.assertEqual(sorted(l, reverse=True), output)
     def test_delete_indices_by_space_dry_run(self):
         for i in range(1,10):
@@ -343,7 +349,6 @@ class TestCLIDelete(CuratorTestCase):
                     curator.cli,
                     [
                         '--dry-run',
-                        '--logfile', os.devnull,
                         '--host', host,
                         '--port', str(port),
                         'delete',
@@ -354,7 +359,11 @@ class TestCLIDelete(CuratorTestCase):
                     obj={"filters":[]})
         l = curator.get_indices(self.client)
         self.assertEquals(9, len(l))
-        output = sorted(result.output.splitlines(), reverse=True)[:9]
+        output = sorted(result.output.splitlines(), reverse=True)
+        # I tried doing a nested, double list comprehension here.
+        # It works in the interpreter, but not here for some reason.
+        output = [ x.split(' ')[-1:] for x in output ]
+        output = [ x[0] for x in output if x[0].startswith('index') ]
         self.assertEqual(sorted(l, reverse=True), output)
     def test_delete_indices_huge_list(self):
         self.create_indices(365)
@@ -730,7 +739,6 @@ class TestCLISnapshotSelection(CuratorTestCase):
                     curator.cli,
                     [
                         '--dry-run',
-                        '--logfile', os.devnull,
                         '--host', host,
                         '--port', str(port),
                         'delete',
@@ -740,7 +748,12 @@ class TestCLISnapshotSelection(CuratorTestCase):
                         '--exclude', '2',
                     ],
                     obj={"filters":[]})
-        self.assertEqual(['snapshot1'], result.output.splitlines()[:1])
+        output = sorted(result.output.splitlines(), reverse=True)[:4]
+        # I tried doing a nested, double list comprehension here.
+        # It works in the interpreter, but not here for some reason.
+        output = [ x.split(' ')[-1:] for x in output ]
+        output = [ x[0] for x in output if x[0].startswith('snapshot1') ]
+        self.assertEqual(['snapshot1'], output)
     def test_snapshot_selection_delete_snapshot(self):
         self.create_repository()
         for i in ["1", "2"]:

--- a/test/unit/test_cli_utils.py
+++ b/test/unit/test_cli_utils.py
@@ -62,6 +62,16 @@ snap_body       = {
                     "indices" : "index1,index2"
                   }
 
+class TestExitMsg(TestCase):
+    def test_exit_msg_positive(self):
+        with self.assertRaises(SystemExit) as cm:
+            curator.exit_msg(True)
+        self.assertEqual(cm.exception.code, 0)
+    def test_exit_msg_negative(self):
+        with self.assertRaises(SystemExit) as cm:
+            curator.exit_msg(False)
+        self.assertEqual(cm.exception.code, 1)
+
 class TestCheckVersion(TestCase):
     def test_check_version_positive(self):
         client = Mock()


### PR DESCRIPTION
Several tests died with the code changes, so those tests were
refactored accordingly.  Also, to avoid repetition, some code
was broken out into methods.

All tests passing, 99% code coverage still.

fixes #328