### PR TITLE
Fix call to cluster health during Allocation wait_for_completion

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -197,7 +197,7 @@ class Allocation(object):
                         ' {0}'.format(to_csv(l))
                     )
                     self.client.cluster.health(index=to_csv(l),
-                        level='indices', wait_for_relocation_shards=0,
+                        level='indices', wait_for_relocating_shards=0,
                         timeout=self.timeout,
                     )
         except Exception as e:


### PR DESCRIPTION
https://github.com/elastic/elasticsearch-py/blob/2.x/elasticsearch/client/cluster.py#L24
```
        :arg wait_for_relocating_shards: Wait until the specified number of
            relocating shards is finished
```

Fixes #705