### PR TITLE
Fix TimestringSearch to work with Python 2.6

### DIFF
--- a/curator/utils.py
+++ b/curator/utils.py
@@ -220,10 +220,14 @@ class TimestringSearch(object):
         if match:
             if match.group("date"):
                 timestamp = match.group("date")
-                return (
-                    (get_datetime(timestamp, self.timestring) -
-                    datetime(1970,1,1)).total_seconds()
+                # I would have used `total_seconds`, but apparently that's new
+                # to Python 2.7+, and due to so many people still using
+                # RHEL/CentOS 6, I need this to support Python 2.6.
+                tdelta = (
+                    get_datetime(timestamp, self.timestring) -
+                    datetime(1970,1,1)
                 )
+                return tdelta.seconds + tdelta.days * 24 * 3600
 
 def get_point_of_reference(unit, count, epoch=None):
     """

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -22,6 +22,7 @@ Changelog
   * Fix an issue where arguments weren't being properly passed and populated.
   * ForceMerge replaced Optimize in ES 2.1.0.
   * Fix prune_nones to work with Python 2.6. Fixes #619 (untergeek)
+  * Fix TimestringSearch to work with Python 2.6. Fixes #622 (untergeek)
 
 4.0.0a9 (27 Apr 2016)
 ---------------------


### PR DESCRIPTION
fixes #622