### PR TITLE
Add create_indices action

### DIFF
--- a/curator/settings.py
+++ b/curator/settings.py
@@ -62,6 +62,10 @@ ACTION_DEFAULTS = {
         'allocation_type' : 'require',
     },
     'close' : {},
+    'create_index' : {
+        'name' : None,
+        'body' : {},
+    },
     'delete_indices' : {},
     'delete_snapshots' : {
         'repository' : None,

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -354,7 +354,7 @@ def get_indices(client):
     """
     Get the current list of indices from the cluster.
 
-    :arg client: An Elasticsearch client connection
+    :arg client: An :class:`elasticsearch.Elasticsearch` client object
     :rtype: list
     """
     try:
@@ -372,7 +372,7 @@ def get_version(client):
     Return the ES version number as a tuple.
     Omits trailing tags like -dev, or Beta
 
-    :arg client: An Elasticsearch client connection
+    :arg client: An :class:`elasticsearch.Elasticsearch` client object
     :rtype: tuple
     """
     version = client.info()['version']['number']
@@ -388,7 +388,7 @@ def is_master_node(client):
     Return `True` if the connected client node is the elected master node in
     the Elasticsearch cluster, otherwise return `False`.
 
-    :arg client: An Elasticsearch client connection
+    :arg client: An :class:`elasticsearch.Elasticsearch` client object
     :rtype: bool
     """
     my_node_id = list(client.nodes.info('_local')['nodes'])[0]
@@ -399,7 +399,7 @@ def check_version(client):
     """
     Verify version is within acceptable range.  Raise an exception if it is not.
 
-    :arg client: An Elasticsearch client connection
+    :arg client: An :class:`elasticsearch.Elasticsearch` client object
     :rtype: None
     """
     version_number = get_version(client)
@@ -419,7 +419,7 @@ def check_master(client, master_only=False):
     Check if connected client is the elected master node of the cluster.
     If not, cleanly exit with a log message.
 
-    :arg client: An Elasticsearch client connection
+    :arg client: An :class:`elasticsearch.Elasticsearch` client object
     :rtype: None
     """
     if master_only and not is_master_node(client):
@@ -567,57 +567,25 @@ def override_timeout(timeout, action):
             )
     return retval
 
-def show_dry_run(list_object, action, **kwargs):
+def show_dry_run(ilo, action, **kwargs):
     """
     Log dry run output with the action which would have been executed.
 
-    :arg list_object: A :class:`curator.indexlist.IndexList`, a
-        :class:`curator.snapshotlist.SnapshotList`, or an
-        :class:`curator.actions.Alias` action object.
+    :arg ilo: A :class:`curator.indexlist.IndexList`
     :arg action: The `action` to be performed.
     :arg kwargs: Any other args to show in the log output
     """
     logger.info('DRY-RUN MODE.  No changes will be made.')
-
-    if action == 'delete_snapshots':
-        items = sorted(list_object.snapshots)
-        item_type = 'snapshots'
-    elif action == 'alias':
-        items = list_object.actions
-        item_type = 'alias_actions'
-    else:
-        items = sorted(list_object.indices)
-        item_type = 'indices'
-        logger.info(
-            '(CLOSED) indices may be shown that may not be acted on by '
-            'action "{0}".'.format(action)
-        )
-    for item in items:
-        if item_type == 'indices':
-            index_closed = list_object.index_info[item]['state'] == 'close'
+    logger.info(
+        '(CLOSED) indices may be shown that may not be acted on by '
+        'action "{0}".'.format(action)
+    )
+    indices = sorted(ilo.indices)
+    for idx in indices:
+            index_closed = ilo.index_info[idx]['state'] == 'close'
             logger.info(
                 'DRY-RUN: {0}: {1}{2} with arguments: {3}'.format(
-                    action, item, ' (CLOSED)' if index_closed else '', kwargs
-                )
-            )
-        elif item_type == 'snapshots':
-            logger.info('DRY-RUN: {0}: {1} with arguments: '
-                '{2}'.format(action, item, kwargs)
-            )
-        elif item_type == 'alias_actions':
-            job = list(item.keys())[0]
-            index = item[job]['index']
-            alias = item[job]['alias']
-            # We want our log to look clever, so if job is "remove", strip the
-            # 'e' so "remove" can become "removing".  "adding" works already.
-            logger.info(
-                'DRY-RUN: {0}: {1}ing index "{2}" {3} alias '
-                '"{4}"'.format(
-                    action,
-                    job.rstrip('e'),
-                    index,
-                    'to' if action is 'add' else 'from',
-                    alias
+                    action, idx, ' (CLOSED)' if index_closed else '', kwargs
                 )
             )
 
@@ -626,7 +594,7 @@ def get_repository(client, repository=''):
     """
     Return configuration information for the indicated repository.
 
-    :arg client: An Elasticsearch client connection
+    :arg client: An :class:`elasticsearch.Elasticsearch` client object
     :arg repository: The Elasticsearch snapshot repository to use
     :rtype: dict
     """
@@ -642,7 +610,7 @@ def get_snapshot(client, repository=None, snapshot=''):
     If no snapshot specified, it will return all snapshots.  If none exist, an
     empty dictionary will be returned.
 
-    :arg client: An Elasticsearch client connection
+    :arg client: An :class:`elasticsearch.Elasticsearch` client object
     :arg repository: The Elasticsearch snapshot repository to use
     :arg snapshot: The snapshot name, or a comma-separated list of snapshots
     :rtype: dict
@@ -662,7 +630,7 @@ def get_snapshot_data(client, repository=None):
     """
     Get ``_all`` snapshots from repository and return a list.
 
-    :arg client: An Elasticsearch client connection
+    :arg client: An :class:`elasticsearch.Elasticsearch` client object
     :arg repository: The Elasticsearch snapshot repository to use
     :rtype: list
     """
@@ -683,7 +651,7 @@ def snapshot_in_progress(client, repository=None, snapshot=None):
     If no value is provided for `snapshot`, then check all of them.
     Return `snapshot` if it is found to be in progress, or `False`
 
-    :arg client: An Elasticsearch client connection
+    :arg client: An :class:`elasticsearch.Elasticsearch` client object
     :arg repository: The Elasticsearch snapshot repository to use
     :arg snapshot: The snapshot name
     """
@@ -708,7 +676,7 @@ def safe_to_snap(client, repository=None, retry_interval=120, retry_count=3):
     """
     Ensure there are no snapshots in progress.  Pause and retry accordingly
 
-    :arg client: An Elasticsearch client connection
+    :arg client: An :class:`elasticsearch.Elasticsearch` client object
     :arg repository: The Elasticsearch snapshot repository to use
     :arg retry_interval: Number of seconds to delay betwen retries. Default:
         120 (seconds)
@@ -835,7 +803,7 @@ def create_repository(client, **kwargs):
     """
     Create repository with repository and body settings
 
-    :arg client:  An Elasticsearch client connection
+    :arg client: An :class:`elasticsearch.Elasticsearch` client object
 
     :arg repo_type: The type of repository (presently only `fs` and `s3`)
     :arg compress: Turn on compression of the snapshot files. Compression is
@@ -911,7 +879,7 @@ def repository_exists(client, repository=None):
     """
     Verify the existence of a repository
 
-    :arg client:  An Elasticsearch client connection
+    :arg client: An :class:`elasticsearch.Elasticsearch` client object
     :arg repository: The Elasticsearch snapshot repository to use
     :rtype: bool
     """
@@ -929,7 +897,7 @@ def test_repo_fs(client, repository=None):
     """
     Test whether all nodes have write access to the repository
 
-    :arg client:  An Elasticsearch client connection
+    :arg client: An :class:`elasticsearch.Elasticsearch` client object
     :arg repository: The Elasticsearch snapshot repository to use
     """
     try:
@@ -961,7 +929,7 @@ def snapshot_running(client):
     """
     Return `True` if a snapshot is in progress, and `False` if not
 
-    :arg client:  An Elasticsearch client connection
+    :arg client: An :class:`elasticsearch.Elasticsearch` client object
     :rtype: bool
     """
     try:
@@ -972,7 +940,7 @@ def snapshot_running(client):
     # suspect.
     return False if status == [] else True
 
-def parse_snapshot_name(name):
+def parse_date_pattern(name):
     """
     Scan and parse `name` for :py:func:`time.strftime` strings, replacing them
     with the associated value when found, but otherwise returning lowercase
@@ -991,7 +959,7 @@ def parse_snapshot_name(name):
     * ``S``: The 2 digit number of second of the minute
     * ``j``: The 3 digit day of the year
 
-    :arg name: A snapshot name, which can contain :py:func:`time.strftime`
+    :arg name: A name, which can contain :py:func:`time.strftime`
         strings
     """
     prev = ''; curr = ''; rendered = ''

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,13 +3,22 @@
 Changelog
 =========
 
-4.0.0a5 (? ? ?)
----------------
+4.0.0a5 (25 Apr 2016)
+---------------------
+
+**General**
+
+  * Documentation updates.
+  * Improve API by giving each action its own `do_dry_run()` method.
 
 **Bug Fixes**
 
   * Do not escape characters other than ``.`` and ``-`` in timestrings. Fixes
     #602 (untergeek)
+
+** New Features**
+
+  * Added `CreateIndex` action.
 
 4.0.0a4 (21 Apr 2016)
 ---------------------

--- a/docs/asciidoc/actions.asciidoc
+++ b/docs/asciidoc/actions.asciidoc
@@ -141,6 +141,49 @@ Optional settings
 TIP: See an example of this action in an <<actionfile,actionfile>>
     <<ex_close,here>>.
 
+
+[[create_index]]
+== create_index
+
+[source,text]
+-------------
+action: create_index
+description: "Create index as named"
+options:
+  name:
+  body:
+  continue_if_exception: False
+  disable_action: False
+filters:
+- filtertype: ...
+-------------
+
+NOTE: Empty values and commented lines will result in the default value, if any,
+    being selected.  If a setting is set, but not used by a given action, it
+    will be ignored.
+
+This action closes the selected indices.
+
+[float]
+Required settings
+~~~~~~~~~~~~~~~~~
+* <<option_name,name>>
+
+[float]
+Optional settings
+~~~~~~~~~~~~~~~~~
+* <<body,body>> No default value.  Can create any acceptable index settings and
+    mappings as nested YAML.  See
+    https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html
+    for more information.
+* <<option_continue,continue_if_exception>> (has a default value which can
+    optionally be changed)
+* <<option_disable,disable_action>> (has a default value which can optionally
+    be changed)
+
+TIP: See an example of this action in an <<actionfile,actionfile>>
+    <<ex_create_index,here>>.
+
 [[delete_indices]]
 == Delete Indices
 

--- a/docs/asciidoc/examples.asciidoc
+++ b/docs/asciidoc/examples.asciidoc
@@ -123,6 +123,34 @@ actions:
       unit_count: 30
 -------------
 
+
+[[ex_create_index]]
+== create_index
+
+[source,text]
+-------------
+---
+# Remember, leave a key empty if there is no value.  None will be a string,
+# not a Python "NoneType"
+#
+# Also remember that all examples have 'disable_action' set to True.  If you
+# want to use this action as a template, be sure to set this to False after
+# copying it.
+actions:
+  1:
+    action: create_index
+    description: Create the index as named, with the specified settings.
+    options:
+      name: myindex
+      body:
+        settings:
+          number_of_shards: 2
+          number_of_replicas: 1
+      continue_if_exception: False
+      disable_action: True
+-------------
+
+
 [[ex_delete_indices]]
 === delete_indices
 

--- a/docs/asciidoc/options.asciidoc
+++ b/docs/asciidoc/options.asciidoc
@@ -30,6 +30,14 @@ https://www.elastic.co/guide/en/elasticsearch/reference/current/shard-allocation
 
 The default value for this setting is `require`.
 
+[[option_body]]
+== body
+
+This setting should be nested YAML.  The values beneath `body` will be used by
+whichever action uses the option.
+
+There is no default value.
+
 [[option_continue]]
 == continue_if_exception
 
@@ -156,11 +164,12 @@ will be raised, and execution will halt.
 [[option_name]]
 == name
 
-NOTE: This setting is only used by the <<snapshot,snapshot>> action.
+NOTE: This setting is only used by the <<snapshot,snapshot>> and
+    <<create_index,create_index>> actions.
 
-The value of this setting is the name of the snapshot.
+The value of this setting is the name of the snapshot or index.
 
-This setting should contain a valid Python strftime string.  Curator will
+This setting may contain a valid Python strftime string.  Curator will
 extract the strftime identifiers and replace them with the corresponding values.
 
 The Python strftime identifiers that Curator currently recognizes include:
@@ -175,7 +184,11 @@ The Python strftime identifiers that Curator currently recognizes include:
 * `S`: The 2 digit number of second of the minute
 * `j`: The 3 digit day of the year
 
-The default value of this setting is `curator-%Y%m%d%H%M%S`
+For the <<create_index,create_index>> action, there is no default setting.
+
+For the <<snapshot,snapshot>> action, the default value of this setting is
+`curator-%Y%m%d%H%M%S`
+
 
 
 [[option_partial]]

--- a/examples/actions/create_index.yml
+++ b/examples/actions/create_index.yml
@@ -1,0 +1,19 @@
+---
+# Remember, leave a key empty if there is no value.  None will be a string,
+# not a Python "NoneType"
+#
+# Also remember that all examples have 'disable_action' set to True.  If you
+# want to use this action as a template, be sure to set this to False after
+# copying it.
+actions:
+  1:
+    action: create_index
+    description: Create the index as named, with the specified settings.
+    options:
+      name: myindex
+      body:
+        settings:
+          number_of_shards: 2
+          number_of_replicas: 1
+      continue_if_exception: False
+      disable_action: True

--- a/test/integration/test_create_index.py
+++ b/test/integration/test_create_index.py
@@ -1,0 +1,83 @@
+import elasticsearch
+import curator
+import os
+import json
+import string, random, tempfile
+import click
+from click import testing as clicktest
+from mock import patch, Mock
+
+from . import CuratorTestCase
+from . import testvars as testvars
+
+import logging
+logger = logging.getLogger(__name__)
+
+host, port = os.environ.get('TEST_ES_SERVER', 'localhost:9200').split(':')
+port = int(port) if port else 9200
+
+class TestCLICreateIndex(CuratorTestCase):
+    def test_plain(self):
+        self.write_config(
+            self.args['configfile'], testvars.client_config.format(host, port))
+        self.write_config(self.args['actionfile'],
+            testvars.create_index.format('testing'))
+        self.assertEqual([], curator.get_indices(self.client))
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--config', self.args['configfile'],
+                        self.args['actionfile']
+                    ],
+                    )
+        self.assertEqual(['testing'], curator.get_indices(self.client))
+    def test_with_body(self):
+        self.write_config(
+            self.args['configfile'], testvars.client_config.format(host, port))
+        self.write_config(self.args['actionfile'],
+            testvars.create_index_with_body.format('testing'))
+        self.assertEqual([], curator.get_indices(self.client))
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--config', self.args['configfile'],
+                        self.args['actionfile']
+                    ],
+                    )
+        ilo = curator.IndexList(self.client)
+        self.assertEqual(['testing'], ilo.indices)
+        self.assertEqual(ilo.index_info['testing']['number_of_shards'], '1')
+        self.assertEqual(ilo.index_info['testing']['number_of_replicas'], '0')
+    def test_with_date(self):
+        self.write_config(
+            self.args['configfile'], testvars.client_config.format(host, port))
+        self.write_config(self.args['actionfile'],
+            testvars.create_index.format('testing-%Y.%m.%d'))
+        self.assertEqual([], curator.get_indices(self.client))
+        name = curator.parse_date_pattern('testing-%Y.%m.%d')
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--config', self.args['configfile'],
+                        self.args['actionfile']
+                    ],
+                    )
+        self.assertEqual([name], curator.get_indices(self.client))
+    def test_extra_option(self):
+        self.write_config(
+            self.args['configfile'], testvars.client_config.format(host, port))
+        self.write_config(self.args['actionfile'],
+            testvars.bad_option_proto_test.format('create_index'))
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--config', self.args['configfile'],
+                        self.args['actionfile']
+                    ],
+                    )
+        self.assertEqual([], curator.get_indices(self.client))
+        self.assertEqual(1, result.exit_code)

