### PR TITLE
Update elasticsearch python module dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def get_version():
     return VERSION
 
 def get_install_requires():
-    res = ['elasticsearch>=1.0.0,<2.0.0' ]
+    res = ['elasticsearch>=1.6.0,<2.0.0' ]
     res.append('click>=3.3')
     return res
 


### PR DESCRIPTION
The version needs to be 1.6.0+ to have the synced_flush call.

fixes #447