### PR TITLE
Enable snapshot of .security in 2.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - ES_VERSION=2.1.1
   - ES_VERSION=2.2.2
   - ES_VERSION=2.3.5
-  - ES_VERSION=2.4.0
+  - ES_VERSION=2.4.2
   - ES_VERSION=5.0.0
 
 os: linux

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -374,6 +374,24 @@ def get_indices(client):
             client.indices.get_settings(
             index='_all', params={'expand_wildcards': 'open,closed'})
         )
+        version_number = get_version(client)
+        logger.debug(
+            'Detected Elasticsearch version '
+            '{0}'.format(".".join(map(str,version_number)))
+        )
+        # This hack ONLY works if you're using 2.4.2 or higher, but is unneeded
+        # if you are using 5.0 or higher.  See issue #826
+        if version_number >= (2, 4, 2) \
+            and version_number < (5, 0, 0):
+            logger.debug('Using Elasticsearch >= 2.4.2 < 5.0.0')
+            if client.indices.exists(index='.security'):
+                logger.debug(
+                    'Found the ".security" index.  '
+                    'Adding to list of all indices'
+                )
+                # Double check to see if it's there before appending
+                if not '.security' in indices:
+                    indices.append('.security')
         logger.debug("All indices: {0}".format(indices))
         return indices
     except Exception as e:

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -11,6 +11,8 @@ Changelog
   * ``--wait_for_completion`` should be `True` by default for Snapshot singleton
     action.  Reported in #829 (untergeek)
   * Increase `version_max` to 5.1.99. Prematurely reported in #832 (untergeek)
+  * Make the '.security' index visible for snapshots so long as proper
+    credentials are used. Reported in #826 (untergeek)
 
 4.2.3.post1 (22 November 2016)
 ------------------------------

