### PR TITLE
Massive refactor for Elasticsearch 2.0

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -8,8 +8,12 @@ Changelog
 
 **General**
 
+  * API change in elasticsearch-py 1.7.0 prevented alias operations.  Fixed in
+    #486 (HonzaKral)
   * During index selection you can now select only closed indices with ``--closed-only``.
-   Does not impact ``--all-indices`` #476 (Basster)
+    Does not impact ``--all-indices`` Reported in #476. Fixed in #487 (Basster)
+  * API Changes in Elasticsearch 2.0.0 required some refactoring.  All tests pass
+    for ES versions 1.0.3 through 2.0.0-rc1.  Fixed in #488 (untergeek)
 
 3.3.0 (31 August 2015)
 ----------------------

--- a/curator/_version.py
+++ b/curator/_version.py
@@ -1,1 +1,1 @@
-__version__ = '3.4.0.dev0'
+__version__ = '3.4.0.dev1'

--- a/curator/api/delete.py
+++ b/curator/api/delete.py
@@ -14,6 +14,9 @@ def delete_indices(client, indices, master_timeout=30000):
     :rtype bool:
     """
     indices = ensure_list(indices)
+    if get_version(client) >= (2,0,0):
+        if type(master_timeout) == type(int()):
+            master_timeout = str(master_timeout/1000) + 's'
     try:
         logger.info("Deleting indices as a batch operation:")
         for i in indices:
@@ -37,6 +40,9 @@ def delete(client, indices, master_timeout=30000):
     :arg master_timeout: Number of milliseconds to wait for master node response
     :rtype bool:
     """
+    if get_version(client) >= (2,0,0):
+        if type(master_timeout) == type(int()):
+            master_timeout = str(master_timeout/1000) + 's'
     for count in range(1, 4): # Try 3 times
         logger.debug("master_timeout value: {0}".format(master_timeout))
         delete_indices(client, indices, master_timeout)

--- a/curator/api/filter.py
+++ b/curator/api/filter.py
@@ -324,11 +324,10 @@ def filter_by_space(client, indices, disk_space=None, reverse=True):
 
     def get_stat_list(stats):
         retval = []
-        for (index_name, index_stats) in stats['indices'].items():
-            replica_count = client.indices.get_settings(index_name)[index_name]['settings']['index']['number_of_replicas']
-            size = "size_in_bytes" if int(replica_count) > 0 else "primary_size_in_bytes"
-            logger.debug('Index: {0}  Size: {1}'.format(index_name, index_stats['index'][size]))
-            retval.append((index_name, index_stats['index'][size]))
+        for index_name in stats['indices']:
+            size = stats['indices'][index_name]['total']['store']['size_in_bytes']
+            logger.debug('Index: {0}  Size: {1}'.format(index_name, size))
+            retval.append((index_name, size))
         return retval
 
     # Ensure that disk_space is a float
@@ -355,9 +354,9 @@ def filter_by_space(client, indices, disk_space=None, reverse=True):
             index_lists = chunk_index_list(not_closed)
             statlist = []
             for l in index_lists:
-                statlist.extend(get_stat_list(client.indices.status(index=to_csv(l))))
+                statlist.extend(get_stat_list(client.indices.stats(index=to_csv(l))))
         else:
-            statlist = get_stat_list(client.indices.status(index=to_csv(not_closed)))
+            statlist = get_stat_list(client.indices.stats(index=to_csv(not_closed)))
 
         sorted_indices = sorted(statlist, reverse=reverse)
 

