### PR TITLE
Add alias filtertype

### DIFF
--- a/curator/defaults/settings.py
+++ b/curator/defaults/settings.py
@@ -54,8 +54,9 @@ def snapshot_actions():
 def all_actions():
     return sorted(index_actions() + snapshot_actions())
 
-def all_filtertypes():
+def index_filtertypes():
     return [
+        'alias',
         'allocated',
         'age',
         'closed',
@@ -65,8 +66,13 @@ def all_filtertypes():
         'opened',
         'pattern',
         'space',
-        'state',
     ]
+
+def snapshot_filtertypes():
+    return ['age', 'none', 'pattern', 'state']
+
+def all_filtertypes():
+    return sorted(list(set(index_filtertypes() + snapshot_filtertypes())))
 
 def default_options():
     return {

--- a/curator/validators/filter_elements.py
+++ b/curator/validators/filter_elements.py
@@ -3,6 +3,10 @@ from ..defaults import settings
 
 ### Schema information ###
 
+def aliases(**kwargs):
+    # This setting is used by the alias filtertype and is required
+    return { Required('aliases'): Any(str, [str]) }
+
 def allocation_type(**kwargs):
     return { Optional('allocation_type', default='require'): All(
         str, Any('require', 'include', 'exclude')) }

--- a/curator/validators/filters.py
+++ b/curator/validators/filters.py
@@ -19,6 +19,7 @@ def structure():
     # This is to first ensure that only the possible keys/filter elements are
     # there, and get a dictionary back to work with.
     retval = {
+        Optional('aliases'): Any(str, [str]),
         Optional('allocation_type'): str,
         Optional('direction'): str,
         Optional('disk_space'): float,

--- a/curator/validators/filtertypes.py
+++ b/curator/validators/filtertypes.py
@@ -6,6 +6,12 @@ logger = logging.getLogger(__name__)
 
 ### Schema information ###
 
+def alias(action, config):
+    return [
+        filter_elements.aliases(),
+        filter_elements.exclude(),
+    ]
+
 def age(action, config):
     # Required & Optional
     retval = [

--- a/docs/asciidoc/filter_elements.asciidoc
+++ b/docs/asciidoc/filter_elements.asciidoc
@@ -4,6 +4,7 @@
 
 [partintro]
 --
+* <<fe_aliases,aliases>>
 * <<fe_allocation_type,allocation_type>>
 * <<fe_direction,direction>>
 * <<fe_disk_space,disk_space>>
@@ -23,6 +24,52 @@
 * <<fe_use_age,use_age>>
 * <<fe_value,value>>
 --
+
+[[fe_aliases]]
+== aliases
+
+NOTE: This setting is used only when using the <<filtertype_alias,alias>>
+    filter.
+
+The value of this setting must be a single alias name, or a list of alias names.
+This can be done in any of the ways YAML allows for lists or arrays.  Here are
+a few examples.
+
+**Single**
+[source,txt]
+-------
+filters:
+- filtertype: alias
+  aliases: my_alias
+  exclude: False
+-------
+
+**List**
+
+- Flow style:
++
+[source,txt]
+-------
+filters:
+- filtertype: alias
+  aliases: [ my_alias, another_alias ]
+  exclude: False
+-------
+
+- Block style:
++
+[source,txt]
+-------
+filters:
+- filtertype: alias
+  aliases:
+    - my_alias
+    - another_alias
+  exclude: False
+-------
+
+There is no default value. This setting must be set by the user or an
+exception will be raised, and execution will halt.
 
 [[fe_allocation_type]]
 == allocation_type

--- a/docs/asciidoc/filters.asciidoc
+++ b/docs/asciidoc/filters.asciidoc
@@ -8,6 +8,7 @@ Filters are the way to select only the indices (or snapshots) you want.
 
 The index filtertypes are:
 
+* <<filtertype_alias,alias>>
 * <<filtertype_age,age>>
 * <<filtertype_pattern,pattern>>
 * <<filtertype_space,space>>
@@ -66,6 +67,34 @@ The snapshot filtertypes are:
 * <<filtertype_age,age>>
 * <<filtertype_pattern,pattern>>
 
+[[filtertype_alias]]
+== alias
+
+[source,text]
+-------------
+- filtertype: alias
+  aliases:
+  exclude: True
+-------------
+
+NOTE: Empty values and commented lines will result in the default value, if any,
+    being selected.  If a setting is set, but not used by a given
+    <<filtertype,filtertype>>, it will be ignored.
+
+This <<filtertype,filtertype>> will iterate over the actionable list and match
+indices based on whether they are associated with the given
+<<fe_aliases,aliases>>.  They will remain in, or be removed from the actionable
+list based on the value of <<fe_exclude,exclude>>.
+
+[float]
+Required settings
+~~~~~~~~~~~~~~~~~
+* <<fe_aliases,aliases>> (required)
+
+[float]
+Optional settings
+~~~~~~~~~~~~~~~~~
+* <<fe_exclude,exclude>> (default is `False`)
 
 [[filtertype_allocated]]
 == allocated

--- a/test/integration/test_integrations.py
+++ b/test/integration/test_integrations.py
@@ -1,0 +1,75 @@
+import elasticsearch
+import curator
+import os
+import json
+import string, random, tempfile
+import click
+from click import testing as clicktest
+from mock import patch, Mock
+
+from . import CuratorTestCase
+from . import testvars as testvars
+
+import logging
+logger = logging.getLogger(__name__)
+
+host, port = os.environ.get('TEST_ES_SERVER', 'localhost:9200').split(':')
+port = int(port) if port else 9200
+
+class TestFilters(CuratorTestCase):
+    def test_filter_by_alias(self):
+        alias = 'testalias'
+        self.write_config(
+            self.args['configfile'], testvars.client_config.format(host, port))
+        self.write_config(self.args['actionfile'],
+            testvars.filter_by_alias.format('testalias', False))
+        self.create_index('my_index')
+        self.create_index('dummy')
+        self.client.indices.put_alias(index='dummy', name=alias)
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--config', self.args['configfile'],
+                        self.args['actionfile']
+                    ],
+                    )
+        self.assertEquals(1, len(curator.get_indices(self.client)))
+    def test_filter_by_array_of_aliases(self):
+        alias = 'testalias'
+        self.write_config(
+            self.args['configfile'], testvars.client_config.format(host, port))
+        self.write_config(self.args['actionfile'],
+            testvars.filter_by_alias.format(' [ testalias, foo ]', False))
+        self.create_index('my_index')
+        self.create_index('dummy')
+        self.client.indices.put_alias(index='dummy', name=alias)
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--config', self.args['configfile'],
+                        self.args['actionfile']
+                    ],
+                    )
+        self.assertEquals(1, len(curator.get_indices(self.client)))
+    def test_filter_by_alias_bad_aliases(self):
+        alias = 'testalias'
+        self.write_config(
+            self.args['configfile'], testvars.client_config.format(host, port))
+        self.write_config(self.args['actionfile'],
+            testvars.filter_by_alias.format('{"this":"isadict"}', False))
+        self.create_index('my_index')
+        self.create_index('dummy')
+        self.client.indices.put_alias(index='dummy', name=alias)
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--config', self.args['configfile'],
+                        self.args['actionfile']
+                    ],
+                    )
+        self.assertEquals(
+            type(curator.ConfigurationError()), type(result.exception))
+        self.assertEquals(2, len(curator.get_indices(self.client)))