--- a/test/integration/testvars.py
+++ b/test/integration/testvars.py
@@ -304,3 +304,25 @@ delete_snap_proto = ('---\n'
 '        unit: {5}\n'
 '        unit_count: {6}\n'
 '        epoch: {7}\n')
+
+create_index = ('---\n'
+'actions:\n'
+'  1:\n'
+'    description: "Create index as named"\n'
+'    action: create_index\n'
+'    options:\n'
+'      name: {0}\n'
+'      continue_if_exception: False\n'
+'      disable_action: False\n')
+
+create_index_with_body = ('---\n'
+'actions:\n'
+'  1:\n'
+'    description: "Create index as named with body"\n'
+'    action: create_index\n'
+'    options:\n'
+'      name: {0}\n'
+'      body:\n'
+
+'      continue_if_exception: False\n'
+'      disable_action: False\n')

--- a/test/unit/test_action_alias.py
+++ b/test/unit/test_action_alias.py
@@ -84,6 +84,16 @@ class TestActionAlias(TestCase):
         ilo = curator.IndexList(client)
         ao = curator.Alias(alias='alias')
         self.assertRaises(curator.ActionError, ao.body)
+    def test_do_dry_run(self):
+        client = Mock()
+        client.indices.get_settings.return_value = testvars.settings_one
+        client.cluster.state.return_value = testvars.clu_state_one
+        client.indices.stats.return_value = testvars.stats_one
+        client.indices.update_aliases.return_value = testvars.alias_success
+        ilo = curator.IndexList(client)
+        ao = curator.Alias(alias='alias')
+        ao.add(ilo)
+        self.assertIsNone(ao.do_dry_run())
     def test_do_action(self):
         client = Mock()
         client.indices.get_settings.return_value = testvars.settings_one

