### PR TITLE
Proposed fix for #348

### DIFF
--- a/curator/cli/index_selection.py
+++ b/curator/cli/index_selection.py
@@ -96,6 +96,15 @@ def indices(ctx, newer_than, older_than, prefix, suffix, time_unit,
                            )
 
     if working_list:
+        ### Issue #348
+        # I don't care about using only --timestring if it's a `show` or `dry_run`
+        if timestring and not newer_than and not older_than \
+          and not (ctx.parent.info_name == 'show') \
+          and not ctx.parent.parent.params['dry_run']:
+            click.echo(click.style('You are using --timestring without --older-than or --newer-than.', fg='yellow', bold=True))
+            click.echo('This could result in actions being performed on all indices matching {0}'.format(timestring))
+            click.echo(click.style('Press CTRL-C to exit Curator before the timer expires:', fg='red', bold=True))
+            countdown(10)
         # Make a sorted, unique list of indices
         working_list = sorted(list(set(working_list)))
         logger.debug('ACTION: {0}. INDICES: {1}'.format(ctx.parent.info_name, working_list))

--- a/curator/cli/utils.py
+++ b/curator/cli/utils.py
@@ -23,6 +23,13 @@ REGEX_MAP = {
     'suffix': r'^.*{0}$',
 }
 
+def countdown(seconds):
+    """Display an inline countdown to stdout."""
+    for i in range(seconds,0,-1):
+        sys.stdout.write(str(i) + ' ')
+        sys.stdout.flush()
+        time.sleep(1)
+
 class LogstashFormatter(logging.Formatter):
     # The LogRecord attributes we want to carry over to the Logstash message,
     # mapped to the corresponding output key.

--- a/test/integration/test_cli_commands.py
+++ b/test/integration/test_cli_commands.py
@@ -28,7 +28,7 @@ class TestCLIIndexSelection(CuratorTestCase):
     def test_index_selection_only_timestamp_filter(self):
         self.create_indices(10)
         indices = curator.get_indices(self.client)
-        expected = sorted(indices, reverse=True)[:4]
+        # expected = sorted(indices, reverse=True)[:4]
         test = clicktest.CliRunner()
         result = test.invoke(
                     curator.cli,
@@ -36,13 +36,12 @@ class TestCLIIndexSelection(CuratorTestCase):
                         '--logfile', os.devnull,
                         '--host', host,
                         '--port', str(port),
-                        'show',
+                        'close',
                         'indices',
                         '--timestring', '%Y.%m.%d',
                     ],
                     obj={"filters":[]})
-        output = sorted(result.output.splitlines(), reverse=True)[:4]
-        self.assertEqual(expected, output)
+        self.assertEqual(0, result.exit_code)
     def test_index_selection_no_filters(self):
         self.create_indices(1)
         test = clicktest.CliRunner()


### PR DESCRIPTION
Add a warning and a countdown (which allows this to still work in
a cron situation, without the need for crazy dialog, Y/N, etc.) in
the event you are filtering by `--timestamp` and not using the
`--older-than` or `--newer-than` flags.  This gives users 10 seconds
to "bow out" before it will act.

Update tests to test this functionality (very passively).