### PR TITLE
Improve Travis to test multiple ES versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,13 @@ python:
   - "3.4"
   - "3.5"
 
+env:
+  - ES_VERSION=2.0.0
+  - ES_VERSION=2.1.1
+  - ES_VERSION=2.2.2
+  - ES_VERSION=2.3.3
+  - ES_VERSION=5.0.0-alpha3
+
 os: linux
 
 cache:
@@ -16,12 +23,10 @@ jdk:
 install:
   - pip install -r requirements.txt
   - pip install .
-  - mkdir /tmp/elasticsearch
-  - wget -O - https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-2.3.3.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1
-
-before_script:
-  - /tmp/elasticsearch/bin/elasticsearch -d -D es.path.data=/tmp -D es.path.repo /
-  - sleep 10
 
 script:
-  - python setup.py test
+  - sudo apt-get update && sudo apt-get install oracle-java8-installer
+  - java -version
+  - sudo update-alternatives --set java /usr/lib/jvm/java-8-oracle/jre/bin/java
+  - java -version
+  - ./travis-run.sh

--- a/travis-run.sh
+++ b/travis-run.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -ex
+
+setup_es() {
+  download_url=$1
+  curl -sL $download_url > elasticsearch.tar.gz
+  mkdir elasticsearch
+  tar -xzf elasticsearch.tar.gz --strip-components=1 -C ./elasticsearch/.
+
+}
+
+start_es() {
+  jhome=$1
+  es_args=$2
+  export JAVA_HOME=$jhome
+  elasticsearch/bin/elasticsearch $es_args > /tmp/elasticsearch.log &
+  sleep 10
+  curl http://localhost:9200 && echo "ES is up!" || cat /tmp/elasticsearch.log
+}
+
+setup_es https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/$ES_VERSION/elasticsearch-$ES_VERSION.tar.gz
+
+java_home='/usr/lib/jvm/java-8-oracle'
+if [[ "$ES_VERSION" == 5.* ]]; then
+  start_es $java_home '-d -Edefault.path.repo=/'
+else
+  start_es $java_home '-d -Des.path.repo=/'
+fi
+python setup.py test
+result=$(head -1 nosetests.xml | awk '{print $6 " " $7 " " $8}' | awk -F\> '{print $1}')
+expected='errors="0" failures="0" skip="0"'
+echo "Result = $result"
+if [[ "$result" != "$expected" ]]; then
+  exit 1
+fi


### PR DESCRIPTION
This mirrors some of what the logstash elasticsearch output plugin does.  This should allow for Travis to do CI testing against multiple Elasticsearch variants.