--- a/test/unit/test_action_allocation.py
+++ b/test/unit/test_action_allocation.py
@@ -61,6 +61,15 @@ class TestActionAllocation(TestCase):
         ilo = curator.IndexList(client)
         ao = curator.Allocation(ilo, key='key', value='value')
         self.assertRaises(Exception, ao.do_action)
+    def test_do_dry_run(self):
+        client = Mock()
+        client.indices.get_settings.return_value = testvars.settings_one
+        client.cluster.state.return_value = testvars.clu_state_one
+        client.indices.stats.return_value = testvars.stats_one
+        client.indices.put_settings.return_value = None
+        ilo = curator.IndexList(client)
+        ao = curator.Allocation(ilo, key='key', value='value')
+        self.assertIsNone(ao.do_dry_run())
     def test_do_action(self):
         client = Mock()
         client.indices.get_settings.return_value = testvars.settings_one

--- a/test/unit/test_action_close.py
+++ b/test/unit/test_action_close.py
@@ -17,6 +17,16 @@ class TestActionClose(TestCase):
         co = curator.Close(ilo)
         self.assertEqual(ilo, co.index_list)
         self.assertEqual(client, co.client)
+    def test_do_dry_run(self):
+        client = Mock()
+        client.indices.get_settings.return_value = testvars.settings_one
+        client.cluster.state.return_value = testvars.clu_state_one
+        client.indices.stats.return_value = testvars.stats_one
+        client.indices.flush_synced.return_value = testvars.synced_pass
+        client.indices.close.return_value = None
+        ilo = curator.IndexList(client)
+        co = curator.Close(ilo)
+        self.assertIsNone(co.do_dry_run())
     def test_do_action(self):
         client = Mock()
         client.indices.get_settings.return_value = testvars.settings_one

