### PR TITLE
Remove print() in setup.py as it breaks commands like "python setup.py --url"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,6 @@ try:
     )
     ### end cx_Freeze ###
 except ImportError:
-    print('Unable to load cx_Freeze.  Cannot do \'build_exe\' or \'bdist_msi\'.\n')
     setup(
         name = "elasticsearch-curator",
         version = get_version(),


### PR DESCRIPTION
Hi,
We are using some standard commands to fetch data from the setup.py itself like 
$ python setup.py --url
$ python setup.py --description
This is broken since the setup.py is printing stuff when the cx_Freeze import fails.

I agree it's nice to know the import failed, but I think it should be printed somewhere else ?

Thanks,