--- a/curator/cli/index_selection.py
+++ b/curator/cli/index_selection.py
@@ -110,6 +110,7 @@ def indices(ctx, newer_than, older_than, prefix, suffix, time_unit,
     if working_list and ctx.parent.info_name == 'delete':
         # If filter by disk space, filter the working_list by space:
         if ctx.parent.params['disk_space']:
+            logger.info("Filtering to keep disk usage below {0} gigabytes".format(ctx.parent.params['disk_space']))
             working_list = filter_by_space(
                                 client, working_list,
                                 disk_space=ctx.parent.params['disk_space'],

--- a/curator/cli/utils.py
+++ b/curator/cli/utils.py
@@ -12,7 +12,7 @@ from ..api import *
 logger = logging.getLogger(__name__)
 
 # Elasticsearch versions supported
-version_max  = (2, 0, 0)
+version_max  = (3, 0, 0)
 version_min = (1, 0, 0)
 
 REGEX_MAP = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 urllib3>=1.8.3
-elasticsearch>=1.6.0
+elasticsearch>=1.70,<2.0.0
 click>=3.3

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def get_version():
     return VERSION
 
 def get_install_requires():
-    res = ['elasticsearch>=1.6.0,<2.0.0' ]
+    res = ['elasticsearch>=1.7.0,<2.0.0' ]
     res.append('click>=3.3')
     return res
 

--- a/test/unit/test_api_commands.py
+++ b/test/unit/test_api_commands.py
@@ -208,9 +208,9 @@ class TestAllocate(TestCase):
         client.cluster.state.return_value = open_index
         client.indices.get_settings.return_value = allocation_out
         client.indices.put_settings.return_value = None
-        self.assertTrue(curator.allocation(client, named_index, rule="foo=bar", allocation_type="require"))   
-        self.assertTrue(curator.allocation(client, named_index, rule="foo=bar", allocation_type="include"))   
-        self.assertTrue(curator.allocation(client, named_index, rule="foo=bar", allocation_type="exclude"))   
+        self.assertTrue(curator.allocation(client, named_index, rule="foo=bar", allocation_type="require"))
+        self.assertTrue(curator.allocation(client, named_index, rule="foo=bar", allocation_type="include"))
+        self.assertTrue(curator.allocation(client, named_index, rule="foo=bar", allocation_type="exclude"))
 
 class TestBloom(TestCase):
     def test_disable_bloom_no_more_bloom_positive(self):
@@ -318,10 +318,12 @@ class TestClose(TestCase):
 class TestDelete(TestCase):
     def test_delete_indices_positive(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.0.0'} }
         client.indices.delete.return_value = None
         self.assertTrue(curator.delete_indices(client, named_indices))
     def test_delete_indices_negative(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.0.0'} }
         client.indices.delete.side_effect = fake_fail
         self.assertFalse(curator.delete_indices(client, named_indices))
 
@@ -336,11 +338,13 @@ class TestDelete(TestCase):
     #     self.assertTrue(curator.delete(client, named_indices))
     def test_full_delete_negative(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '1.7.2'} }
         client.indices.delete.return_value = None
         client.indices.get_settings.return_value = named_indices
         self.assertFalse(curator.delete(client, named_indices))
     def test_full_delete_exception(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '1.7.2'} }
         client.indices.delete.side_effect = fake_fail
         client.indices.get_settings.return_value = named_indices
         self.assertFalse(curator.delete(client, named_indices))

--- a/test/unit/test_api_filter.py
+++ b/test/unit/test_api_filter.py
@@ -13,9 +13,11 @@ open_indices   = { 'metadata': { 'indices' : { 'index1' : { 'state' : 'open' },
 closed_indices = { 'metadata': { 'indices' : { 'index1' : { 'state' : 'close' },
                                                'index2' : { 'state' : 'close' }}}}
 fake_fail      = Exception('Simulated Failure')
-indices_space  = { 'indices' : {
-        'index1' : { 'index' : { 'primary_size_in_bytes': 1083741824 }},
-        'index2' : { 'index' : { 'primary_size_in_bytes': 1083741824 }}}}
+
+indices_stats  = { 'indices' : {
+         'index1' : { 'total' : { 'store' : { 'size_in_bytes' : 1083741824 }}},
+         'index2' : { 'total' : { 'store' : { 'size_in_bytes' : 1083741824 }}}}}
+
 re_test_indices = [
     "logstash-2014.12.31", "logstash-2014.12.30", "logstash-2014.12.29",
     ".marvel-2015.12.31", ".marvel-2015.12.30", ".marvel-2015.12.29",
@@ -29,9 +31,6 @@ re_test_indices = [
     "foologstash", "barlogstash",
     "logstashfoo", "logstashbar",
     ]
-
-sized           = { u'index1': {u'settings': {u'index': {u'number_of_replicas': u'0'} } },
-                    u'index2': {u'settings': {u'index': {u'number_of_replicas': u'0'} } } }
 
 class FilterBySpace(TestCase):
     def test_filter_by_space_param_check(self):
@@ -47,25 +46,22 @@ class FilterBySpace(TestCase):
         client = Mock()
         ds = 10.0
         client.cluster.state.return_value = open_indices
-        client.indices.get_settings.return_value = sized
         # Build return value of over 1G in size for each index
-        client.indices.status.return_value = indices_space
+        client.indices.stats.return_value = indices_stats
         self.assertEqual([], curator.filter_by_space(client, named_indices, disk_space=ds))
     def test_filter_by_space_one_deletion(self):
         client = Mock()
         ds = 2.0
         client.cluster.state.return_value = open_indices
-        client.indices.get_settings.return_value = sized
         # Build return value of over 1G in size for each index
-        client.indices.status.return_value = indices_space
+        client.indices.stats.return_value = indices_stats
         self.assertEqual(["index1"], curator.filter_by_space(client, named_indices, disk_space=ds))
     def test_filter_by_space_one_deletion_no_reverse(self):
         client = Mock()
         ds = 2.0
         client.cluster.state.return_value = open_indices
-        client.indices.get_settings.return_value = sized
         # Build return value of over 1G in size for each index
-        client.indices.status.return_value = indices_space
+        client.indices.stats.return_value = indices_stats
         self.assertEqual(["index2"], curator.filter_by_space(client, named_indices, disk_space=ds, reverse=False))
 
 class TestBuildFilter(TestCase):

--- a/test/unit/test_cli_utils.py
+++ b/test/unit/test_cli_utils.py
@@ -85,7 +85,7 @@ class TestCheckVersion(TestCase):
         self.assertEqual(cm.exception.code, 1)
     def test_check_version_greater_than(self):
         client = Mock()
-        client.info.return_value = {'version': {'number': '2.0.1'} }
+        client.info.return_value = {'version': {'number': '3.0.1'} }
         with self.assertRaises(SystemExit) as cm:
             curator.check_version(client)
         self.assertEqual(cm.exception.code, 1)


### PR DESCRIPTION
All tests now pass for all versions of ES from 1.0.3 through 2.0.0-rc1