### PR TITLE
Update show.asciidoc

### DIFF
--- a/docs/asciidoc/commands/show.asciidoc
+++ b/docs/asciidoc/commands/show.asciidoc
@@ -42,7 +42,7 @@ Examples
 Display a list of indices matching the selection parameters:
 
 ------------------------------------------------------------------
-curator show --show-indices indices <<index selection parameters>>
+curator show indices <<index selection parameters>>
 ------------------------------------------------------------------
 
 &nbsp;


### PR DESCRIPTION
The show-indices command doesn't seem to exists.
The fixed command works.
It seems to be a typo.