### PR TITLE
fix(cli.es_repo_mgr): Ensure proper parent CLI parameters are passed int...

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -58,3 +58,4 @@ Contributors:
 * Michael-Keith Bernard (SegFaultAX)
 * Simon Lundström (simmel)
 * (pkr1234)
+* Mark Feltner (feltnerm)

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -10,7 +10,8 @@ Changelog
 
  * If an index is closed, indicate in ``show`` and ``--dry-run`` output.
    Reported in #327. (untergeek)
- * Fix issue where CLI parameters were not being passed to sub-commands.
+ * Fix issue where CLI parameters were not being passed to the ``es_repo_mgr``
+   create sub-command.
    Reported in #337. (feltnerm)
 
 3.0.3 (27 Mar 2015)

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -10,6 +10,8 @@ Changelog
 
  * If an index is closed, indicate in ``show`` and ``--dry-run`` output.
    Reported in #327. (untergeek)
+ * Fix issue where CLI parameters were not being passed to sub-commands.
+   Reported in #337. (feltnerm)
 
 3.0.3 (27 Mar 2015)
 -------------------

--- a/curator/cli/__init__.py
+++ b/curator/cli/__init__.py
@@ -12,3 +12,4 @@ from .show import *
 from .snapshot import *
 from .index_selection import *
 from .snapshot_selection import *
+from .es_repo_mgr import *

--- a/curator/cli/es_repo_mgr.py
+++ b/curator/cli/es_repo_mgr.py
@@ -146,7 +146,7 @@ def fs(
     """
     Create a filesystem repository.
     """
-    client = get_client(**ctx.parent.params)
+    client = get_client(**ctx.parent.parent.params)
     success = create_repository(client, repo_type='fs', **ctx.params)
     if not success:
         sys.exit(1)
@@ -180,7 +180,7 @@ def s3(
     """
     Create an S3 repository.
     """
-    client = get_client(**ctx.parent.params)
+    client = get_client(**ctx.parent.parent.params)
     success = create_repository(client, repo_type='s3', **ctx.params)
     if not success:
         sys.exit(1)

--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -61,6 +61,11 @@ class CuratorTestCase(TestCase):
         args['prefix'] = 'logstash-'
         self.args = args
         dirname = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(8))
+        # This will create a psuedo-random temporary directory on the machine
+        # which runs the unit tests, but NOT on the machine where elasticsearch
+        # is running. This means tests may fail if run against remote instances
+        # unless you explicitly set `self.args['location']` to a proper spot
+        # on the target machine.
         self.args['location'] = tempfile.mkdtemp(suffix=dirname)
         self.args['repository'] = 'TEST_REPOSITORY'
         if not os.path.exists(self.args['location']):

--- a/test/integration/test_cli_commands.py
+++ b/test/integration/test_cli_commands.py
@@ -887,7 +887,7 @@ class TestCLIRepositoryCreate(CuratorTestCase):
                         'create',
                         'fs',
                         '--repository', self.args['repository'],
-                        '--location', '/tmp'
+                        '--location', self.args['location']
                     ],
                     obj={"filters":[]})
         self.assertTrue(1, len(self.client.snapshot.get_repository(repository=self.args['repository'])))

--- a/test/integration/test_cli_commands.py
+++ b/test/integration/test_cli_commands.py
@@ -874,3 +874,21 @@ class TestCLILogging(CuratorTestCase):
                     obj={"filters":[]})
         output = sorted(result.output.splitlines(), reverse=True)[:4]
         self.assertEqual(expected, output)
+
+class TestCLIRepositoryCreate(CuratorTestCase):
+    def test_create_fs_repository(self):
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.repomgrcli,
+                    [
+                        '--debug',
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        'create',
+                        'fs',
+                        '--repository', self.args['repository'],
+                        '--location', '/tmp'
+                    ],
+                    obj={"filters":[]})
+        self.assertTrue(1, len(self.client.snapshot.get_repository(repository=self.args['repository'])))

--- a/test/integration/test_cli_commands.py
+++ b/test/integration/test_cli_commands.py
@@ -881,7 +881,6 @@ class TestCLIRepositoryCreate(CuratorTestCase):
         result = test.invoke(
                     curator.repomgrcli,
                     [
-                        '--debug',
                         '--logfile', os.devnull,
                         '--host', host,
                         '--port', str(port),


### PR DESCRIPTION
...o create sub-command

fixes #336