### PR TITLE
Add note to settings available in all actions

### DIFF
--- a/docs/asciidoc/options.asciidoc
+++ b/docs/asciidoc/options.asciidoc
@@ -30,6 +30,8 @@ There is no default value.
 [[option_continue]]
 == continue_if_exception
 
+NOTE: This setting is available in all actions.
+
 If `continue_if_exception` is set to `True`, Curator will attempt to continue on
 to the next action, if any, even if an exception is encountered. Curator will
 log but ignore the exception that was raised.
@@ -71,6 +73,8 @@ The default value is `False`.
 
 [[option_disable]]
 == disable_action
+
+NOTE: This setting is available in all actions.
 
 If `disable_action` is set to `True`, Curator will ignore the current action.
 This may be useful for temporarily disabling actions in a large configuration


### PR DESCRIPTION
Added notes match the existing note for timeout_override, which is one of three settings available for all actions in 4.0.0 version of curator.