### PR TITLE
Ignore indices with no `creation_date`

### DIFF
--- a/curator/indexlist.py
+++ b/curator/indexlist.py
@@ -152,9 +152,18 @@ class IndexList(object):
                 for index in list(working_list.keys()):
                     s = self.index_info[index]
                     wl = working_list[index]
-                    s['age']['creation_date'] = (
-                        fix_epoch(wl['settings']['index']['creation_date'])
-                    )
+                    if not 'creation_date' in wl['settings']['index']:
+                        self.loggit.warn(
+                            'Index: {0} has no "creation_date"! This implies '
+                            'that the index predates Elasticsearch v1.4. For '
+                            'safety, this index will be removed from the '
+                            'actionable list.'.format(index)
+                        )
+                        self.__not_actionable(index)
+                    else:
+                        s['age']['creation_date'] = (
+                            fix_epoch(wl['settings']['index']['creation_date'])
+                        )
                     s['number_of_replicas'] = (
                         wl['settings']['index']['number_of_replicas']
                     )

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -10,6 +10,9 @@ Changelog
 
   * Coerce Logstash/JSON logformat type timestamp value to always use UTC.
     #661 (untergeek)
+  * Catch and remove indices from the actionable list if they do not have a
+    `creation_date` field in settings.  This field was introduced in ES v1.4, so
+    that indicates a rather old index. #663 (untergeek)
 
 4.0.0 (24 June 2016)
 --------------------

--- a/test/unit/test_class_index_list.py
+++ b/test/unit/test_class_index_list.py
@@ -37,7 +37,13 @@ class TestIndexListClientAndInit(TestCase):
         client.indices.stats.return_value = testvars.stats_two
         il = curator.IndexList(client)
         self.assertEqual('close', il.index_info['index-2016.03.03']['state'])
-
+    def test_skip_index_without_creation_date(self):
+        client = Mock()
+        client.indices.get_settings.return_value = testvars.settings_two_no_cd
+        client.cluster.state.return_value = testvars.clu_state_two_no_cd
+        client.indices.stats.return_value = testvars.stats_two
+        il = curator.IndexList(client)
+        self.assertEqual(['index-2016.03.03'], sorted(il.indices))
 class TestIndexListOtherMethods(TestCase):
     def test_empty_list(self):
         client = Mock()

--- a/test/unit/testvars.py
+++ b/test/unit/testvars.py
@@ -239,6 +239,35 @@ settings_2_closed = {
     }
 }
 
+settings_two_no_cd  = {
+    u'index-2016.03.03': {
+        u'state': u'open',
+        u'aliases': [u'my_alias'],
+        u'mappings': {},
+        u'settings': {
+            u'index': {
+                u'number_of_replicas': u'1', u'uuid': u'random_uuid_string_here',
+                u'number_of_shards': u'5', u'creation_date': u'1456963200172',
+                u'routing': {u'allocation': {u'include': {u'tag': u'foo'}}},
+                u'version': {u'created': u'2020099'}, u'refresh_interval': u'5s'
+            }
+        }
+    },
+    u'index-2016.03.04': {
+        u'state': u'open',
+        u'aliases': [u'my_alias'],
+        u'mappings': {},
+        u'settings': {
+            u'index': {
+                u'number_of_replicas': u'1', u'uuid': u'another_random_uuid_string',
+                u'number_of_shards': u'5',
+                u'routing': {u'allocation': {u'include': {u'tag': u'bar'}}},
+                u'version': {u'created': u'2020099'}, u'refresh_interval': u'5s'
+            }
+        }
+    }
+}
+
 settings_four  = {
     u'a-2016.03.03': {
         u'state': u'open',
@@ -336,6 +365,11 @@ clu_state_two  = {
 cs_two_closed  = {
     u'metadata': {
         u'indices': settings_2_closed
+    }
+}
+clu_state_two_no_cd  = {
+    u'metadata': {
+        u'indices': settings_two_no_cd
     }
 }
 clu_state_four = {


### PR DESCRIPTION
This fixes scenarios where people have older indices and it gives a `KeyError` exception, and can't find `creation_date`.

fixes #663