--- a/test/unit/test_action_create_index.py
+++ b/test/unit/test_action_create_index.py
@@ -1,0 +1,34 @@
+from unittest import TestCase
+from mock import Mock, patch
+import elasticsearch
+import curator
+# Get test variables and constants from a single source
+from . import testvars as testvars
+
+class TestActionCreate_index(TestCase):
+    def test_init_raise(self):
+        self.assertRaises(TypeError, curator.CreateIndex, 'invalid')
+    def test_init_raise_no_name(self):
+        client = Mock()
+        self.assertRaises(curator.ConfigurationError,
+            curator.CreateIndex, client, None)
+    def test_init(self):
+        client = Mock()
+        co = curator.CreateIndex(client, 'name')
+        self.assertEqual('name', co.name)
+        self.assertEqual(client, co.client)
+    def test_do_dry_run(self):
+        client = Mock()
+        co = curator.CreateIndex(client, 'name')
+        self.assertIsNone(co.do_dry_run())
+    def test_do_action(self):
+        client = Mock()
+        client.indices.create.return_value = None
+        co = curator.CreateIndex(client, 'name')
+        self.assertIsNone(co.do_action())
+    def test_do_action_raises_exception(self):
+        client = Mock()
+        client.indices.create.return_value = None
+        client.indices.create.side_effect = testvars.fake_fail
+        co = curator.CreateIndex(client, 'name')
+        self.assertRaises(curator.FailedExecution, co.do_action)

