### PR TITLE
Add log notifications for matching items

### DIFF
--- a/curator/cli/index_selection.py
+++ b/curator/cli/index_selection.py
@@ -111,6 +111,7 @@ def indices(ctx, newer_than, older_than, prefix, suffix, time_unit,
 
         # Do action here!!! Don't forget to account for DRY_RUN!!!
         if ctx.parent.info_name == 'show':
+            logger.info('Matching indices:')
             show(client, working_list, type='indices')
         else:
             if ctx.parent.parent.params['dry_run']:

--- a/curator/cli/snapshot_selection.py
+++ b/curator/cli/snapshot_selection.py
@@ -81,6 +81,7 @@ def snapshots(ctx, newer_than, older_than, prefix, suffix, time_unit,
         working_list = sorted(list(set(working_list)))
         logger.debug('ACTION: {0} will be executed against the following snapshots: {1}'.format(ctx.parent.info_name, working_list))
         if ctx.parent.info_name == 'show':
+            logger.info('Matching snapshots:')
             show(client, working_list)
         elif ctx.parent.parent.params['dry_run']:
             show_dry_run(client, working_list, ctx.parent.info_name)


### PR DESCRIPTION
This helps reveal to the user that using `show` will show which
indices or snapshots matched their criteria.

Dry run already makes that more clear, so it doesn't need to be
addressed in this PR.

fixes #293