### PR TITLE
Don't escape non-special characters

### DIFF
--- a/curator/utils.py
+++ b/curator/utils.py
@@ -130,8 +130,10 @@ def get_date_regex(timestring):
             pass
         elif curr in DATE_REGEX and prev == '%':
             regex += '\d{' + DATE_REGEX[curr] + '}'
-        else:
+        elif curr in ['.', '-']:
             regex += "\\" + curr
+        else:
+            regex += curr
         prev = curr
     logger.debug("regex = {0}".format(regex))
     return regex

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,14 @@
 Changelog
 =========
 
+4.0.0a5 (? ? ?)
+---------------
+
+**Bug Fixes**
+
+  * Do not escape characters other than ``.`` and ``-`` in timestrings. Fixes
+    #602 (untergeek)
+
 4.0.0a4 (21 Apr 2016)
 ---------------------
 

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -109,9 +109,16 @@ class TestGetIndexTime(TestCase):
             ('2014-28', '%Y-%U', datetime(2014, 7, 14)),
             ('2010.12.29.12', '%Y.%m.%d.%H', datetime(2010, 12, 29, 12)),
             ('2009101112136', '%Y%m%d%H%M%S', datetime(2009, 10, 11, 12, 13, 6)),
+            ('2016-03-30t16', '%Y-%m-%dt%H', datetime(2016, 3, 30, 16, 0)),
                 ]:
             self.assertEqual(dt, curator.get_datetime(text, datestring))
 
+class TestGetDateRegex(TestCase):
+    def test_non_escaped(self):
+        self.assertEqual(
+            '\\d{4}\\-\\d{2}\\-\\d{2}t\\d{2}',
+            curator.get_date_regex('%Y-%m-%dt%H')
+        )
 class TestFixEpoch(TestCase):
     def test_fix_epoch(self):
         for long_epoch, epoch in [


### PR DESCRIPTION
`.` and `-` need to be escaped, but not other characters.

fixes #602