### PR TITLE
Bump version_max to 5.1.99

### DIFF
--- a/curator/defaults/settings.py
+++ b/curator/defaults/settings.py
@@ -3,7 +3,7 @@ from voluptuous import *
 
 # Elasticsearch versions supported
 def version_max():
-    return (5, 1, 0)
+    return (5, 1, 99)
 def version_min():
     return (2, 0, 0)
 

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -10,6 +10,7 @@ Changelog
 
   * ``--wait_for_completion`` should be `True` by default for Snapshot singleton
     action.  Reported in #829 (untergeek)
+  * Increase `version_max` to 5.1.99. Prematurely reported in #832 (untergeek)
 
 4.2.3.post1 (22 November 2016)
 ------------------------------


### PR DESCRIPTION
Curator tests pass with release candidate for 5.1.1

fixes #832