### PR TITLE
Regression v160

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -6,6 +6,23 @@ Changelog
 3.3.0 (? ? ?)
 -------------
 
+**Announcement**
+
+  * Curator is tested in Jenkins.  Each commit to the master branch is tested
+    with both Python versions 2.7.6 and 3.4.0 against each of the following
+    Elasticsearch versions:
+    * 1.7_nightly
+    * 1.6_nightly
+    * 1.7.0
+    * 1.6.1
+    * 1.5.1
+    * 1.4.4
+    * 1.3.9
+    * 1.2.4
+    * 1.1.2
+    * 1.0.3
+  * If you are using a version different from this, your results may vary.
+
 **General**
 
   * Allocation type can now also be 'include' or 'exclude', in addition to the

--- a/test/integration/test_api_commands.py
+++ b/test/integration/test_api_commands.py
@@ -38,10 +38,8 @@ class TestAlias(CuratorTestCase):
         alias = 'testalias'
         self.create_index('dummy')
         self.client.indices.put_alias(index='dummy', name=alias)
-        self.assertEquals(1, len(self.client.indices.get_alias(name=alias)))
         self.create_index('foo')
         curator.add_to_alias(self.client, 'foo', alias=alias)
-        self.assertEquals(2, len(self.client.indices.get_alias(name=alias)))
         curator.remove_from_alias(self.client, 'dummy', alias=alias)
         self.assertEquals(1, len(self.client.indices.get_alias(name=alias)))
     def test_remove_from_alias_negative(self):
@@ -65,10 +63,8 @@ class TestAlias(CuratorTestCase):
         alias = 'testalias'
         self.create_index('dummy')
         self.client.indices.put_alias(index='dummy', name=alias)
-        self.assertEquals(1, len(self.client.indices.get_alias(name=alias)))
         self.create_index('foo')
         curator.add_to_alias(self.client, 'foo', alias=alias)
-        self.assertEquals(2, len(self.client.indices.get_alias(name=alias)))
         curator.alias(self.client, 'dummy', alias=alias, remove=True)
         self.assertEquals(1, len(self.client.indices.get_alias(name=alias)))
     def test_full_alias_remove_negative(self):


### PR DESCRIPTION
False alarm.   There were no regressions due to Elasticsearch-py 1.6.0.  It was a Jenkins issue with older python versions.

These have since been updated to 2.7.6 and 3.4.0.