### PR TITLE
support to sort index names starting on given character position when deleting by disk space

### DIFF
--- a/curator/api/filter.py
+++ b/curator/api/filter.py
@@ -301,7 +301,7 @@ def timestamp_check(timestamp, timestring=None, time_unit=None,
                         timestamp, method.replace('_', ' '), value, time_unit))
     return False
 
-def filter_by_space(client, indices, disk_space=None, reverse=True):
+def filter_by_space(client, indices, disk_space=None, reverse=True, position=0):
     """
     Remove indices from the provided list of indices based on space consumed,
     sorted reverse-alphabetically by default.  If you set `reverse` to
@@ -315,10 +315,15 @@ def filter_by_space(client, indices, disk_space=None, reverse=True):
     By setting reverse to `False`, then ``index3`` will be deleted before
     ``index2``, which will be deleted before ``index1``
 
+    By setting position to a non-zero number, sorting index names will start
+    from the character position from the end of the name, to allow for sorting 
+    on the timestamp part instead of the full name of the index.
+
     :arg client: The Elasticsearch client connection
     :arg indices: A list of indices to act on
     :arg disk_space: Filter indices over *n* gigabytes
     :arg reverse: The filtering direction. (default: `True`)
+    :arg position: starting position for sort. (default: 0)
     :rtype: list
     """
 
@@ -358,7 +363,7 @@ def filter_by_space(client, indices, disk_space=None, reverse=True):
         else:
             statlist = get_stat_list(client.indices.stats(index=to_csv(not_closed)))
 
-        sorted_indices = sorted(statlist, reverse=reverse)
+        sorted_indices = sorted(statlist, reverse=reverse, key=lambda x: (x[0][position:], x[1]))
 
         for index_name, index_size in sorted_indices:
             disk_usage += index_size

--- a/curator/cli/delete.py
+++ b/curator/cli/delete.py
@@ -11,8 +11,10 @@ logger = logging.getLogger(__name__)
 @click.option('--reverse', type=bool, default=True, expose_value=True,
             show_default=True, is_eager=True,
             help='Only valid with --disk-space. Affects sort order of the indices.  True means reverse-alphabetical (if dates are involved, older is deleted first).')
+@click.option('--position', type=int, default=0, expose_value=True,
+            help='Specify character position in index name to start sorting from. Can be negative to count back from end of name.')
 @click.pass_context
-def delete(ctx, disk_space, reverse):
+def delete(ctx, disk_space, reverse, position):
     """Delete indices or snapshots"""
 delete.add_command(indices)
 delete.add_command(snapshots)

--- a/curator/cli/index_selection.py
+++ b/curator/cli/index_selection.py
@@ -117,7 +117,8 @@ def indices(ctx, newer_than, older_than, prefix, suffix, time_unit,
             working_list = filter_by_space(
                                 client, working_list,
                                 disk_space=ctx.parent.params['disk_space'],
-                                reverse=ctx.parent.params['reverse']
+                                reverse=ctx.parent.params['reverse'],
+                                position=ctx.parent.params['position']
                            )
 
     if working_list:


### PR DESCRIPTION
curator delete --disk-space sorts alphabetically by default. This creates problems if we have multiple index names with timestamps, e.g.:

apache-2015.12.02 
apache-2015.12.01
nginx-2015.12.02
nginx-2015.12.01

curator would potentially delete both the nginx logs instead of the oldest apache and nginx log.

This patch adds a "position" parameter to the delete command that allows one to specify at what character the sort should start. It also allows for negative positions that start from the end of the index name:

    curator delete --disk-space 1 --position -10 

Sort from the tenth character counted from the end of the index name, e.g. "apache-2015.12.01" would be sorted as "2015.12.01"