### PR TITLE
Fix/492

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -16,6 +16,7 @@ Changelog
     for ES versions 1.0.3 through 2.0.0-rc1.  Fixed in #488 (untergeek)
   * es_repo_mgr now has access to the same SSL options from #462. #489 (untergeek)
   * Logging improvements requested in #475. (untergeek)
+  * Added ``--quiet`` flag. #494 (untergeek)
 
 3.3.0 (31 August 2015)
 ----------------------

--- a/docs/asciidoc/flags/index.asciidoc
+++ b/docs/asciidoc/flags/index.asciidoc
@@ -14,6 +14,7 @@
 * <<loglevel,--loglevel>>
 * <<master-only,--master-only>>
 * <<port,--port>>
+* <<quiet, --quiet>>
 * <<timeout,--timeout>>
 * <<url_prefix,--url_prefix>>
 * <<use_ssl,--use_ssl>>
@@ -57,6 +58,7 @@ include::logfile.asciidoc[]
 include::logformat.asciidoc[]
 include::loglevel.asciidoc[]
 include::master-only.asciidoc[]
+include::quiet.asciidoc[]
 include::port.asciidoc[]
 include::timeout.asciidoc[]
 include::url_prefix.asciidoc[]

--- a/docs/asciidoc/flags/quiet.asciidoc
+++ b/docs/asciidoc/flags/quiet.asciidoc
@@ -1,0 +1,32 @@
+[[quiet]]
+== --quiet
+
+[float]
+Summary
+~~~~~~~
+
+Disallows non-log STDOUT output, which is typically error messages.
+
+If no <<logfile, --logfile>> is specified, logging will still output to STDOUT
+by default.
+
+NOTE: If <<logformat, --logformat logstash>> is specified, `--quiet` is
+automatically implied.
+
+[float]
+Flags
+~~~~~
+
+* `--quiet` Suppress command-line output.
+
+IMPORTANT: This flag must come before any <<commands,command>>.
+
+[float]
+Example
+~~~~~~~
+
+Silence non-log command-line output:
+
+-----------------------------------------------------------------------------
+curator --logfile /tmp/curator.log --quiet <<command>> <<flags>>
+-----------------------------------------------------------------------------

--- a/docs/asciidoc/misc/installation.asciidoc
+++ b/docs/asciidoc/misc/installation.asciidoc
@@ -89,7 +89,7 @@ Download and install the Public Signing Key:
 
 [source,sh]
 --------------------------------------------------
-wget -qO - https://packages.elasticsearch.org/GPG-KEY-elasticsearch | sudo apt-key add -
+wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
 --------------------------------------------------
 
 [float]
@@ -100,7 +100,7 @@ Add the following in your `/etc/apt/sources.list.d/` directory in a file with a
 
 ["source","sh",subs="attributes,callouts"]
 --------------------------------------------------
-deb http://packages.elasticsearch.org/curator/{curator_major}/debian stable main
+deb http://packages.elastic.co/curator/{curator_major}/debian stable main
 --------------------------------------------------
 
 [WARNING]
@@ -148,7 +148,7 @@ Download and install the public signing key:
 
 [source,sh]
 --------------------------------------------------
-rpm --import https://packages.elasticsearch.org/GPG-KEY-elasticsearch
+rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch
 --------------------------------------------------
 
 [float]
@@ -167,9 +167,9 @@ RHEL/CentOS 6:
 --------------------------------------------------
 [curator-{curator_major}]
 name=CentOS/RHEL 6 repository for Elasticsearch Curator {curator_major}.x packages
-baseurl=http://packages.elasticsearch.org/curator/{curator_major}/centos/6
+baseurl=http://packages.elastic.co/curator/{curator_major}/centos/6
 gpgcheck=1
-gpgkey=http://packages.elasticsearch.org/GPG-KEY-elasticsearch
+gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
 enabled=1
 --------------------------------------------------
 
@@ -178,9 +178,9 @@ RHEL/CentOS 7:
 --------------------------------------------------
 [curator-{curator_major}]
 name=CentOS/RHEL 7 repository for Elasticsearch Curator {curator_major}.x packages
-baseurl=http://packages.elasticsearch.org/curator/{curator_major}/centos/7
+baseurl=http://packages.elastic.co/curator/{curator_major}/centos/7
 gpgcheck=1
-gpgkey=http://packages.elasticsearch.org/GPG-KEY-elasticsearch
+gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
 enabled=1
 --------------------------------------------------
 =========================================
@@ -249,6 +249,6 @@ WARNING: If you do have Python installed, do not uncompress the zip file into
 your Python directory.  It can cause library path collisions which will prevent
 Curator from properly functioning.
 
-* http://packages.elasticsearch.org/curator/{curator_major}/windows/curator-{curator_version}-win64.zip[Download Curator]
-** http://packages.elasticsearch.org/curator/{curator_major}/windows/curator-{curator_version}-win64.zip.md5.txt[MD5]
-** http://packages.elasticsearch.org/curator/{curator_major}/windows/curator-{curator_version}-win64.zip.sha1.txt[SHA1]
+* http://packages.elastic.co/curator/{curator_major}/windows/curator-{curator_version}-win64.zip[Download Curator]
+** http://packages.elastic.co/curator/{curator_major}/windows/curator-{curator_version}-win64.zip.md5.txt[MD5]
+** http://packages.elastic.co/curator/{curator_major}/windows/curator-{curator_version}-win64.zip.sha1.txt[SHA1]


### PR DESCRIPTION
Update installation docs to refer to packages.elastic.co instead of elasticsearch.org

fixes #492 