### PR TITLE
Fix test when different IP/port are used

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -9,7 +9,12 @@ Changelog
 **General**
 
   * Add and increment test versions for Travis CI. #839 (untergeek)
-  
+
+**Bug Fixes**
+
+  * Fix cli integration test when different host/port are specified.  Reported
+    in #843 (untergeek)
+
 4.2.4 (7 December 2016)
 -----------------------
 

--- a/test/integration/test_cli.py
+++ b/test/integration/test_cli.py
@@ -37,6 +37,15 @@ class TestCLIMethods(CuratorTestCase):
                     )
         self.assertEqual(-1, result.exit_code)
     def test_no_config(self):
+        # This test checks whether localhost:9200 is provided if no hosts or
+        # port are in the configuration. But in testing, sometimes
+        # TEST_ES_SERVER is set to something other than localhost:9200.  In this
+        # case, the test here would fail.  The if statement at the end now
+        # compensates. See https://github.com/elastic/curator/issues/843
+        localtest = False
+        if (host == 'localhost' or host == '127.0.0.1') and \
+          port == 9200:
+            localtest = True
         self.create_indices(10)
         self.write_config(
             self.args['configfile'],
@@ -54,7 +63,10 @@ class TestCLIMethods(CuratorTestCase):
 
                     ],
                     )
-        self.assertEqual(0, result.exit_code)
+        if localtest:
+            self.assertEqual(0, result.exit_code)
+        else:
+            self.assertEqual(-1, result.exit_code)
     def test_no_logging_config(self):
         self.create_indices(10)
         self.write_config(


### PR DESCRIPTION
This guarantees the test does what it should in either case.

fixes #843