### PR TITLE
Add support for client certificates #520

### DIFF
--- a/curator/cli/cli.py
+++ b/curator/cli/cli.py
@@ -35,6 +35,8 @@ DEFAULT_ARGS = {
 @click.option('--port', help='Elasticsearch port.', default=DEFAULT_ARGS['port'], type=int)
 @click.option('--use_ssl', help='Connect to Elasticsearch through SSL.', is_flag=True, default=DEFAULT_ARGS['use_ssl'])
 @click.option('--certificate', help='Path to certificate to use for SSL validation. (OPTIONAL)', type=str, default=None)
+@click.option('--client-cert', help='Path to file containing SSL certificate for client auth. (OPTIONAL)', type=str, default=None)
+@click.option('--client-key', help='Path to file containing SSL key for client auth. (OPTIONAL)', type=str, default=None)
 @click.option('--ssl-no-validate', help='Do not validate SSL certificate', is_flag=True)
 @click.option('--http_auth', help='Use Basic Authentication ex: user:pass', default=DEFAULT_ARGS['http_auth'])
 @click.option('--timeout', help='Connection timeout in seconds.', default=DEFAULT_ARGS['timeout'], type=int)
@@ -47,7 +49,7 @@ DEFAULT_ARGS = {
 @click.option('--quiet', help='Suppress command-line output.', is_flag=True)
 @click.version_option(version=__version__)
 @click.pass_context
-def cli(ctx, host, url_prefix, port, use_ssl, certificate, ssl_no_validate, http_auth, timeout, master_only, dry_run, debug, loglevel, logfile, logformat, quiet):
+def cli(ctx, host, url_prefix, port, use_ssl, certificate, client_cert, client_key, ssl_no_validate, http_auth, timeout, master_only, dry_run, debug, loglevel, logfile, logformat, quiet):
     """
     Curator for Elasticsearch indices.
 
@@ -82,6 +84,24 @@ def cli(ctx, host, url_prefix, port, use_ssl, certificate, ssl_no_validate, http
         except IOError:
             logger.error('Could not open certificate at {0}'.format(certificate))
             msgout('Error: Could not open certificate at {0}'.format(certificate), error=True, quiet=quiet)
+            sys.exit(1)
+
+    # Test whether client_cert is a valid file path
+    if use_ssl is True and client_cert is not None:
+        try:
+            open(client_cert, 'r')
+        except IOError:
+            logger.error('Could not open client cert at {0}'.format(client_cert))
+            msgout('Error: Could not open client cert at {0}'.format(client_cert), error=True, quiet=quiet)
+            sys.exit(1)
+
+    # Test whether client_key is a valid file path
+    if use_ssl is True and client_key is not None:
+        try:
+            open(client_key, 'r')
+        except IOError:
+            logger.error('Could not open client key at {0}'.format(client_key))
+            msgout('Error: Could not open client key at {0}'.format(client_key), error=True, quiet=quiet)
             sys.exit(1)
 
     # Filter out logging from Elasticsearch and associated modules by default

--- a/curator/cli/es_repo_mgr.py
+++ b/curator/cli/es_repo_mgr.py
@@ -105,7 +105,9 @@ def s3(
 @click.option('--port', help='Elasticsearch port.', default=DEFAULT_ARGS['port'], type=int)
 @click.option('--use_ssl', help='Connect to Elasticsearch through SSL.', is_flag=True, default=DEFAULT_ARGS['use_ssl'])
 @click.option('--certificate', help='Path to certificate to use for SSL validation. (OPTIONAL)', type=str, default=None)
-@click.option('--ssl-no-validate', help='Do not validate SSL certificate', is_flag=True)
+@click.option('--client-cert', help='Path to file containing SSL certificate for client auth. (OPTIONAL)', type=str, default=None)
+@click.option('--client-key', help='Path to file containing SSL key for client auth. (OPTIONAL)', type=str, default=None)
+@click.option('--ssl-no-validate', help='Do not validate server\'s SSL certificate', is_flag=True)
 @click.option('--http_auth', help='Use Basic Authentication ex: user:pass', default=DEFAULT_ARGS['http_auth'])
 @click.option('--timeout', help='Connection timeout in seconds.', default=DEFAULT_ARGS['timeout'], type=int)
 @click.option('--master-only', is_flag=True, help='Only operate on elected master node.')
@@ -115,7 +117,7 @@ def s3(
 @click.option('--logformat', help='Log output format [default|logstash].', default=DEFAULT_ARGS['logformat'])
 @click.version_option(version=__version__)
 @click.pass_context
-def repomgrcli(ctx, host, url_prefix, port, use_ssl, certificate, ssl_no_validate, http_auth, timeout, master_only, debug, loglevel, logfile, logformat):
+def repomgrcli(ctx, host, url_prefix, port, use_ssl, certificate, client_cert, client_key, ssl_no_validate, http_auth, timeout, master_only, debug, loglevel, logfile, logformat):
     """Repository manager for Elasticsearch Curator.
     """
 

--- a/curator/cli/utils.py
+++ b/curator/cli/utils.py
@@ -109,6 +109,8 @@ def get_client(**kwargs):
     kwargs['use_ssl'] = False if not 'use_ssl' in kwargs else kwargs['use_ssl']
     kwargs['ssl_no_validate'] = False if not 'ssl_no_validate' in kwargs else kwargs['ssl_no_validate']
     kwargs['certificate'] = False if not 'certificate' in kwargs else kwargs['certificate']
+    kwargs['client_cert'] = False if not 'client_cert' in kwargs else kwargs['client_cert']
+    kwargs['client_key'] = False if not 'client_key' in kwargs else kwargs['client_key']
     logger.debug("kwargs = {0}".format(kwargs))
     master_only = kwargs.pop('master_only')
     if kwargs['use_ssl']:

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -8,6 +8,12 @@ Changelog
 
 **General**
 
+  * Add support for the `--client-cert` and `--client-key` command line parameters
+    and client_cert and client_key parameters to the get_client() call. #520 (richm)
+
+**Bug fixes**
+
+
 
 3.4.1 (10 February 2016)
 ------------------------

--- a/docs/asciidoc/flags/client-cert.asciidoc
+++ b/docs/asciidoc/flags/client-cert.asciidoc
@@ -1,0 +1,35 @@
+[[client-cert]]
+== --client-cert
+
+[float]
+Summary
+~~~~~~~
+
+Allows the use of a specified SSL client cert file to authenticate to
+Elasticsearch.  The file may contain both an SSL client certificate and an SSL
+key, in which case `--client-key` is not used.  If using `--client-cert`, and
+the file specified does not also contain the key, use `--client-key` to specify
+the file containing the SSL key.  The cert file must be in PEM format, and the
+key part, if used, must be an unencrypted key in PEM format as well.
+
+[float]
+Flags
+~~~~~
+
+* `--client-cert` Path to client certificate file to use for SSL client authentication.
+
+IMPORTANT: This flag must come before any <<commands,command>>.
+
+[float]
+Example
+~~~~~~~
+
+Connect to a cluster at `https://example.com/` via SSL using SSL client authentication:
+
+---------------------------------------------------------------------
+curator --host example.com --port 443 --use_ssl \
+        --certificate /path/to/cacert.pem \
+        --client-cert /path/to/clientcert.pem \
+        --client-key /path/to/clientkey.pem \
+        <<command>> <<flags>>
+---------------------------------------------------------------------

--- a/docs/asciidoc/flags/client-key.asciidoc
+++ b/docs/asciidoc/flags/client-key.asciidoc
@@ -1,0 +1,33 @@
+[[client-key]]
+== --client-key
+
+[float]
+Summary
+~~~~~~~
+
+Allows the use of a specified SSL client key file to authenticate to
+Elasticsearch.  If using `--client-cert` and the file specified does not also
+contain the key, use `--client-key` to specify the file containing the
+SSL key.  The key file must be an unencrypted key in PEM format.
+
+[float]
+Flags
+~~~~~
+
+* `--client-key` Path to client key file to use for SSL client authentication.
+
+IMPORTANT: This flag must come before any <<commands,command>>.
+
+[float]
+Example
+~~~~~~~
+
+Connect to a cluster at `https://example.com/` via SSL using SSL client authentication:
+
+---------------------------------------------------------------------
+curator --host example.com --port 443 --use_ssl \
+        --certificate /path/to/cacert.pem \
+        --client-cert /path/to/clientcert.pem \
+        --client-key /path/to/clientkey.pem \
+        <<command>> <<flags>>
+---------------------------------------------------------------------

--- a/docs/asciidoc/flags/help.asciidoc
+++ b/docs/asciidoc/flags/help.asciidoc
@@ -36,20 +36,24 @@ Usage: curator [OPTIONS] COMMAND [ARGS]...
   See http://elastic.co/guide/en/elasticsearch/client/curator/current
 
 Options:
-  --host TEXT        Elasticsearch host.
-  --url_prefix TEXT  Elasticsearch http url prefix.
-  --port INTEGER     Elasticsearch port.
-  --use_ssl          Connect to Elasticsearch through SSL.
-  --http_auth TEXT   Use Basic Authentication ex: user:pass
-  --timeout INTEGER  Connection timeout in seconds.
-  --master-only      Only operate on elected master node.
-  --dry-run          Do not perform any changes.
-  --debug            Debug mode
-  --loglevel TEXT    Log level
-  --logfile TEXT     log file
-  --logformat TEXT   Log output format [default|logstash].
-  --version          Show the version and exit.
-  --help             Show this message and exit.
+  --host TEXT         Elasticsearch host.
+  --url_prefix TEXT   Elasticsearch http url prefix.
+  --port INTEGER      Elasticsearch port.
+  --use_ssl           Connect to Elasticsearch through SSL.
+  --ssl-no-validate   Use SSL but do not validate the certificate (WARNING: UNSAFE!).
+  --certificate TEXT  Path to CA certificate to use for SSL validation.
+  --client-cert TEXT  Path to client certificate file to use for SSL client authentication.
+  --client-key TEXT   Path to client key file to use for SSL client authentication.
+  --http_auth TEXT    Use Basic Authentication ex: user:pass
+  --timeout INTEGER   Connection timeout in seconds.
+  --master-only       Only operate on elected master node.
+  --dry-run           Do not perform any changes.
+  --debug             Debug mode
+  --loglevel TEXT     Log level
+  --logfile TEXT      log file
+  --logformat TEXT    Log output format [default|logstash].
+  --version           Show the version and exit.
+  --help              Show this message and exit.
 
 Commands:
   alias       Index Aliasing

--- a/docs/asciidoc/flags/index.asciidoc
+++ b/docs/asciidoc/flags/index.asciidoc
@@ -19,6 +19,8 @@
 * <<url_prefix,--url_prefix>>
 * <<use_ssl,--use_ssl>>
 * <<certificate,--certificate>>
+* <<client-cert,--client-cert>>
+* <<client-key,--client-key>>
 * <<ssl-no-validate,--ssl-no-validate>>
 * <<version,--version>>
 
@@ -64,6 +66,8 @@ include::timeout.asciidoc[]
 include::url_prefix.asciidoc[]
 include::use_ssl.asciidoc[]
 include::certificate.asciidoc[]
+include::client-cert.asciidoc[]
+include::client-key.asciidoc[]
 include::ssl-no-validate.asciidoc[]
 include::version.asciidoc[]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 urllib3>=1.8.3
-elasticsearch>=1.8.0,<2.1.0
+elasticsearch>=2.3.0,<3.0.0
 click>=3.3

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def get_version():
     return VERSION
 
 def get_install_requires():
-    res = ['elasticsearch>=1.8.0,<2.4.0' ]
+    res = ['elasticsearch>=2.3.0,<3.0.0' ]
     res.append('click>=3.3')
     return res
 

--- a/test/integration/test_cli_utils.py
+++ b/test/integration/test_cli_utils.py
@@ -96,3 +96,43 @@ class TestSSLFlags(CuratorTestCase):
                     ],
                     obj={"filters":[]})
         self.assertTrue(1, result.exit_code)
+    def test_bad_client_cert(self):
+        self.create_indices(10)
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        '--use_ssl',
+                        '--client-cert', '/path/to/nowhere',
+                        'show',
+                        'indices',
+                        '--older-than', '5',
+                        '--time-unit', 'days',
+                        '--timestring', '%Y.%m.%d',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(1, result.exit_code)
+        self.assertEqual('Error: Could not open client cert at /path/to/nowhere\n', result.output)
+    def test_bad_client_key(self):
+        self.create_indices(10)
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--logfile', os.devnull,
+                        '--host', host,
+                        '--port', str(port),
+                        '--use_ssl',
+                        '--client-key', '/path/to/nowhere',
+                        'show',
+                        'indices',
+                        '--older-than', '5',
+                        '--time-unit', 'days',
+                        '--timestring', '%Y.%m.%d',
+                    ],
+                    obj={"filters":[]})
+        self.assertEqual(1, result.exit_code)
+        self.assertEqual('Error: Could not open client key at /path/to/nowhere\n', result.output)

--- a/test/unit/test_cli_utils.py
+++ b/test/unit/test_cli_utils.py
@@ -130,3 +130,17 @@ class TestGetClient(TestCase):
             curator.get_client(**kwargs)
             self.assertEqual(sys.stdout.getvalue(),'ERROR: Connection failure.\n')
         self.assertEqual(cm.exception.code, 1)
+    def test_client_cert_logic(self):
+        client = Mock()
+        kwargs = { 'use_ssl' : True, 'client_cert' : 'myclientcert.pem' }
+        with self.assertRaises(SystemExit) as cm:
+            curator.get_client(**kwargs)
+            self.assertEqual(sys.stdout.getvalue(),'ERROR: Connection failure.\n')
+        self.assertEqual(cm.exception.code, 1)
+    def test_client_key_logic(self):
+        client = Mock()
+        kwargs = { 'use_ssl' : True, 'client_key' : 'myclientkey.pem' }
+        with self.assertRaises(SystemExit) as cm:
+            curator.get_client(**kwargs)
+            self.assertEqual(sys.stdout.getvalue(),'ERROR: Connection failure.\n')
+        self.assertEqual(cm.exception.code, 1)


### PR DESCRIPTION
https://github.com/elastic/curator/issues/520
Add support for the `--client-cert` and `--client-key` command
line parameters and client_cert and client_key parameters to
the get_client() call.
NOTE: This depends on
https://github.com/elastic/elasticsearch-py/issues/344

Closes #520