### PR TITLE
Fix versioning issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - ES_VERSION=2.2.2
   - ES_VERSION=2.3.5
   - ES_VERSION=2.4.0
-  - ES_VERSION=5.0.0-beta1
+  - ES_VERSION=5.0.0-rc1
 
 os: linux
 

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -6,6 +6,12 @@ Changelog
 4.2.0 (? ? ?)
 -------------
 
+**General**
+
+  * Update testing to the most recent versions.
+  * Lock elasticsearch-py module version at >= 2.4.0 and <= 3.0.0.  There are
+    API changes in the 5.0 release that cause tests to fail.
+    
 **Bug Fixes**
 
   * Guarantee that binary packages are built from the latest Python + libraries.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 urllib3>=1.8.3
-elasticsearch>=2.4.0,<5.1.0
+elasticsearch>=2.4.0,<3.0.0
 click>=3.3
 pyyaml>=3.10
 voluptuous>=0.9.3

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def get_version():
     return VERSION
 
 def get_install_requires():
-    res = ['elasticsearch>=2.4.0,<5.1.0' ]
+    res = ['elasticsearch>=2.4.0,<3.0.0' ]
     res.append('click>=3.3')
     res.append('pyyaml>=3.10')
     res.append('voluptuous>=0.9.3')


### PR DESCRIPTION
Elasticsearch-py 5.0 is finally out, and it breaks things.  Must fix that before moving on...

fixes #787