--- a/test/unit/test_action_alias.py
+++ b/test/unit/test_action_alias.py
@@ -10,6 +10,7 @@ class TestActionAlias(TestCase):
         self.assertRaises(curator.MissingArgument, curator.Alias)
     def test_add_raises_on_missing_parameter(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -18,6 +19,7 @@ class TestActionAlias(TestCase):
         self.assertRaises(TypeError, ao.add)
     def test_add_raises_on_invalid_parameter(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -26,6 +28,7 @@ class TestActionAlias(TestCase):
         self.assertRaises(TypeError, ao.add, [])
     def test_add_single(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -35,6 +38,7 @@ class TestActionAlias(TestCase):
         self.assertEqual(testvars.alias_one_add, ao.actions)
     def test_add_single_with_extra_settings(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -47,6 +51,7 @@ class TestActionAlias(TestCase):
         self.assertEqual(testvars.alias_one_add_with_extras, ao.actions)
     def test_remove_single(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -56,6 +61,7 @@ class TestActionAlias(TestCase):
         self.assertEqual(testvars.alias_one_rm, ao.actions)
     def test_add_multiple(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -66,6 +72,7 @@ class TestActionAlias(TestCase):
         self.assertEqual(testvars.alias_two_add, cmp)
     def test_remove_multiple(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -76,6 +83,7 @@ class TestActionAlias(TestCase):
         self.assertEqual(testvars.alias_two_rm, cmp)
     def test_show_body(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -90,6 +98,7 @@ class TestActionAlias(TestCase):
             testvars.alias_one_body['actions'][1], body['actions'][1])
     def test_raise_on_empty_body(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -98,6 +107,7 @@ class TestActionAlias(TestCase):
         self.assertRaises(curator.ActionError, ao.body)
     def test_do_dry_run(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -108,6 +118,7 @@ class TestActionAlias(TestCase):
         self.assertIsNone(ao.do_dry_run())
     def test_do_action(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -118,6 +129,7 @@ class TestActionAlias(TestCase):
         self.assertIsNone(ao.do_action())
     def test_do_action_raises_exception(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one

--- a/test/unit/test_action_allocation.py
+++ b/test/unit/test_action_allocation.py
@@ -10,6 +10,7 @@ class TestActionAllocation(TestCase):
         self.assertRaises(TypeError, curator.Allocation, 'invalid')
     def test_init(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -19,6 +20,7 @@ class TestActionAllocation(TestCase):
         self.assertEqual(client, ao.client)
     def test_create_body_no_key(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -26,6 +28,7 @@ class TestActionAllocation(TestCase):
         self.assertRaises(curator.MissingArgument, curator.Allocation, ilo)
     def test_create_body_no_value(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -34,6 +37,7 @@ class TestActionAllocation(TestCase):
             curator.Allocation, ilo, key='key')
     def test_create_body_invalid_allocation_type(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -45,6 +49,7 @@ class TestActionAllocation(TestCase):
         )
     def test_create_body_valid(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -53,6 +58,7 @@ class TestActionAllocation(TestCase):
         self.assertEqual({'index.routing.allocation.require.key': 'value'}, ao.body)
     def test_do_action_raise_on_put_settings(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -63,6 +69,7 @@ class TestActionAllocation(TestCase):
         self.assertRaises(Exception, ao.do_action)
     def test_do_dry_run(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -72,6 +79,7 @@ class TestActionAllocation(TestCase):
         self.assertIsNone(ao.do_dry_run())
     def test_do_action(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -81,6 +89,7 @@ class TestActionAllocation(TestCase):
         self.assertIsNone(ao.do_action())
     def test_do_action_wait(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one

--- a/test/unit/test_action_close.py
+++ b/test/unit/test_action_close.py
@@ -10,6 +10,7 @@ class TestActionClose(TestCase):
         self.assertRaises(TypeError, curator.Close, 'invalid')
     def test_init(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -19,6 +20,7 @@ class TestActionClose(TestCase):
         self.assertEqual(client, co.client)
     def test_do_dry_run(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -29,6 +31,7 @@ class TestActionClose(TestCase):
         self.assertIsNone(co.do_dry_run())
     def test_do_action(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -39,6 +42,7 @@ class TestActionClose(TestCase):
         self.assertIsNone(co.do_action())
     def test_do_action_with_delete_aliases(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -49,6 +53,7 @@ class TestActionClose(TestCase):
         self.assertIsNone(co.do_action())
     def test_do_action_raises_exception(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -60,6 +65,7 @@ class TestActionClose(TestCase):
         self.assertRaises(curator.FailedExecution, co.do_action)
     def test_do_action_delete_aliases_with_exception(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one

--- a/test/unit/test_action_delete_indices.py
+++ b/test/unit/test_action_delete_indices.py
@@ -10,6 +10,7 @@ class TestActionDeleteIndices(TestCase):
         self.assertRaises(TypeError, curator.DeleteIndices, 'invalid')
     def test_init_raise_bad_master_timeout(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -17,6 +18,7 @@ class TestActionDeleteIndices(TestCase):
         self.assertRaises(TypeError, curator.DeleteIndices, ilo, 'invalid')
     def test_init(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -26,6 +28,7 @@ class TestActionDeleteIndices(TestCase):
         self.assertEqual(client, do.client)
     def test_do_dry_run(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -35,6 +38,7 @@ class TestActionDeleteIndices(TestCase):
         self.assertIsNone(do.do_dry_run())
     def test_do_action(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -44,6 +48,7 @@ class TestActionDeleteIndices(TestCase):
         self.assertIsNone(do.do_action())
     def test_do_action_not_successful(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -53,6 +58,7 @@ class TestActionDeleteIndices(TestCase):
         self.assertIsNone(do.do_action())
     def test_do_action_raises_exception(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -63,6 +69,7 @@ class TestActionDeleteIndices(TestCase):
         self.assertRaises(curator.FailedExecution, do.do_action)
     def test_verify_result_positive(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four

--- a/test/unit/test_action_forcemerge.py
+++ b/test/unit/test_action_forcemerge.py
@@ -11,6 +11,7 @@ class TestActionForceMerge(TestCase):
             TypeError, curator.ForceMerge, 'invalid', max_num_segments=2)
     def test_init_raise_no_segment_count(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -20,6 +21,7 @@ class TestActionForceMerge(TestCase):
             curator.MissingArgument, curator.ForceMerge, ilo)
     def test_init(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -30,6 +32,7 @@ class TestActionForceMerge(TestCase):
         self.assertEqual(client, fmo.client)
     def test_do_dry_run(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -41,6 +44,7 @@ class TestActionForceMerge(TestCase):
         self.assertIsNone(fmo.do_dry_run())
     def test_do_action_pre5(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -52,6 +56,7 @@ class TestActionForceMerge(TestCase):
         self.assertIsNone(fmo.do_action())
     def test_do_action(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -63,6 +68,7 @@ class TestActionForceMerge(TestCase):
         self.assertIsNone(fmo.do_action())
     def test_do_action_with_delay(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -74,6 +80,7 @@ class TestActionForceMerge(TestCase):
         self.assertIsNone(fmo.do_action())
     def test_do_action_raises_exception(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one

--- a/test/unit/test_action_open.py
+++ b/test/unit/test_action_open.py
@@ -10,6 +10,7 @@ class TestActionOpen(TestCase):
         self.assertRaises(TypeError, curator.Open, 'invalid')
     def test_init(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -19,6 +20,7 @@ class TestActionOpen(TestCase):
         self.assertEqual(client, oo.client)
     def test_do_dry_run(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -30,6 +32,7 @@ class TestActionOpen(TestCase):
         self.assertIsNone(oo.do_dry_run())
     def test_do_action(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -41,6 +44,7 @@ class TestActionOpen(TestCase):
         self.assertIsNone(oo.do_action())
     def test_do_action_raises_exception(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four

--- a/test/unit/test_action_replicas.py
+++ b/test/unit/test_action_replicas.py
@@ -11,6 +11,7 @@ class TestActionReplicas(TestCase):
             TypeError, curator.Replicas, 'invalid', count=2)
     def test_init_raise_no_count(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -19,6 +20,7 @@ class TestActionReplicas(TestCase):
             curator.MissingArgument, curator.Replicas, ilo)
     def test_init(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -29,6 +31,7 @@ class TestActionReplicas(TestCase):
         self.assertEqual(client, ro.client)
     def test_do_dry_run(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -38,6 +41,7 @@ class TestActionReplicas(TestCase):
         self.assertIsNone(ro.do_dry_run())
     def test_do_action(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -47,6 +51,7 @@ class TestActionReplicas(TestCase):
         self.assertIsNone(ro.do_action())
     def test_do_action_wait(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -57,6 +62,7 @@ class TestActionReplicas(TestCase):
         self.assertIsNone(ro.do_action())
     def test_do_action_raises_exception(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one

--- a/test/unit/test_action_restore.py
+++ b/test/unit/test_action_restore.py
@@ -94,6 +94,7 @@ class TestActionRestore(TestCase):
         self.assertIsNone(ro.do_dry_run())
     def test_report_state_all(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.snapshot.get.return_value = testvars.snapshot
         client.snapshot.get_repository.return_value = testvars.test_repo
         client.indices.get_settings.return_value = testvars.settings_named
@@ -102,6 +103,7 @@ class TestActionRestore(TestCase):
         self.assertIsNone(ro.report_state())
     def test_report_state_not_all(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.snapshot.get.return_value = testvars.snapshots
         client.snapshot.get_repository.return_value = testvars.test_repo
         client.indices.get_settings.return_value = testvars.settings_one
@@ -111,6 +113,7 @@ class TestActionRestore(TestCase):
         self.assertIsNone(ro.report_state())
     def test_do_action_success(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.snapshot.get.return_value = testvars.snapshots
         client.snapshot.get_repository.return_value = testvars.test_repo
         client.snapshot.status.return_value = testvars.nosnap_running

--- a/test/unit/test_action_snapshot.py
+++ b/test/unit/test_action_snapshot.py
@@ -10,6 +10,7 @@ class TestActionSnapshot(TestCase):
         self.assertRaises(TypeError, curator.Snapshot, 'invalid')
     def test_init_no_repo_arg_exception(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -17,6 +18,7 @@ class TestActionSnapshot(TestCase):
         self.assertRaises(curator.MissingArgument, curator.Snapshot, ilo)
     def test_init_no_repo_exception(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -26,6 +28,7 @@ class TestActionSnapshot(TestCase):
             curator.ActionError, curator.Snapshot, ilo, repository='notfound')
     def test_init_no_name_exception(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -35,6 +38,7 @@ class TestActionSnapshot(TestCase):
             repository=testvars.repo_name)
     def test_init_success(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -46,6 +50,7 @@ class TestActionSnapshot(TestCase):
         self.assertIsNone(so.state)
     def test_get_state_success(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -58,6 +63,7 @@ class TestActionSnapshot(TestCase):
         self.assertEqual('SUCCESS', so.state)
     def test_get_state_fail(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -69,6 +75,7 @@ class TestActionSnapshot(TestCase):
         self.assertRaises(curator.CuratorException, so.get_state)
     def test_report_state_success(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -81,6 +88,7 @@ class TestActionSnapshot(TestCase):
         self.assertEqual('SUCCESS', so.state)
     def test_report_state_other(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -93,6 +101,7 @@ class TestActionSnapshot(TestCase):
         self.assertEqual('IN_PROGRESS', so.state)
     def test_do_dry_run(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -107,6 +116,7 @@ class TestActionSnapshot(TestCase):
         self.assertIsNone(so.do_dry_run())
     def test_do_action_success(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -121,6 +131,7 @@ class TestActionSnapshot(TestCase):
         self.assertIsNone(so.do_action())
     def test_do_action_raise_snap_in_progress(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -135,6 +146,7 @@ class TestActionSnapshot(TestCase):
         self.assertRaises(curator.SnapshotInProgress, so.do_action)
     def test_do_action_no_wait_for_completion(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -149,6 +161,7 @@ class TestActionSnapshot(TestCase):
         self.assertIsNone(so.do_action())
     def test_do_action_raise_on_failure(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one

--- a/test/unit/test_class_index_list.py
+++ b/test/unit/test_class_index_list.py
@@ -12,11 +12,13 @@ class TestIndexListClientAndInit(TestCase):
         self.assertRaises(TypeError, curator.IndexList, client)
     def test_init_get_indices_exception(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.indices.get_settings.side_effect = testvars.fake_fail
         self.assertRaises(curator.FailedExecution, curator.IndexList, client)
     def test_init(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -32,6 +34,7 @@ class TestIndexListClientAndInit(TestCase):
         self.assertEqual(['index-2016.03.03','index-2016.03.04'], sorted(il.indices))
     def test_for_closed_index(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_2_closed
         client.cluster.state.return_value = testvars.cs_two_closed
         client.indices.stats.return_value = testvars.stats_two
@@ -39,6 +42,7 @@ class TestIndexListClientAndInit(TestCase):
         self.assertEqual('close', il.index_info['index-2016.03.03']['state'])
     def test_skip_index_without_creation_date(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two_no_cd
         client.cluster.state.return_value = testvars.clu_state_two_no_cd
         client.indices.stats.return_value = testvars.stats_two
@@ -47,6 +51,7 @@ class TestIndexListClientAndInit(TestCase):
 class TestIndexListOtherMethods(TestCase):
     def test_empty_list(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -56,6 +61,7 @@ class TestIndexListOtherMethods(TestCase):
         self.assertRaises(curator.NoIndices, il.empty_list_check)
     def test_get_segmentcount(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -67,6 +73,7 @@ class TestIndexListOtherMethods(TestCase):
 class TestIndexListAgeFilterName(TestCase):
     def test_get_name_based_ages_match(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -75,6 +82,7 @@ class TestIndexListAgeFilterName(TestCase):
         self.assertEqual(1456963200,il.index_info['index-2016.03.03']['age']['name'])
     def test_get_name_based_ages_no_match(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -90,6 +98,7 @@ class TestIndexListAgeFilterName(TestCase):
 class TestIndexListAgeFilterStatsAPI(TestCase):
     def test_get_field_stats_dates_success(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -104,6 +113,7 @@ class TestIndexListAgeFilterStatsAPI(TestCase):
         )
     def test_get_field_stats_dates_negative(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -113,6 +123,7 @@ class TestIndexListAgeFilterStatsAPI(TestCase):
         self.assertNotIn('not_an_index_name', list(il.index_info.keys()))
     def test_get_field_stats_dates_field_not_found(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -124,6 +135,7 @@ class TestIndexListAgeFilterStatsAPI(TestCase):
 class TestIndexListRegexFilters(TestCase):
     def test_filter_by_regex_prefix(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -141,6 +153,7 @@ class TestIndexListRegexFilters(TestCase):
         self.assertEqual([], il.indices)
     def test_filter_by_regex_timestring(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -158,6 +171,7 @@ class TestIndexListRegexFilters(TestCase):
         self.assertEqual([], il.indices)
     def test_filter_by_regex_no_match_exclude(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -174,6 +188,7 @@ class TestIndexListRegexFilters(TestCase):
         )
     def test_filter_by_regex_no_value(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -191,6 +206,7 @@ class TestIndexListRegexFilters(TestCase):
         self.assertEqual([], il.indices)
     def test_filter_by_regex_bad_kind(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -204,6 +220,7 @@ class TestIndexListRegexFilters(TestCase):
 class TestIndexListFilterByAge(TestCase):
     def test_missing_direction(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -213,6 +230,7 @@ class TestIndexListFilterByAge(TestCase):
         )
     def test_bad_direction(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -222,6 +240,7 @@ class TestIndexListFilterByAge(TestCase):
         )
     def test_name_no_timestring(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -232,6 +251,7 @@ class TestIndexListFilterByAge(TestCase):
         )
     def test_name_older_than_now(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -244,6 +264,7 @@ class TestIndexListFilterByAge(TestCase):
         )
     def test_name_older_than_now_exclude(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -256,6 +277,7 @@ class TestIndexListFilterByAge(TestCase):
         )
     def test_name_younger_than_now(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -266,6 +288,7 @@ class TestIndexListFilterByAge(TestCase):
         self.assertEqual([], sorted(il.indices))
     def test_name_younger_than_now_exclude(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -277,6 +300,7 @@ class TestIndexListFilterByAge(TestCase):
             ['index-2016.03.03','index-2016.03.04'], sorted(il.indices))
     def test_name_younger_than_past_date(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -288,6 +312,7 @@ class TestIndexListFilterByAge(TestCase):
         self.assertEqual(['index-2016.03.04'], sorted(il.indices))
     def test_name_older_than_past_date(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -299,6 +324,7 @@ class TestIndexListFilterByAge(TestCase):
         self.assertEqual(['index-2016.03.03'], sorted(il.indices))
     def test_creation_date_older_than_now(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -311,6 +337,7 @@ class TestIndexListFilterByAge(TestCase):
         )
     def test_creation_date_older_than_now_raises(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -323,6 +350,7 @@ class TestIndexListFilterByAge(TestCase):
         self.assertEqual([], il.indices)
     def test_creation_date_younger_than_now(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -333,6 +361,7 @@ class TestIndexListFilterByAge(TestCase):
         self.assertEqual([], sorted(il.indices))
     def test_creation_date_younger_than_now_raises(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -346,6 +375,7 @@ class TestIndexListFilterByAge(TestCase):
         self.assertEqual([], il.indices)
     def test_creation_date_younger_than_past_date(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -356,6 +386,7 @@ class TestIndexListFilterByAge(TestCase):
         self.assertEqual(['index-2016.03.04'], sorted(il.indices))
     def test_creation_date_older_than_past_date(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -366,6 +397,7 @@ class TestIndexListFilterByAge(TestCase):
         self.assertEqual(['index-2016.03.03'], sorted(il.indices))
     def test_field_stats_missing_field(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -375,6 +407,7 @@ class TestIndexListFilterByAge(TestCase):
         )
     def test_field_stats_invalid_stats_result(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -385,6 +418,7 @@ class TestIndexListFilterByAge(TestCase):
         )
     def test_field_stats_invalid_source(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -394,6 +428,7 @@ class TestIndexListFilterByAge(TestCase):
         )
     def test_field_stats_older_than_now(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -407,6 +442,7 @@ class TestIndexListFilterByAge(TestCase):
         )
     def test_field_stats_younger_than_now(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -418,6 +454,7 @@ class TestIndexListFilterByAge(TestCase):
         self.assertEqual([], sorted(il.indices))
     def test_field_stats_younger_than_past_date(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -429,6 +466,7 @@ class TestIndexListFilterByAge(TestCase):
         self.assertEqual(['index-2016.03.04'], sorted(il.indices))
     def test_field_stats_older_than_past_date(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -440,6 +478,7 @@ class TestIndexListFilterByAge(TestCase):
         self.assertEqual(['index-2016.03.03'], sorted(il.indices))
     def test_field_stats_older_than_now_max(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -453,6 +492,7 @@ class TestIndexListFilterByAge(TestCase):
         )
     def test_field_stats_younger_than_now_max(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -464,6 +504,7 @@ class TestIndexListFilterByAge(TestCase):
         self.assertEqual([], sorted(il.indices))
     def test_field_stats_younger_than_past_date_max(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -476,6 +517,7 @@ class TestIndexListFilterByAge(TestCase):
         self.assertEqual(['index-2016.03.04'], sorted(il.indices))
     def test_field_stats_older_than_past_date_max(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -490,6 +532,7 @@ class TestIndexListFilterByAge(TestCase):
 class TestIndexListFilterBySpace(TestCase):
     def test_missing_disk_space_value(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -498,6 +541,7 @@ class TestIndexListFilterBySpace(TestCase):
         self.assertRaises(curator.MissingArgument, il.filter_by_space)
     def test_filter_result_by_name(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -507,6 +551,7 @@ class TestIndexListFilterBySpace(TestCase):
         self.assertEqual(['index-2016.03.03'], il.indices)
     def test_filter_result_by_name_reverse_order(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -516,6 +561,7 @@ class TestIndexListFilterBySpace(TestCase):
         self.assertEqual(['index-2016.03.04'], il.indices)
     def test_filter_result_by_name_exclude(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -525,6 +571,7 @@ class TestIndexListFilterBySpace(TestCase):
         self.assertEqual(['index-2016.03.04'], il.indices)
     def test_filter_result_by_date_raise(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -535,6 +582,7 @@ class TestIndexListFilterBySpace(TestCase):
         )
     def test_filter_result_by_date_timestring_raise(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -545,6 +593,7 @@ class TestIndexListFilterBySpace(TestCase):
         )
     def test_filter_result_by_date_timestring(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -557,6 +606,7 @@ class TestIndexListFilterBySpace(TestCase):
         self.assertEqual(['a-2016.03.03'], sorted(il.indices))
     def test_filter_result_by_date_non_matching_timestring(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -569,6 +619,7 @@ class TestIndexListFilterBySpace(TestCase):
         self.assertEqual([], sorted(il.indices))
     def test_filter_result_by_date_field_stats_raise(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -580,6 +631,7 @@ class TestIndexListFilterBySpace(TestCase):
         )
     def test_filter_result_by_date_no_field_raise(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -591,6 +643,7 @@ class TestIndexListFilterBySpace(TestCase):
         )
     def test_filter_result_by_date_invalid_stats_result_raise(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -602,6 +655,7 @@ class TestIndexListFilterBySpace(TestCase):
         )
     def test_filter_result_by_date_field_stats(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -614,6 +668,7 @@ class TestIndexListFilterBySpace(TestCase):
         self.assertEqual(['a-2016.03.03'], il.indices)
     def test_filter_result_by_creation_date(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -625,6 +680,7 @@ class TestIndexListFilterBySpace(TestCase):
 class TestIndexListFilterKibana(TestCase):
     def test_filter_kibana_positive(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -636,6 +692,7 @@ class TestIndexListFilterKibana(TestCase):
         self.assertEqual(['dummy'], il.indices)
     def test_filter_kibana_positive_exclude(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -650,6 +707,7 @@ class TestIndexListFilterKibana(TestCase):
         self.assertEqual(kibana_indices, il.indices)
     def test_filter_kibana_negative(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -666,6 +724,7 @@ class TestIndexListFilterKibana(TestCase):
 class TestIndexListFilterForceMerged(TestCase):
     def test_filter_forcemerge_raise(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -674,6 +733,7 @@ class TestIndexListFilterForceMerged(TestCase):
         self.assertRaises(curator.MissingArgument, il.filter_forceMerged)
     def test_filter_forcemerge_positive(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -683,6 +743,7 @@ class TestIndexListFilterForceMerged(TestCase):
         self.assertEqual([testvars.named_index], il.indices)
     def test_filter_forcemerge_negative(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -694,6 +755,7 @@ class TestIndexListFilterForceMerged(TestCase):
 class TestIndexListFilterOpened(TestCase):
     def test_filter_opened(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -705,6 +767,7 @@ class TestIndexListFilterOpened(TestCase):
 class TestIndexListFilterAllocated(TestCase):
     def test_missing_key(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -715,6 +778,7 @@ class TestIndexListFilterAllocated(TestCase):
         )
     def test_missing_value(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -725,6 +789,7 @@ class TestIndexListFilterAllocated(TestCase):
         )
     def test_invalid_allocation_type(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -735,6 +800,7 @@ class TestIndexListFilterAllocated(TestCase):
         )
     def test_success(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -743,6 +809,7 @@ class TestIndexListFilterAllocated(TestCase):
         self.assertEqual(['index-2016.03.04'], il.indices)
     def test_invalid_tag(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -755,6 +822,7 @@ class TestIndexListFilterAllocated(TestCase):
 class TestIterateFiltersIndex(TestCase):
     def test_no_filters(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -766,6 +834,7 @@ class TestIterateFiltersIndex(TestCase):
         )
     def test_no_filtertype(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -775,6 +844,7 @@ class TestIterateFiltersIndex(TestCase):
             curator.ConfigurationError, ilo.iterate_filters, config)
     def test_invalid_filtertype(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -784,6 +854,7 @@ class TestIterateFiltersIndex(TestCase):
             curator.ConfigurationError, ilo.iterate_filters, config)
     def test_pattern_filtertype(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -793,6 +864,7 @@ class TestIterateFiltersIndex(TestCase):
         self.assertEqual(['a-2016.03.03'], ilo.indices)
     def test_age_filtertype(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -802,6 +874,7 @@ class TestIterateFiltersIndex(TestCase):
         self.assertEqual(['index-2016.03.03'], ilo.indices)
     def test_space_filtertype(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -812,6 +885,7 @@ class TestIterateFiltersIndex(TestCase):
         self.assertEqual(['a-2016.03.03'], ilo.indices)
     def test_forcemerge_filtertype(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -822,6 +896,7 @@ class TestIterateFiltersIndex(TestCase):
         self.assertEqual([testvars.named_index], ilo.indices)
     def test_allocated_filtertype(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -831,6 +906,7 @@ class TestIterateFiltersIndex(TestCase):
         self.assertEqual(['index-2016.03.04'], ilo.indices)
     def test_kibana_filtertype(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -846,6 +922,7 @@ class TestIterateFiltersIndex(TestCase):
         self.assertEqual(['dummy'], ilo.indices)
     def test_opened_filtertype(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -856,6 +933,7 @@ class TestIterateFiltersIndex(TestCase):
         self.assertEqual(['c-2016.03.05'], ilo.indices)
     def test_closed_filtertype(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_four
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
@@ -867,6 +945,7 @@ class TestIterateFiltersIndex(TestCase):
             ['a-2016.03.03','b-2016.03.04','d-2016.03.06'], sorted(ilo.indices))
     def test_none_filtertype(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -877,6 +956,7 @@ class TestIterateFiltersIndex(TestCase):
             ['index-2016.03.03', 'index-2016.03.04'], sorted(ilo.indices))
     def test_unknown_filtertype_raises(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -889,6 +969,7 @@ class TestIterateFiltersIndex(TestCase):
 class TestIndexListFilterAlias(TestCase):
     def test_raise(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -896,6 +977,7 @@ class TestIndexListFilterAlias(TestCase):
         self.assertRaises(curator.MissingArgument, il.filter_by_alias)
     def test_positive(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -906,6 +988,7 @@ class TestIndexListFilterAlias(TestCase):
             sorted(list(testvars.settings_two.keys())), sorted(il.indices))
     def test_negative(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -916,6 +999,7 @@ class TestIndexListFilterAlias(TestCase):
             sorted([]), sorted(il.indices))
     def test_get_alias_raises(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -929,6 +1013,7 @@ class TestIndexListFilterAlias(TestCase):
 class TestIndexListFilterCount(TestCase):
     def test_raise(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
@@ -936,6 +1021,7 @@ class TestIndexListFilterCount(TestCase):
         self.assertRaises(curator.MissingArgument, il.filter_by_count)
     def test_without_age(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -945,6 +1031,7 @@ class TestIndexListFilterCount(TestCase):
         self.assertEqual([u'index-2016.03.03'], il.indices)
     def test_without_age_reversed(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -954,6 +1041,7 @@ class TestIndexListFilterCount(TestCase):
         self.assertEqual([u'index-2016.03.04'], il.indices)
     def test_with_age(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -965,6 +1053,7 @@ class TestIndexListFilterCount(TestCase):
         self.assertEqual([u'index-2016.03.03'], il.indices)
     def test_with_age_creation_date(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
@@ -974,6 +1063,7 @@ class TestIndexListFilterCount(TestCase):
         self.assertEqual([u'index-2016.03.03'], il.indices)
     def test_with_age_reversed(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -174,6 +174,7 @@ class TestChunkIndexList(TestCase):
 class TestGetIndices(TestCase):
     def test_client_exception(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.indices.get_settings.side_effect = testvars.fake_fail
         self.assertRaises(
@@ -181,14 +182,25 @@ class TestGetIndices(TestCase):
     def test_positive(self):
         client = Mock()
         client.indices.get_settings.return_value = testvars.settings_two
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         self.assertEqual(
             ['index-2016.03.03', 'index-2016.03.04'],
             sorted(curator.get_indices(client))
         )
     def test_empty(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = {}
         self.assertEqual([], curator.get_indices(client))
+    def test_issue_826(self):
+        client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.2'} }
+        client.indices.get_settings.return_value = testvars.settings_two
+        client.indices.exists.return_value = True
+        self.assertEqual(
+            ['.security', 'index-2016.03.03', 'index-2016.03.04'],
+            sorted(curator.get_indices(client))
+        )
 
 class TestCheckVersion(TestCase):
     def test_check_version_(self):

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -319,6 +319,7 @@ class TestShowDryRun(TestCase):
     # simple code coverage run
     def test_index_list(self):
         client = Mock()
+        client.info.return_value = {'version': {'number': '2.4.1'} }
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two


### PR DESCRIPTION
This is a rather manual hack for a limited use case.  It allows the snapshotting of the `.security` index (with proper credentials) but only if you are using 2.4.2 or higher, and lower than 5.x, as this isn't a problem in 5.x

fixes #826