### PR TITLE
Replace region for aws_region in utils.py

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -78,3 +78,4 @@ Contributors:
 * Luke Waite (lukewaite)
 * (dtrv)
 * Christopher "Chief" Najewicz (chiefy)
+* Filipe Gonçalves (basex)

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -524,14 +524,14 @@ def get_client(**kwargs):
             else kwargs['aws_key']
         kwargs['aws_secret_key'] = False if not 'aws_secret_key' in kwargs \
             else kwargs['aws_secret_key']
-        kwargs['region'] = False if not 'region' in kwargs \
-            else kwargs['region']
+        kwargs['aws_region'] = False if not 'aws_region' in kwargs \
+            else kwargs['aws_region']
         if kwargs['aws_key'] or kwargs['aws_secret_key'] or kwargs['region']:
             if not kwargs['aws_key'] and kwargs['aws_secret_key'] \
-                    and kwargs['region']:
+                    and kwargs['aws_region']:
                 raise MissingArgument(
                     'Missing one or more of "aws_key", "aws_secret_key", '
-                    'or "region".'
+                    'or "aws_region".'
                 )
             # Override these kwargs
             kwargs['use_ssl'] = True
@@ -540,7 +540,7 @@ def get_client(**kwargs):
             kwargs['http_auth'] = (
                 AWS4Auth(
                     kwargs['aws_key'], kwargs['aws_secret_key'],
-                    kwargs['region'], 'es')
+                    kwargs['aws_region'], 'es')
             )
         else:
             logger.debug('"requests_aws4auth" module present, but not used.')

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -10,6 +10,9 @@ Changelog
 
 **New Features**
 
+**Bug Fixes**
+
+  * Fix incorrect variable name for AWS Region reported in #679 (basex)
 
 4.0.4 (1 August 2016)
 ---------------------


### PR DESCRIPTION
Corrects https://github.com/elastic/curator/issues/679

The elastic search guides mention aws_region instead of region on the config file.