### PR TITLE
Use slim version of base image for docker definition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Docker Definition for ElasticSearch Curator
 
-FROM python:2.7.8
+FROM python:2.7.8-slim
 MAINTAINER Christian R. Vozar <christian@rogueethic.com>
 
 RUN pip install --quiet elasticsearch-curator


### PR DESCRIPTION
REPOSITORY                                                    |TAG                    |IMAGE ID            |CREATED             |VIRTUAL SIZE
---                                                    |---                    |---            |---             |---
python                                                        |2.7.8-slim             |609e0e7ecb8a        |12 months ago       |**241.2 MB**
python                                                        |2.7.8                  |481b175a31db        |12 months ago       |800.5 MB