### PR TITLE
Add missing `source` to 2nd age filter

### DIFF
--- a/docs/asciidoc/examples.asciidoc
+++ b/docs/asciidoc/examples.asciidoc
@@ -60,6 +60,7 @@ actions:
         unit_count: 7
         exclude:
       - filtertype: age
+        source: name
         direction: younger
         timestring: '%Y.%m.%d'
         unit: days


### PR DESCRIPTION
When using this example it produces a trackback due to `source` being missing from the younger age filter.