### PR TITLE
There is no _status endpoint before 1.1.0

### DIFF
--- a/curator/api/snapshot.py
+++ b/curator/api/snapshot.py
@@ -35,16 +35,15 @@ def create_snapshot(client, indices='_all', name=None,
         logger.error('Missing required repository parameter')
         return False
     # This is to address older versions of Elasticsearch
+    # Older versions do not have the _status endpoint
     # See https://github.com/elastic/curator/issues/379
-    no__all = (1, 1, 0)
+    no__status = (1, 1, 0)
     version_number = get_version(client)
-    if version_number < no__all:
-        in_progress = client.snapshot.status(repository=repository)['snapshots']
-    else:
+    if version_number >= no__status:
         in_progress = client.snapshot.status()['snapshots']
-    if not len(in_progress) == 0:
-        logger.error('Snapshot already in progress: {0}'.format(in_progress))
-        return False
+        if not len(in_progress) == 0:
+            logger.error('Snapshot already in progress: {0}'.format(in_progress))
+            return False
     if not indices == '_all':
         indices = prune_closed(client, indices)
     if not indices:


### PR DESCRIPTION
This should put the final nail in the coffin.

fixes #379