### PR TITLE
Be explicit when calling exists_alias since order is unreliable

### DIFF
--- a/curator/api/alias.py
+++ b/curator/api/alias.py
@@ -21,7 +21,7 @@ def add_to_alias(client, index_name, alias=None):
     if not alias: # This prevents _all from being aliased by accident...
         logger.error('No alias provided.')
         return False
-    if not client.indices.exists_alias(alias):
+    if not client.indices.exists_alias(name=alias):
         indices_in_alias = []
         logger.info('Alias {0} not found.  Creating...'.format(alias))
     else:

--- a/curator/api/utils.py
+++ b/curator/api/utils.py
@@ -14,7 +14,7 @@ def get_alias(client, alias):
     :arg alias: Alias name to operate on.
     :rtype: list of strings
     """
-    if client.indices.exists_alias(alias):
+    if client.indices.exists_alias(name=alias):
         return client.indices.get_alias(name=alias).keys()
     else:
         logger.error('Unable to find alias {0}.'.format(alias))


### PR DESCRIPTION
Fixes #485 

This is due to change in order of the parameters in `1.7.0` - both `index` and `name` parameters are optional so they need to be referred to as keyword arguments.