--- a/test/unit/test_action_delete_indices.py
+++ b/test/unit/test_action_delete_indices.py
@@ -24,6 +24,15 @@ class TestActionDeleteIndices(TestCase):
         do = curator.DeleteIndices(ilo)
         self.assertEqual(ilo, do.index_list)
         self.assertEqual(client, do.client)
+    def test_do_dry_run(self):
+        client = Mock()
+        client.indices.get_settings.return_value = testvars.settings_four
+        client.cluster.state.return_value = testvars.clu_state_four
+        client.indices.stats.return_value = testvars.stats_four
+        client.indices.delete.return_value = None
+        ilo = curator.IndexList(client)
+        do = curator.DeleteIndices(ilo)
+        self.assertIsNone(do.do_dry_run())
     def test_do_action(self):
         client = Mock()
         client.indices.get_settings.return_value = testvars.settings_four

--- a/test/unit/test_action_delete_snapshots.py
+++ b/test/unit/test_action_delete_snapshots.py
@@ -16,6 +16,14 @@ class TestActionDeleteSnapshots(TestCase):
         do = curator.DeleteSnapshots(slo)
         self.assertEqual(slo, do.snapshot_list)
         self.assertEqual(client, do.client)
+    def test_do_dry_run(self):
+        client = Mock()
+        client.snapshot.get.return_value = testvars.snapshots
+        client.snapshot.get_repository.return_value = testvars.test_repo
+        client.snapshot.delete.return_value = None
+        slo = curator.SnapshotList(client, repository=testvars.repo_name)
+        do = curator.DeleteSnapshots(slo)
+        self.assertIsNone(do.do_dry_run())
     def test_do_action(self):
         client = Mock()
         client.snapshot.get.return_value = testvars.snapshots

