### PR TITLE
Add support for environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - ES_VERSION=2.1.1
   - ES_VERSION=2.2.2
   - ES_VERSION=2.3.5
+  - ES_VERSION=2.4.0
   - ES_VERSION=5.0.0-alpha5
 
 os: linux

--- a/curator/validators/config_file.py
+++ b/curator/validators/config_file.py
@@ -5,7 +5,8 @@ def config_client():
     return {
         Optional('hosts', default='127.0.0.1'): Any(None, str, list),
         Optional('port', default=9200): Any(
-            None, All(int, Range(min=1, max=65535))),
+            None, All(Coerce(int), Range(min=1, max=65535))
+        ),
         Optional('url_prefix', default=''): Any(None, str),
         Optional('use_ssl', default=False): All(Any(int, bool), Coerce(bool)),
         Optional('certificate', default=None): Any(None, str),
@@ -17,7 +18,8 @@ def config_client():
         Optional('ssl_no_validate', default=False): All(
             Any(int, bool), Coerce(bool)),
         Optional('http_auth', default=None): Any(None, str),
-        Optional('timeout', default=30): All(int, Range(min=1, max=86400)),
+        Optional('timeout', default=30): All(
+            Coerce(int), Range(min=1, max=86400)),
         Optional('master_only', default=False): All(
             Any(int, bool), Coerce(bool)),
     }
