### PR TITLE
Fix error message for boolean values

### DIFF
--- a/curator/validators/config_file.py
+++ b/curator/validators/config_file.py
@@ -8,7 +8,7 @@ def config_client():
             None, All(Coerce(int), Range(min=1, max=65535))
         ),
         Optional('url_prefix', default=''): Any(None, str),
-        Optional('use_ssl', default=False): All(Any(int, bool), Coerce(bool)),
+        Optional('use_ssl', default=False): All(Any(bool, int), Coerce(bool)),
         Optional('certificate', default=None): Any(None, str),
         Optional('client_cert', default=None): Any(None, str),
         Optional('client_key', default=None): Any(None, str),
@@ -16,12 +16,12 @@ def config_client():
         Optional('aws_secret_key', default=None): Any(None, str),
         Optional('aws_region', default=None): Any(None, str),
         Optional('ssl_no_validate', default=False): All(
-            Any(int, bool), Coerce(bool)),
+            Any(bool, int), Coerce(bool)),
         Optional('http_auth', default=None): Any(None, str),
         Optional('timeout', default=30): All(
             Coerce(int), Range(min=1, max=86400)),
         Optional('master_only', default=False): All(
-            Any(int, bool), Coerce(bool)),
+            Any(bool, int), Coerce(bool)),
     }
 
 # Configuration file: logging

--- a/curator/validators/filter_elements.py
+++ b/curator/validators/filter_elements.py
@@ -62,7 +62,7 @@ def reverse(**kwargs):
     # Only used with space filtertype
     # Should be ignored if `use_age` is True
     return { Optional('reverse', default=True): All(
-        Any(int, bool), Coerce(bool)) }
+        Any(bool, int), Coerce(bool)) }
 
 def source(**kwargs):
     # This setting is only used with the age filtertype, or with the space
@@ -111,7 +111,7 @@ def unit_count(**kwargs):
 def use_age(**kwargs):
     # Use of this setting requires the additional setting, source.
     return { Optional('use_age', default=False): All(
-        Any(int, bool), Coerce(bool)) }
+        Any(bool, int), Coerce(bool)) }
 
 def value(**kwargs):
     # This setting is only used with the pattern filtertype and is a required

--- a/curator/validators/options.py
+++ b/curator/validators/options.py
@@ -9,7 +9,7 @@ def allocation_type():
 
 def continue_if_exception():
     return { Optional('continue_if_exception', default=False): All(
-        Any(int, bool), Coerce(bool)) }
+        Any(bool, int), Coerce(bool)) }
 
 def count():
     return { Required('count'): All(Coerce(int), Range(min=0, max=10)) }
@@ -23,30 +23,30 @@ def delay():
 
 def delete_aliases():
     return { Optional('delete_aliases', default=False): All(
-        Any(int, bool), Coerce(bool)) }
+        Any(bool, int), Coerce(bool)) }
 
 def disable_action():
     return { Optional('disable_action', default=False): All(
-        Any(int, bool), Coerce(bool)) }
+        Any(bool, int), Coerce(bool)) }
 
 def extra_settings():
     return { Optional('extra_settings', default={}): dict }
 
 def ignore_empty_list():
     return { Optional('ignore_empty_list', default=False): All(
-        Any(int, bool), Coerce(bool)) }
+        Any(bool, int), Coerce(bool)) }
 
 def ignore_unavailable():
     return { Optional('ignore_unavailable', default=False): All(
-        Any(int, bool), Coerce(bool)) }
+        Any(bool, int), Coerce(bool)) }
 
 def include_aliases():
     return { Optional('include_aliases', default=False): All(
-        Any(int, bool), Coerce(bool)) }
+        Any(bool, int), Coerce(bool)) }
 
 def include_global_state():
     return { Optional('include_global_state', default=True): All(
-        Any(int, bool), Coerce(bool)) }
+        Any(bool, int), Coerce(bool)) }
 
 def indices():
     return { Optional('indices', default=None): Any(None, list) }
@@ -69,7 +69,7 @@ def name(action):
 
 def partial():
     return { Optional('partial', default=False): All(
-        Any(int, bool), Coerce(bool)) }
+        Any(bool, int), Coerce(bool)) }
 
 def rename_pattern():
     return { Optional('rename_pattern'): str }
@@ -96,7 +96,7 @@ def retry_interval():
 
 def skip_repo_fs_check():
     return { Optional('skip_repo_fs_check', default=False): All(
-        Any(int, bool), Coerce(bool)) }
+        Any(bool, int), Coerce(bool)) }
 
 def timeout_override(action):
     if action in ['forcemerge', 'restore', 'snapshot']:
@@ -119,10 +119,10 @@ def value():
 def wait_for_completion(action):
     if action in ['allocation', 'replicas']:
         return { Optional('wait_for_completion', default=False): All(
-            Any(int, bool), Coerce(bool)) }
+            Any(bool, int), Coerce(bool)) }
     elif action in ['restore', 'snapshot']:
         return { Optional('wait_for_completion', default=True): All(
-            Any(int, bool), Coerce(bool)) }
+            Any(bool, int), Coerce(bool)) }
 
 ## Methods for building the schema
 def action_specific(action):

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,15 @@
 Changelog
 =========
 
+4.1.1 (? ? ?)
+-------------
+
+**Bug Fixes**
+
+  * Have the boolean schema tests report ``expected bool`` instead of ``expected
+    int``.  The result is the same, but the error message is misleading.
+    Reported in #757 (untergeek)
+
 4.1.0 (6 September 2016)
 ------------------------
 


### PR DESCRIPTION
With `Any(bool, int)` in the Schema tests, it will properly report `expected bool` now instead of `expected int` if a non-boolean value was provided.

fixes #757