--- a/test/integration/testvars.py
+++ b/test/integration/testvars.py
@@ -301,6 +301,20 @@ delete_ignore_proto = ('---\n'
 '        stats_result: {7}\n'
 '        epoch: {8}\n')
 
+filter_by_alias = ('---\n'
+'actions:\n'
+'  1:\n'
+'    description: "Delete indices as filtered"\n'
+'    action: delete_indices\n'
+'    options:\n'
+'      ignore_empty_list: True\n'
+'      continue_if_exception: False\n'
+'      disable_action: False\n'
+'    filters:\n'
+'      - filtertype: alias\n'
+'        aliases: {0}\n'
+'        exclude: {1}\n')
+
 bad_option_proto_test = ('---\n'
 'actions:\n'
 '  1:\n'

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -573,3 +573,19 @@ class TestPruneNones(TestCase):
     def test_prune_nones_without(self):
         a = {'foo':'bar'}
         self.assertEqual(a, curator.prune_nones(a))
+
+class TestValidateFilters(TestCase):
+    def test_snapshot_with_index_filter(self):
+        self.assertRaises(
+            curator.ConfigurationError,
+            curator.validate_filters,
+            'delete_snapshots',
+            [{'filtertype': 'kibana'}]
+        )
+    def test_index_with_snapshot_filter(self):
+        self.assertRaises(
+            curator.ConfigurationError,
+            curator.validate_filters,
+            'delete_indices',
+            [{'filtertype': 'state', 'state': 'SUCCESS'}]
+        )

--- a/test/unit/test_validators.py
+++ b/test/unit/test_validators.py
@@ -6,6 +6,14 @@ from voluptuous import *
 import curator
 
 
+def shared_result(config, action):
+    return curator.validators.SchemaCheck(
+        config,
+        Schema(curator.validators.filters.Filters(action)),
+        'filters',
+        'testing'
+    ).result()
+
 class TestFilters(TestCase):
     def test_single_raises_configuration_error(self):
         data = {'max_num_segments': 1, 'exclude': True}
@@ -17,6 +25,16 @@ class TestFilters(TestCase):
         )
 
 class TestFilterTypes(TestCase):
