### PR TITLE
Logging improvements

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -8,6 +8,8 @@ Changelog
 
 **General**
 
+ * Logs individual deletes per index, even though they happen in batch mode.
+   Also log individual snapshot deletions. Reported in #372 (untergeek)
  * Moved ``chunk_index_list`` from cli to api utils as it's now also used by ``filter.py``
  * Added a warning and 10 second timer countdown if you use ``--timestring`` to filter
    indices, but do not use ``--older-than`` or ``--newer-than`` in conjunction with it.

--- a/curator/api/delete.py
+++ b/curator/api/delete.py
@@ -14,10 +14,13 @@ def delete_indices(client, indices):
     """
     indices = ensure_list(indices)
     try:
+        logger.info("Deleting indices as a batch operation:")
+        for i in indices:
+            logger.info("---deleting index {0}".format(i))
         client.indices.delete(index=to_csv(indices))
         return True
     except Exception:
-        logger.error("Error deleting indices.  Check logs for more information.")
+        logger.error("Error deleting one or more indices.  Check logs for more information.")
         return False
 
 def delete(client, indices):

--- a/curator/api/snapshot.py
+++ b/curator/api/snapshot.py
@@ -84,6 +84,7 @@ def delete_snapshot(client, snapshot=None, repository=None):
         logger.error('Cannot delete multiple snapshots at once.  CSV value or list detected: {0}'.format(snapshot))
         return False
     try:
+        logger.info("Deleting snapshot {0}".format(snapshot))
         client.snapshot.delete(repository=repository, snapshot=snapshot)
         return True
     except elasticsearch.RequestError:


### PR DESCRIPTION
Log individual index deletes, even though they happen in batches.
Also log individual snapshots.

fixes #372