--- a/test/unit/test_action_forcemerge.py
+++ b/test/unit/test_action_forcemerge.py
@@ -28,6 +28,16 @@ class TestActionForceMerge(TestCase):
         fmo = curator.ForceMerge(ilo, max_num_segments=2)
         self.assertEqual(ilo, fmo.index_list)
         self.assertEqual(client, fmo.client)
+    def test_do_dry_run(self):
+        client = Mock()
+        client.indices.get_settings.return_value = testvars.settings_one
+        client.cluster.state.return_value = testvars.clu_state_one
+        client.indices.stats.return_value = testvars.stats_one
+        client.indices.segments.return_value = testvars.shards
+        client.indices.forcemerge.return_value = None
+        ilo = curator.IndexList(client)
+        fmo = curator.ForceMerge(ilo, max_num_segments=2)
+        self.assertIsNone(fmo.do_dry_run())
     def test_do_action(self):
         client = Mock()
         client.indices.get_settings.return_value = testvars.settings_one

--- a/test/unit/test_action_open.py
+++ b/test/unit/test_action_open.py
@@ -17,6 +17,17 @@ class TestActionOpen(TestCase):
         oo = curator.Open(ilo)
         self.assertEqual(ilo, oo.index_list)
         self.assertEqual(client, oo.client)
