### PR TITLE
Fix es_repo_mgr path in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ try:
             "console_scripts" : [
                 "curator = curator.cli:cli",
                 "curator_cli = curator.curator_cli:main",
-                "es_repo_mgr = curator.es_repo_mgr:repo_mgr_cli",
+                "es_repo_mgr = curator.repomgrcli:repo_mgr_cli",
             ]
         },
         classifiers=[
@@ -133,7 +133,7 @@ except ImportError:
             "console_scripts" : [
                 "curator = curator.cli:cli",
                 "curator_cli = curator.curator_cli:main",
-                "es_repo_mgr = curator.es_repo_mgr:repo_mgr_cli",
+                "es_repo_mgr = curator.repomgrcli:repo_mgr_cli",
             ]
         },
         classifiers=[


### PR DESCRIPTION
the settings in `setup.py` point to a non existent module causing all calls to `es_repo_mgr` to end with
```
ImportError: No module named es_repo_mgr
```