+    def test_alias(self):
+        action = 'delete_indices'
+        config = [
+            {
+                'filtertype' : 'alias',
+                'aliases' : ['alias1', 'alias2'],
+                'exclude' : False,
+            }
+        ]
+        self.assertEqual(config, shared_result(config, action))
     def test_age(self):
         action = 'delete_indices'
         config = [
@@ -29,13 +47,7 @@ class TestFilterTypes(TestCase):
                 'field'  : '@timestamp',
             }
         ]
-        result = curator.validators.SchemaCheck(
-            config,
-            Schema(curator.validators.filters.Filters(action)),
-            'filters',
-            'testing'
-        ).result()
-        self.assertEqual(config, result)
+        self.assertEqual(config, shared_result(config, action))
     def test_allocated(self):
         action = 'delete_indices'
         config = [
@@ -47,13 +59,7 @@ class TestFilterTypes(TestCase):
                 'exclude' : False,
             }
         ]
-        result = curator.validators.SchemaCheck(
-            config,
-            Schema(curator.validators.filters.Filters(action)),
-            'filters',
-            'testing'
-        ).result()
-        self.assertEqual(config, result)
+        self.assertEqual(config, shared_result(config, action))
     def test_closed(self):
         action = 'delete_indices'
         config = [
@@ -62,13 +68,7 @@ class TestFilterTypes(TestCase):
                 'exclude' : False,
             }
         ]
-        result = curator.validators.SchemaCheck(
-            config,
-            Schema(curator.validators.filters.Filters(action)),
-            'filters',
-            'testing'
-        ).result()
-        self.assertEqual(config, result)
+        self.assertEqual(config, shared_result(config, action))
     def test_forcemerged(self):
         action = 'delete_indices'
         config = [
@@ -78,13 +78,7 @@ class TestFilterTypes(TestCase):
                 'exclude' : False,
             }
         ]
-        result = curator.validators.SchemaCheck(
-            config,
-            Schema(curator.validators.filters.Filters(action)),
-            'filters',
-            'testing'
-        ).result()
-        self.assertEqual(config, result)
+        self.assertEqual(config, shared_result(config, action))
     def test_kibana(self):
         action = 'delete_indices'
         config = [
@@ -93,13 +87,7 @@ class TestFilterTypes(TestCase):
                 'exclude' : False,
             }
         ]
