### PR TITLE
Allocation will exit 0 on "empty" lists now

### DIFF
--- a/curator/api/allocation.py
+++ b/curator/api/allocation.py
@@ -32,7 +32,7 @@ def apply_allocation_rule(client, indices, rule=None, allocation_type='require' 
 
     if not indices:
         logger.warn("No indices to act on.")
-        return False
+        return True # Send successful execution on empty list #531
     logger.info('Updating index setting index.routing.allocation.{0}.{1}={2}'.format(allocation_type,key,value))
     try:
         client.indices.put_settings(index=to_csv(indices),

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -29,6 +29,8 @@ Changelog
     missing. Reported in #551 (untergeek)
   * Test that ``--timestring`` has the correct variable for ``--time-unit``.
     Reported in #544 (untergeek)
+  * Allocation will exit with exit_code 0 now when there are no indices to work on.
+    Reported in #531 (untergeek)
 
 
 3.4.0 (28 October 2015)

--- a/test/unit/test_api_commands.py
+++ b/test/unit/test_api_commands.py
@@ -187,10 +187,12 @@ class TestAllocate(TestCase):
         client.cluster.state.return_value = open_index
         client.indices.get_settings.return_value = allocation_in
         client.indices.put_settings.return_value = None
-        self.assertFalse(curator.apply_allocation_rule(client, named_index, rule="foo=bar"))
+        # It should return true now because after skipping one, it results in an empty list. #531
+        self.assertTrue(curator.apply_allocation_rule(client, named_index, rule="foo=bar"))
     def test_apply_allocation_rule_empty_list(self):
         client = Mock()
-        self.assertFalse(curator.apply_allocation_rule(client, [], rule="foo=bar"))
+        # It should return true now, even with an empty list. #531
+        self.assertTrue(curator.apply_allocation_rule(client, [], rule="foo=bar"))
     def test_allocation_positive(self):
         client = Mock()
         client.cluster.state.return_value = open_index


### PR DESCRIPTION
Allocation was exiting with code 1 even with an empty list.  This
differed from other command's behavior, so it has been changed to match.

fixes #531