### PR TITLE
Recommend running with --debug on errors

### DIFF
--- a/curator/api/alias.py
+++ b/curator/api/alias.py
@@ -32,7 +32,7 @@ def add_to_alias(client, index_name, alias=None):
                     client.indices.update_aliases(body={'actions': [{ 'add': { 'index': index_name, 'alias': alias}}]})
                     return True
                 except Exception as e:
-                    logger.error("Error adding index {0} to alias {1}.  Exception: {2}  Check logs for more information.".format(index_name, alias, e))
+                    logger.error("Error adding index {0} to alias {1}.  Exception: {2}  Run with --debug flag and/or check Elasticsearch logs for more information.".format(index_name, alias, e))
                     return False
         else:
             logger.info('Skipping index {0}: Index already exists in alias {1}...'.format(index_name, alias))
@@ -62,7 +62,7 @@ def remove_from_alias(client, index_name, alias=None):
             client.indices.update_aliases(body={'actions': [{ 'remove': { 'index': index_name, 'alias': alias}}]})
             return True
         except Exception as e:
-            logger.error("Error removing index {0} from alias {1}.  Exception: {2}  Check logs for more information.".format(index_name, alias, e))
+            logger.error("Error removing index {0} from alias {1}.  Exception: {2}  Run with --debug flag and/or check Elasticsearch logs for more information.".format(index_name, alias, e))
             return False
     else:
         logger.warn('Index {0} does not exist in alias {1}; skipping.'.format(index_name, alias))

--- a/curator/api/allocation.py
+++ b/curator/api/allocation.py
@@ -34,7 +34,7 @@ def apply_allocation_rule(client, indices, rule=None):
             )
         return True
     except:
-        logger.error("Error in updating index settings with allocation rule.  Check logs for more information.")
+        logger.error("Error in updating index settings with allocation rule.  Run with --debug flag and/or check Elasticsearch logs for more information.")
         return False
 
 def allocation(client, indices, rule=None):

--- a/curator/api/bloom.py
+++ b/curator/api/bloom.py
@@ -30,7 +30,7 @@ def disable_bloom_filter(client, indices, delay=None):
                     body='index.codec.bloom.load=false')
                 return True
         except Exception:
-            logger.error("Error disabling bloom filters.  Check logs for more information.")
+            logger.error("Error disabling bloom filters.  Run with --debug flag and/or check Elasticsearch logs for more information.")
             return False
 
 def loop_bloom(client, indices, delay):

--- a/curator/api/close.py
+++ b/curator/api/close.py
@@ -18,7 +18,7 @@ def close_indices(client, indices):
         client.indices.close(index=to_csv(indices), ignore_unavailable=True)
         return True
     except Exception:
-        logger.error("Error closing indices.  Check logs for more information.")
+        logger.error("Error closing indices.  Run with --debug flag and/or check Elasticsearch logs for more information.")
         return False
 
 def close(client, indices):

--- a/curator/api/delete.py
+++ b/curator/api/delete.py
@@ -20,7 +20,7 @@ def delete_indices(client, indices):
         client.indices.delete(index=to_csv(indices))
         return True
     except Exception:
-        logger.error("Error deleting one or more indices.  Check logs for more information.")
+        logger.error("Error deleting one or more indices.  Run with --debug flag and/or check Elasticsearch logs for more information.")
         return False
 
 def delete(client, indices):

--- a/curator/api/opener.py
+++ b/curator/api/opener.py
@@ -17,7 +17,7 @@ def open_indices(client, indices):
         client.indices.open(index=to_csv(indices))
         return True
     except Exception:
-        logger.error("Error opening indices.  Check logs for more information.")
+        logger.error("Error opening indices.  Run with --debug flag and/or check Elasticsearch logs for more information.")
         return False
 
 def opener(client, indices):

--- a/curator/api/optimize.py
+++ b/curator/api/optimize.py
@@ -28,7 +28,7 @@ def optimize_index(client, index_name, max_num_segments=None, delay=0,
             time.sleep(delay)
             return True
         except Exception:
-            logger.error("Error optimizing index {0}.  Check logs for more information.".format(index_name))
+            logger.error("Error optimizing index {0}.  Run with --debug flag and/or check Elasticsearch logs for more information.".format(index_name))
             return False
 
 def optimize(client, indices, max_num_segments=None, delay=0, request_timeout=21600):

--- a/curator/api/replicas.py
+++ b/curator/api/replicas.py
@@ -27,7 +27,7 @@ def change_replicas(client, indices, replicas=None):
                     body='number_of_replicas={0}'.format(replicas))
                 return True
             except Exception:
-                logger.error("Error changing replica count.  Check logs for more information.")
+                logger.error("Error changing replica count.  Run with --debug flag and/or check Elasticsearch logs for more information.")
                 return False
         else:
             logger.warn('No open indices found.')

--- a/curator/api/snapshot.py
+++ b/curator/api/snapshot.py
@@ -113,5 +113,5 @@ def delete_snapshot(client, snapshot=None, repository=None):
         client.snapshot.delete(repository=repository, snapshot=snapshot)
         return True
     except elasticsearch.RequestError:
-        logger.error("Unable to delete snapshot {0} from repository {1}.  Check logs for more information.".format(snapshot, repository))
+        logger.error("Unable to delete snapshot {0} from repository {1}.  Run with --debug flag and/or check Elasticsearch logs for more information.".format(snapshot, repository))
         return False


### PR DESCRIPTION
This adds the words:

```
Run with --debug flag and/or check Elasticsearch logs for more information.
```

when an error is encountered.

fixes #390