### PR TITLE
Add --skip-repo-validation flag

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -12,6 +12,10 @@ Changelog
     figured they were right.  This is better. (untergeek)
   * Exit code 99 was unpopular.  It has been removed. Reported in #371 and #391
     (untergeek)
+  * Add ``--skip-repo-validation`` flag for snapshots.  Do not validate write
+    access to repository on all cluster nodes before proceeding. Useful for
+    shared filesystems where intermittent timeouts can affect validation, but
+    won't likely affect snapshot success. Requested in #396 (untergeek)
 
 **Bug fixes**
 

--- a/curator/cli/snapshot.py
+++ b/curator/cli/snapshot.py
@@ -8,6 +8,7 @@ DEFAULT_ARGS = {
     'snapshot_prefix': 'curator-',
     'wait_for_completion': True,
     'include_global_state': True,
+    'skip_repo_validation': False,
 }
 
 @cli.group('snapshot')
@@ -21,17 +22,19 @@ DEFAULT_ARGS = {
 @click.option('--ignore_unavailable', is_flag=True, expose_value=True,
             help='Ignore unavailable shards/indices.')
 @click.option('--include_global_state', type=bool, show_default=True,
-            default=DEFAULT_ARGS['include_global_state'], expose_value=True, 
+            default=DEFAULT_ARGS['include_global_state'], expose_value=True,
             help='Store cluster global state with snapshot.')
 @click.option('--partial', is_flag=True, expose_value=True,
             help='Do not fail if primary shard is unavailable.')
 @click.option('--request_timeout', type=int, default=21600, show_default=True,
             expose_value=True,
             help='Allow this many seconds before the transaction times out.')
+@click.option('--skip-repo-validation', is_flag=True, expose_value=True,
+            help='Skip repository access validation.')
 @click.pass_context
 def snapshot(
         ctx, repository, name, prefix, wait_for_completion, ignore_unavailable,
-        include_global_state, partial, request_timeout
+        include_global_state, partial, request_timeout, skip_repo_validation,
     ):
     """Take snapshots of indices (Backup)"""
     if not repository:

--- a/curator/cli/utils.py
+++ b/curator/cli/utils.py
@@ -226,4 +226,5 @@ def do_command(client, command, indices, params=None):
                 partial=params['partial'],
                 wait_for_completion=params['wait_for_completion'],
                 request_timeout=params['request_timeout'],
+                skip_repo_validation=params['skip_repo_validation'],
                )


### PR DESCRIPTION
Do not validate write access to repository on all cluster nodes before
proceeding. Useful for shared filesystems where intermittent timeouts
can affect validation, but won't likely affect snapshot success.

fixes #396