### PR TITLE
Regression fix for Jenkins

### DIFF
--- a/curator/api/filter.py
+++ b/curator/api/filter.py
@@ -278,8 +278,11 @@ def timestamp_check(timestamp, timestring=None, time_unit=None,
     :arg utc_now: Used for testing.  Overrides current time with specified time.
     :rtype: bool
     """
-    # Ensure that value is an int
-    cutoff = get_cutoff(unit_count=int(value), time_unit=time_unit, utc_now=utc_now)
+    cutoff = get_cutoff(unit_count=value, time_unit=time_unit, utc_now=utc_now)
+
+    if not cutoff:
+        logger.error('No cutoff value.')
+        return False
 
     try:
         object_time = get_datetime(timestamp, timestring)

--- a/test/unit/test_api_filter.py
+++ b/test/unit/test_api_filter.py
@@ -320,3 +320,19 @@ class TestTimestampCheck(TestCase):
         utc_now = datetime(2015, 1, 5)
         self.assertFalse(curator.timestamp_check(timestamp, timestring=ts,
             time_unit=tu, value=v, utc_now=utc_now))
+    def test_timestamp_check_get_cutoff_with_none(self):
+        ts = '%Y.%m.%d'
+        tu = 'days'
+        v  = None
+        timestamp = '2015.01.01'
+        utc_now = datetime(2015, 1, 5)
+        self.assertFalse(curator.timestamp_check(timestamp, timestring=ts,
+            time_unit=tu, value=v, utc_now=utc_now))
+    def test_timestamp_check_get_cutoff_with_non_int(self):
+        ts = '%Y.%m.%d'
+        tu = 'days'
+        v  = 'foo'
+        timestamp = '2015.01.01'
+        utc_now = datetime(2015, 1, 5)
+        self.assertFalse(curator.timestamp_check(timestamp, timestring=ts,
+            time_unit=tu, value=v, utc_now=utc_now))


### PR DESCRIPTION
Don't know why the original passed on 1.3.4, 1.4.4, and all for me,
but were failing on Jenkins for all ES <1.5.x

Hopefully this fixes the regression.  I can only assume it was
something unusual.

fixes #465