+    def test_do_dry_run(self):
+        client = Mock()
+        client.indices.get_settings.return_value = testvars.settings_four
+        client.cluster.state.return_value = testvars.clu_state_four
+        client.indices.stats.return_value = testvars.stats_four
+        client.indices.open.return_value = None
+        ilo = curator.IndexList(client)
+        ilo.filter_opened()
+        oo = curator.Open(ilo)
+        self.assertEqual([u'c-2016.03.05'], oo.index_list.indices)
+        self.assertIsNone(oo.do_dry_run())
     def test_do_action(self):
         client = Mock()
         client.indices.get_settings.return_value = testvars.settings_four

--- a/test/unit/test_action_replicas.py
+++ b/test/unit/test_action_replicas.py
@@ -27,6 +27,15 @@ class TestActionReplicas(TestCase):
         ro = curator.Replicas(ilo, count=2)
         self.assertEqual(ilo, ro.index_list)
         self.assertEqual(client, ro.client)
+    def test_do_dry_run(self):
+        client = Mock()
+        client.indices.get_settings.return_value = testvars.settings_one
+        client.cluster.state.return_value = testvars.clu_state_one
+        client.indices.stats.return_value = testvars.stats_one
+        client.indices.put_settings.return_value = None
+        ilo = curator.IndexList(client)
+        ro = curator.Replicas(ilo, count=0)
+        self.assertIsNone(ro.do_dry_run())
     def test_do_action(self):
         client = Mock()
         client.indices.get_settings.return_value = testvars.settings_one

--- a/test/unit/test_action_snapshot.py
+++ b/test/unit/test_action_snapshot.py
@@ -91,6 +91,20 @@ class TestActionSnapshot(TestCase):
             name=testvars.snap_name)
         so.report_state()
         self.assertEqual('IN_PROGRESS', so.state)
+    def test_do_dry_run(self):
+        client = Mock()
+        client.indices.get_settings.return_value = testvars.settings_one
+        client.cluster.state.return_value = testvars.clu_state_one
+        client.indices.stats.return_value = testvars.stats_one
+        client.snapshot.get_repository.return_value = testvars.test_repo
+        client.snapshot.get.return_value = testvars.snapshots
+        client.snapshot.create.return_value = None
+        client.snapshot.status.return_value = testvars.nosnap_running
+        client.snapshot.verify_repository.return_value = testvars.verified_nodes
+        ilo = curator.IndexList(client)
+        so = curator.Snapshot(ilo, repository=testvars.repo_name,
+            name=testvars.snap_name)
+        self.assertIsNone(so.do_dry_run())
     def test_do_action_success(self):
         client = Mock()
         client.indices.get_settings.return_value = testvars.settings_one

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -300,21 +300,6 @@ class TestShowDryRun(TestCase):
         client.field_stats.return_value = testvars.fieldstats_two
         il = curator.IndexList(client)
         self.assertIsNone(curator.show_dry_run(il, 'test_action'))
-    def test_snapshot_list(self):
-        client = Mock()
-        client.snapshot.get.return_value = testvars.snapshots
-        client.snapshot.get_repository.return_value = testvars.test_repo
-        sl = curator.SnapshotList(client, repository=testvars.repo_name)
-        self.assertIsNone(curator.show_dry_run(sl, 'delete_snapshots'))
-    def test_alias_list(self):
-        client = Mock()
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        ilo = curator.IndexList(client)
-        ao = curator.Alias(alias='alias')
-        ao.remove(ilo)
-        self.assertIsNone(curator.show_dry_run(ao, 'alias'))
 
 class TestGetRepository(TestCase):
     def test_get_repository_missing_arg(self):


### PR DESCRIPTION
* Update docs and examples accordingly
* Update tests to reflect a change

Big deal here for the API is adding a `do_dry_run()` method
to the action classes.  Streamlined cli.py some, too.

Bump version to alpha 5