### PR TITLE
Fixing sphinx warnings

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -42,8 +42,8 @@ Changelog
 **General**
 
   * Allocation type can now also be ``include`` or ``exclude``, in addition to the
-   the existing default ``require`` type. Add ``--type`` to the allocation command
-   to specify the type. #443 (steffo)
+    the existing default ``require`` type. Add ``--type`` to the allocation command
+    to specify the type. #443 (steffo)
 
   * Bump elasticsearch python module dependency to 1.6.0+ to enable synced_flush
     API call. Reported in #447 (untergeek)

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -4,7 +4,7 @@ Examples
 ========
 
 `build_filter` Examples
----------------------
+-----------------------
 
 Filter indices by prefix
 ++++++++++++++++++++++++


### PR DESCRIPTION
# make man 
sphinx-build -b man -d _build/doctrees   . _build/man
Running Sphinx v1.3.1
making output directory...
loading pickled environment... not yet created
building [mo]: targets for 0 po files that are out of date
building [man]: all manpages
updating environment: 6 added, 0 changed, 0 removed
reading sources... [ 16%] Changelog
reading sources... [ 33%] commands
reading sources... [ 50%] examples
reading sources... [ 66%] filters
reading sources... [ 83%] index
reading sources... [100%] utilities

/var/tmp/portage/dev-python/elasticsearch-curator-3.4.0/work/curator-3.4.0/docs/Changelog.rst:45: WARNING: Bullet list ends without a blank line; unexpected unindent.
/var/tmp/portage/dev-python/elasticsearch-curator-3.4.0/work/curator-3.4.0/docs/examples.rst:7: WARNING: Title underline too short.