-        result = curator.validators.SchemaCheck(
-            config,
-            Schema(curator.validators.filters.Filters(action)),
-            'filters',
-            'testing'
-        ).result()
-        self.assertEqual(config, result)
+        self.assertEqual(config, shared_result(config, action))
     def test_opened(self):
         action = 'delete_indices'
         config = [
@@ -108,13 +96,7 @@ class TestFilterTypes(TestCase):
                 'exclude' : False,
             }
         ]
-        result = curator.validators.SchemaCheck(
-            config,
-            Schema(curator.validators.filters.Filters(action)),
-            'filters',
-            'testing'
-        ).result()
-        self.assertEqual(config, result)
+        self.assertEqual(config, shared_result(config, action))
     def test_space_name_age(self):
         action = 'delete_indices'
         config = [
@@ -127,13 +109,7 @@ class TestFilterTypes(TestCase):
                 'timestring' : '%Y.%m.%d',
             }
         ]
-        result = curator.validators.SchemaCheck(
-            config,
-            Schema(curator.validators.filters.Filters(action)),
-            'filters',
-            'testing'
-        ).result()
-        self.assertEqual(config, result)
+        self.assertEqual(config, shared_result(config, action))
     def test_space_name_age_no_ts(self):
         action = 'delete_indices'
         config = [
@@ -164,13 +140,7 @@ class TestFilterTypes(TestCase):
                 'field' : '@timestamp',
             }
         ]
-        result = curator.validators.SchemaCheck(
-            config,
-            Schema(curator.validators.filters.Filters(action)),
-            'filters',
-            'testing'
-        ).result()
-        self.assertEqual(config, result)
+        self.assertEqual(config, shared_result(config, action))
     def test_space_field_stats_age_no_field(self):
         action = 'delete_indices'
         config = [
@@ -200,13 +170,7 @@ class TestFilterTypes(TestCase):
                 'source' : 'creation_date',
             }
         ]
-        result = curator.validators.SchemaCheck(
-            config,
-            Schema(curator.validators.filters.Filters(action)),
-            'filters',
-            'testing'
-        ).result()
-        self.assertEqual(config, result)
+        self.assertEqual(config, shared_result(config, action))
     def test_state(self):
         action = 'delete_snapshots'
         config = [
@@ -216,10 +180,4 @@ class TestFilterTypes(TestCase):
                 'exclude' : False,
             }
         ]
-        result = curator.validators.SchemaCheck(
-            config,
-            Schema(curator.validators.filters.Filters(action)),
-            'filters',
-            'testing'
-        ).result()
-        self.assertEqual(config, result)
+        self.assertEqual(config, shared_result(config, action))

--- a/test/unit/testvars.py
+++ b/test/unit/testvars.py
@@ -4,6 +4,7 @@ from voluptuous import *
 fake_fail      = Exception('Simulated Failure')
 four_oh_one    = elasticsearch.TransportError(401, "simulated error")
 four_oh_four   = elasticsearch.TransportError(404, "simulated error")
+get_alias_fail = elasticsearch.NotFoundError(404, "simulated error")
 named_index    = 'index_name'
 named_indices  = [ "index-2015.01.01", "index-2015.02.01" ]
 open_index     = {'metadata': {'indices' : { named_index : {'state' : 'open'}}}}
@@ -209,6 +210,11 @@ settings_two  = {
             }
         }
     }
+}
+
+settings_2_get_aliases = {
+    "index-2016.03.03": { "aliases" : { 'my_alias' : { } } },
+    "index-2016.03.04": { "aliases" : { 'my_alias' : { } } },
 }
 
 settings_2_closed = {


### PR DESCRIPTION
This feature allows the user to filter an IndexList based on whether the indices are associated with one or more aliases.

This commit also fixes the absence of configuration validation testing for whether filters were appropriate to the list type, i.e. a SnapshotList or IndexList.

Documentation added, tested, and the appropriate tests also added.

fixes #634