### PR TITLE
Fix missing 'state' filter for snapshotlist

### DIFF
--- a/curator/snapshotlist.py
+++ b/curator/snapshotlist.py
@@ -85,6 +85,7 @@ class SnapshotList(object):
             'age': self.filter_by_age,
             'none': self.filter_none,
             'pattern': self.filter_by_regex,
+            'state': self.filter_by_state,
         }
         return methods[ft]
 

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -13,6 +13,7 @@ Changelog
   * Catch and remove indices from the actionable list if they do not have a
     `creation_date` field in settings.  This field was introduced in ES v1.4, so
     that indicates a rather old index. #663 (untergeek)
+  * Replace missing ``state`` filter for ``snapshotlist``. #665 (untergeek)
 
 4.0.0 (24 June 2016)
 --------------------


### PR DESCRIPTION
This is an egregious oversight.  It probably trigger an automatic release of 4.0.1