@@ -28,7 +30,7 @@ def config_logging():
         Optional(
             'loglevel', default='INFO'): Any(None,
             'NOTSET', 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL',
-            All(int, Any(0, 10, 20, 30, 40, 50))
+            All(Coerce(int), Any(0, 10, 20, 30, 40, 50))
         ),
         Optional('logfile', default=None): Any(None, str),
         Optional(

--- a/curator/validators/filter_elements.py
+++ b/curator/validators/filter_elements.py
@@ -13,7 +13,7 @@ def allocation_type(**kwargs):
 
 def count(**kwargs):
     # This setting is only used with the count filtertype and is required
-    return { Required('count'): All(int, Range(min=1)) }
+    return { Required('count'): All(Coerce(int), Range(min=1)) }
 
 def direction(**kwargs):
     # This setting is only used with the age filtertype.
@@ -21,11 +21,11 @@ def direction(**kwargs):
 
 def disk_space(**kwargs):
     # This setting is only used with the space filtertype and is required
-    return { Required('disk_space'): Any(float, int) }
+    return { Required('disk_space'): Any(Coerce(float)) }
 
 def epoch(**kwargs):
     # This setting is only used with the age filtertype.
-    return { Optional('epoch', default=None): Any(int, None) }
+    return { Optional('epoch', default=None): Any(Coerce(int), None) }
 
 def exclude(**kwargs):
     # This setting is available in all filter types.
@@ -55,7 +55,7 @@ def kind(**kwargs):
 
 def max_num_segments(**kwargs):
     return {
-        Required('max_num_segments'): All(int, Range(min=1))
+        Required('max_num_segments'): All(Coerce(int), Range(min=1))
     }
 
 def reverse(**kwargs):
@@ -68,10 +68,10 @@ def source(**kwargs):
     # This setting is only used with the age filtertype, or with the space
     # filtertype when use_age is set to True.
     if 'action' in kwargs and kwargs['action'] in settings.snapshot_actions():
-        return { Optional('source', default='creation_date'): Any(
+        return { Optional('source'): Any(
             'name', 'creation_date') }
     else:
-        return { Optional('source', default='name'): Any(
+        return { Optional('source'): Any(
             'name', 'creation_date', 'field_stats') }
 
 def state(**kwargs):
@@ -106,7 +106,7 @@ def unit(**kwargs):
 def unit_count(**kwargs):
     # This setting is only used with the age filtertype, or with the space
     # filtertype if use_age is set to True.
-    return { Required('unit_count'): int }
+    return { Required('unit_count'): Coerce(int) }
 
 def use_age(**kwargs):
     # Use of this setting requires the additional setting, source.

--- a/curator/validators/filters.py
+++ b/curator/validators/filters.py
@@ -21,22 +21,22 @@ def structure():
     retval = {
         Optional('aliases'): Any(str, [str]),
         Optional('allocation_type'): str,
-        Optional('count'): int,
+        Optional('count'): Coerce(int),
         Optional('direction'): str,
         Optional('disk_space'): float,
-        Optional('epoch'): Any(int, None),
+        Optional('epoch'): Any(Coerce(int), None),
         Optional('exclude'): Any(int, str, bool, None),
         Optional('field'): Any(str, None),
         Optional('key'): str,
         Optional('kind'): str,
-        Optional('max_num_segments'): int,
+        Optional('max_num_segments'): Coerce(int),
         Optional('reverse'): Any(int, str, bool, None),
         Optional('source'): str,
         Optional('state'): str,
         Optional('stats_result'): Any(str, None),
         Optional('timestring'): Any(str, None),
         Optional('unit'): str,
-        Optional('unit_count'): int,
+        Optional('unit_count'): Coerce(int),
         Optional('use_age'): Any(int, str, bool),
         Optional('value'): Any(int, float, str, bool),
     }
@@ -67,7 +67,7 @@ def Filters(action, location=None):
                 '{0}, filter #{1}: {2}'.format(location, idx, pruned)
             ).result()
             logger.debug('Filter #{0}: {1}'.format(idx, filter_dict))
-            v[idx] = pruned
+            v[idx] = filter_dict
         # If we've made it here without raising an Exception, it's valid
         return v
     return f

--- a/curator/validators/options.py
+++ b/curator/validators/options.py
@@ -12,12 +12,12 @@ def continue_if_exception():
         Any(int, bool), Coerce(bool)) }
 
 def count():
-    return { Required('count'): All(int, Range(min=0, max=10)) }
+    return { Required('count'): All(Coerce(int), Range(min=0, max=10)) }
 
 def delay():
     return {
         Optional('delay', default=0): All(
-                Any(int, float), Range(min=0, max=3600)
+                Coerce(float), Range(min=0.0, max=3600.0)
             )
     }
 
@@ -55,7 +55,9 @@ def key():
     return { Required('key'): str }
 
 def max_num_segments():
-    return { Required('max_num_segments'): All(int, Range(min=1, max=32768)) }
+    return {
+        Required('max_num_segments'): All(Coerce(int), Range(min=1, max=32768))
+    }
 
 def name(action):
     if action in ['alias', 'create_index']:
@@ -79,11 +81,18 @@ def repository():
     return { Required('repository'): str }
 
 def retry_count():
-    return {Optional('retry_count', default=3): All(int, Range(min=0, max=100))}
+    return {
+        Optional('retry_count', default=3): All(
+                Coerce(int), Range(min=0, max=100)
+            )
+    }
 
 def retry_interval():
-    return { Optional('retry_interval', default=120): All(
-        int, Range(min=1, max=600)) }
+    return {
+        Optional('retry_interval', default=120): All(
+                Coerce(int), Range(min=1, max=600)
+            )
+    }
 
 def skip_repo_fs_check():
     return { Optional('skip_repo_fs_check', default=False): All(
@@ -91,12 +100,18 @@ def skip_repo_fs_check():
 
 def timeout_override(action):
     if action in ['forcemerge', 'restore', 'snapshot']:
-        return { Optional('timeout_override', default=21600): Any(int, None) }
+        return {
+            Optional('timeout_override', default=21600): Any(Coerce(int), None)
+        }
     if action in ['close']:
         # This is due to the synced flush operation before closing.
-        return { Optional('timeout_override', default=180): Any(int, None) }
+        return {
+            Optional('timeout_override', default=180): Any(Coerce(int), None)
+        }
     else:
-        return { Optional('timeout_override', default=None): Any(int, None) }
+        return {
+            Optional('timeout_override', default=None): Any(Coerce(int), None)
+        }
 
 def value():
     return { Required('value'): str }

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -10,6 +10,13 @@ Changelog
 
   * Configuration and Action file schema validation.  Requested in #674
     (untergeek)
+  * Alias filtertype! With this filter, you can select indices based on whether
+    they are part of an alias.  Merged in #748 (untergeek)
+  * Count filtertype! With this filter, you can now configure Curator to only
+    keep the most recent _n_ indices (or snapshots!).  Merged in #749
+    (untergeek)
+  * Experimental! Use environment variables in your YAML configuration files.
+    This was a popular request, #697. (untergeek)
 
 **General**
 
@@ -21,6 +28,11 @@ Changelog
   * ``delete_aliases`` option in ``close`` action no longer results in an error
     if not all selected indices have an alias.  Add test to confirm expected
     behavior. Reported in #736 (untergeek)
+
+**Documentation**
+
+  * Add information to FAQ regarding indices created before Elasticsearch 1.4.
+    Merged in #747
 
 4.0.6 (15 August 2016)
 ----------------------

--- a/docs/asciidoc/command-line.asciidoc
+++ b/docs/asciidoc/command-line.asciidoc
@@ -57,6 +57,9 @@ Options:
   --help         Show this message and exit.
 -------
 
+Starting in Curator 4.1, you can use <<envvars,environment variables>> in your
+configuration files.
+
 &nbsp;
 
 [[exit-codes]]

--- a/docs/asciidoc/configuration.asciidoc
+++ b/docs/asciidoc/configuration.asciidoc
@@ -7,12 +7,78 @@
 These are the higher-level configuration settings used by the configuration
 files.  <<actions,Actions>> and <<filters,filters>> are documented separately.
 
+* <<envvars,Environment Variables>>
 * <<actionfile,Action File>>
 * <<configfile,Configuration File>>
 --
 
+[[envvars]]
+== Environment Variables
+
+WARNING: This functionality is experimental and may be changed or removed +
+    completely in a future release.
+
+You can use environment variable references in the both the
+<<configfile,configuration file>> and the <<actionfile,action file>> to set
+values that need to be configurable at runtime. To do this, use:
+
+[source,sh]
+-------
+${VAR}
+-------
+
+Where `VAR` is the name of the environment variable.
+
+Each variable reference is replaced at startup by the value of the environment
+variable. The replacement is case-sensitive and occurs while the YAML file is
+parsed, but before configuration schema validation. References to undefined
+variables are replaced by `None` unless you specify a default value. To specify
+a default value, use:
+
+[source,sh]
+-------
+${VAR:default_value}
+-------
+
+Where `default_value` is the value to use if the environment variable is
+undefined.
+
+[IMPORTANT]
+.Unsupported use cases
+=================================================================
+When using environment variables, the value must _only_ be the environment
+variable.
+
+Using extra text, such as:
+
+[source,sh]
+-------
+logfile: ${LOGPATH}/extra/path/information/file.log
+-------
+
+is not supported at this time.
+=================================================================
+
+=== Examples
+
+Here are some examples of configurations that use environment variables
+and what each configuration looks like after replacement:
+
+[options="header"]
+|==================================
+|Config source	       |Environment setting   |Config after replacement
+|`unit: ${UNIT}`       |`export UNIT=days`    |`unit: days`
+|`unit: ${UNIT}`       |no setting            |`unit:`
+|`unit: ${UNIT:days}`  |no setting            |`unit: days`
+|`unit: ${UNIT:days}`  |`export UNIT=days`    |`unit: days`
+|==================================
+
+
 [[actionfile]]
 == Action File
+
+NOTE: Starting in Curator 4.1, you can use <<envvars,environment variables>> in
+    your configuration files.
 
 An action file has the following structure:
 
@@ -106,6 +172,10 @@ options:
 NOTE: The default location of the configuration file is `~/.curator/curator.yml`,
     but another location can be specified using the `--config` flag on the
     <<command-line,command-line>>.
+
+
+NOTE: Starting in Curator 4.1, you can use <<envvars,environment variables>> in
+    your configuration files.
 
 The configuration file contains client connection and settings for logging.  It
 looks like this:

--- a/docs/asciidoc/examples.asciidoc
+++ b/docs/asciidoc/examples.asciidoc
@@ -3,6 +3,9 @@
 
 These examples should help illustrate how to build your own <<actions,actions>>.
 
+Starting in Curator 4.1, you can use <<envvars,environment variables>> in your
+configuration files.
+
 [[ex_alias]]
 === alias
 

--- a/docs/asciidoc/filter_elements.asciidoc
+++ b/docs/asciidoc/filter_elements.asciidoc
@@ -24,6 +24,9 @@
 * <<fe_unit_count,unit_count>>
 * <<fe_use_age,use_age>>
 * <<fe_value,value>>
+
+Starting in Curator 4.1, you can use <<envvars,environment variables>> in your
+configuration files.
 --
 
 [[fe_aliases]]

--- a/docs/asciidoc/filters.asciidoc
+++ b/docs/asciidoc/filters.asciidoc
@@ -28,6 +28,8 @@ The snapshot filtertypes are:
 * <<filtertype_state,state>>
 * <<filtertype_none,none>>
 
+Starting in Curator 4.1, you can use <<envvars,environment variables>> in your
+configuration files.
 --
 
 [[filtertype]]

--- a/docs/asciidoc/options.asciidoc
+++ b/docs/asciidoc/options.asciidoc
@@ -31,6 +31,9 @@ Options are settings used by <<actions,actions>>.
 * <<option_timeout_override,timeout_override>>
 * <<option_value,value>>
 * <<option_wfc,wait_for_completion>>
+
+Starting in Curator 4.1, you can use <<envvars,environment variables>> in your
+configuration files.
 --
 
 [[option_allocation_type]]

--- a/test/integration/test_envvars.py
+++ b/test/integration/test_envvars.py
@@ -1,0 +1,91 @@
+import elasticsearch
+import curator
+import os
+import json
+import string, random, tempfile
+import click
+from click import testing as clicktest
+from mock import patch, Mock
+
+from . import CuratorTestCase
+from . import testvars as testvars
+
+import logging
+logger = logging.getLogger(__name__)
+
+host, port = os.environ.get('TEST_ES_SERVER', 'localhost:9200').split(':')
+port = int(port) if port else 9200
+
+def random_envvar(size):
+    return ''.join(
+        random.SystemRandom().choice(
+            string.ascii_uppercase + string.digits
+        ) for _ in range(size)
+    )
+
+class TestEnvVars(CuratorTestCase):
+    def test_present(self):
+        evar = random_envvar(8)
+        os.environ[evar] = "1234"
+        dollar = '${' + evar + '}'
+        self.write_config(
+            self.args['configfile'],
+            testvars.client_config_envvars.format(dollar, port, 30)
+        )
+        cfg = curator.get_yaml(self.args['configfile'])
+        self.assertEqual(
+            cfg['client']['hosts'],
+            os.environ.get(evar)
+        )
+        del os.environ[evar]
+    def test_not_present(self):
+        evar = random_envvar(8)
+        dollar = '${' + evar + '}'
+        self.write_config(
+            self.args['configfile'],
+            testvars.client_config_envvars.format(dollar, port, 30)
+        )
+        cfg = curator.get_yaml(self.args['configfile'])
+        self.assertIsNone(cfg['client']['hosts'])
+    def test_not_present_with_default(self):
+        evar = random_envvar(8)
+        default = random_envvar(8)
+        dollar = '${' + evar + ':' + default + '}'
+        self.write_config(
+            self.args['configfile'],
+            testvars.client_config_envvars.format(dollar, port, 30)
+        )
+        cfg = curator.get_yaml(self.args['configfile'])
+        self.assertEqual(
+            cfg['client']['hosts'],
+            default
+        )
+    def test_do_something_with_int_value(self):
+        self.create_indices(10)
+        evar = random_envvar(8)
+        os.environ[evar] = "1234"
+        dollar = '${' + evar + '}'
+        self.write_config(
+            self.args['configfile'],
+            testvars.client_config_envvars.format(host, port, dollar)
+        )
+        cfg = curator.get_yaml(self.args['configfile'])
+        self.assertEqual(
+            cfg['client']['timeout'],
+            os.environ.get(evar)
+        )
+        self.write_config(self.args['actionfile'],
+            testvars.delete_proto.format(
+                'age', 'name', 'older', '\'%Y.%m.%d\'', 'days', 5, ' ', ' ', ' '
+            )
+        )
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--config', self.args['configfile'],
+                        self.args['actionfile']
+                    ],
+                    )
+        self.assertEquals(5, len(curator.get_indices(self.client)))
+        del os.environ[evar]

--- a/test/integration/testvars.py
+++ b/test/integration/testvars.py
@@ -20,6 +20,19 @@ client_config = ('---\n'
 '  logformat: default\n'
 '  blacklist: []\n')
 
+client_config_envvars = ('---\n'
+'client:\n'
+'  hosts: {0}\n'
+'  port: {1}\n'
+'  timeout: {2}\n'
+'  master_only: False\n'
+'\n'
+'logging:\n'
+'  loglevel: DEBUG\n'
+'  logfile:\n'
+'  logformat: default\n'
+'  blacklist: []\n')
+
 bad_client_config = ('---\n'
 'misspelled:\n'
 '  hosts: {0}\n'

--- a/test/unit/test_validators.py
+++ b/test/unit/test_validators.py
@@ -48,6 +48,20 @@ class TestFilterTypes(TestCase):
             }
         ]
         self.assertEqual(config, shared_result(config, action))
+    def test_age_with_string_unit_count(self):
+        action = 'delete_indices'
+        config = [
+            {
+                'filtertype' : 'age',
+                'direction' : 'older',
+                'unit' : 'days',
+                'unit_count' : "1",
+                'source' : 'field_stats',
+                'field'  : '@timestamp',
+            }
+        ]
+        result = shared_result(config, action)
+        self.assertEqual(1, result[0]['unit_count'])
     def test_allocated(self):
         action = 'delete_indices'
         config = [
@@ -121,6 +135,20 @@ class TestFilterTypes(TestCase):
             }
         ]
         self.assertEqual(config, shared_result(config, action))
+    def test_space_name_age_string_float(self):
+        action = 'delete_indices'
+        config = [
+            {
+                'filtertype' : 'space',
+                'disk_space' : "1.0",
+                'use_age' : True,
+                'exclude' : False,
+                'source' : 'name',
+                'timestring' : '%Y.%m.%d',
+            }
+        ]
+        result = shared_result(config, action)
+        self.assertEqual(1.0, result[0]['disk_space'])
     def test_space_name_age_no_ts(self):
         action = 'delete_indices'
         config = [


### PR DESCRIPTION
There were quite a few changes that had to go in, including further strictures on the schema, namely `Coerce` to `int` and `float`, since environment variables are all strings.

More tests were added, and the Changelog updated.

Added Elasticsearch 2.4.0 to the list of instances to be tested.

closes #697