### PR TITLE
Fix logformat json/logstash to send UTC offset

### DIFF
--- a/curator/logtools.py
+++ b/curator/logtools.py
@@ -1,6 +1,7 @@
 import sys
 import json
 import logging
+import time
 
 class LogstashFormatter(logging.Formatter):
     # The LogRecord attributes we want to carry over to the Logstash message,
@@ -15,6 +16,7 @@ class LogstashFormatter(logging.Formatter):
     #     return time.gmtime(timevalue)
 
     def format(self, record):
+        self.converter = time.gmtime
         timestamp = '%s.%03dZ' % (
             self.formatTime(record, datefmt='%Y-%m-%dT%H:%M:%S'), record.msecs)
         result = {'message': record.getMessage(),

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,14 @@
 Changelog
 =========
 
+4.0.1 (? ? ?)
+-------------
+
+**Bug Fixes**
+
+  * Coerce Logstash/JSON logformat type timestamp value to always use UTC.
+    #661 (untergeek)
+
 4.0.0 (24 June 2016)
 --------------------
 


### PR DESCRIPTION
The `@timestamp` field will now look like this:

```
{"@timestamp": "2016-06-27T11:07:37.906-0600", ... }
```

Hattip @ryancurrah

fixes #661