### PR TITLE
delete_aliases works as expected now

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -244,8 +244,14 @@ class Close(object):
                     self.loggit.info(
                         'Deleting aliases from indices before closing.')
                     self.loggit.debug('Deleting aliases from: {0}'.format(l))
-                    self.client.indices.delete_alias(
-                        index=to_csv(l), name='_all')
+                    try:
+                        self.client.indices.delete_alias(
+                            index=to_csv(l), name='_all')
+                    except Exception as e:
+                        self.loggit.warn(
+                            'Some indices may not have had aliases.  Exception:'
+                            ' {0}'.format(e)
+                        )
                 self.client.indices.flush(
                     index=to_csv(l), ignore_unavailable=True)
                 self.client.indices.close(

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -16,6 +16,12 @@ Changelog
   * New requirement! ``voluptuous`` Python schema validation module
   * Requirement version bump:  Now requires ``elasticsearch-py`` 2.4.0
 
+**Bug Fixes**
+
+  * ``delete_aliases`` option in ``close`` action no longer results in an error
+    if not all selected indices have an alias.  Add test to confirm expected
+    behavior. Reported in #736 (untergeek)
+
 4.0.6 (15 August 2016)
 ----------------------
 

--- a/test/integration/test_close.py
+++ b/test/integration/test_close.py
@@ -83,6 +83,7 @@ class TestCLIClose(CuratorTestCase):
         index = 'my_index'
         self.create_index(index)
         self.create_index('dummy')
+        self.create_index('my_other')
         self.client.indices.put_alias(index='my_index,dummy', name=alias)
         self.assertEquals(
             {
@@ -110,6 +111,13 @@ class TestCLIClose(CuratorTestCase):
                 index=index,
                 metric='metadata',
             )['metadata']['indices'][index]['state']
+        )
+        self.assertEquals(
+            'close',
+            self.client.cluster.state(
+                index='my_other',
+                metric='metadata',
+            )['metadata']['indices']['my_other']['state']
         )
         # Now open the indices and verify that the alias is still gone.
         self.client.indices.open(index=index)

--- a/test/unit/test_action_close.py
+++ b/test/unit/test_action_close.py
@@ -58,3 +58,14 @@ class TestActionClose(TestCase):
         ilo = curator.IndexList(client)
         co = curator.Close(ilo)
         self.assertRaises(curator.FailedExecution, co.do_action)
+    def test_do_action_delete_aliases_with_exception(self):
+        client = Mock()
+        client.indices.get_settings.return_value = testvars.settings_one
+        client.cluster.state.return_value = testvars.clu_state_one
+        client.indices.stats.return_value = testvars.stats_one
+        client.indices.flush_synced.return_value = testvars.synced_pass
+        client.indices.close.return_value = None
+        ilo = curator.IndexList(client)
+        client.indices.delete_alias.side_effect = testvars.fake_fail
+        co = curator.Close(ilo, delete_aliases=True)
+        self.assertIsNone(co.do_action())


### PR DESCRIPTION
The method now catches the unexpected exception which resulted if indices _without_ aliases were in the list of indices to have `_all` aliases deleted.

Tests were added to confirm the expected behavior.

fixes #736