### PR TITLE
Make filter_list optional

### DIFF
--- a/curator/singletons.py
+++ b/curator/singletons.py
@@ -473,7 +473,7 @@ def replicas_singleton(
 )
 @click.option(
     '--filter_list', callback=validate_filter_json,
-    help='JSON string representing an array of filters.', required=True
+    help='JSON string representing an array of filters.'
 )
 @click.pass_context
 def snapshot_singleton(
@@ -487,6 +487,7 @@ def snapshot_singleton(
     c_args = ctx.obj['config']['client']
     client = get_client(**c_args)
     logger = logging.getLogger(__name__)
+    filter_list = filter_list or '[]'
     raw_options = {
         'repository': repository,
         'name': name,
@@ -599,7 +600,7 @@ def show_indices_singleton(
 )
 @click.option(
     '--filter_list', callback=validate_filter_json,
-    help='JSON string representing an array of filters.', required=True
+    help='JSON string representing an array of filters.'
 )
 @click.pass_context
 def show_snapshots_singleton(
@@ -611,6 +612,7 @@ def show_snapshots_singleton(
     c_args = ctx.obj['config']['client']
     client = get_client(**c_args)
     logger = logging.getLogger(__name__)
+    filter_list = filter_list or '[]'
     logger.debug('Validating provided filters: {0}'.format(filter_list))
     clean_filters = {
         'filters': filter_schema_check(action, filter_list)

--- a/curator/singletons.py
+++ b/curator/singletons.py
@@ -472,7 +472,7 @@ def replicas_singleton(
     help='Do not raise exception if there are no actionable indices'
 )
 @click.option(
-    '--filter_list', callback=validate_filter_json,
+    '--filter_list', callback=validate_filter_json, default='{"filtertype":"none"}',
     help='JSON string representing an array of filters.'
 )
 @click.pass_context
@@ -487,7 +487,6 @@ def snapshot_singleton(
     c_args = ctx.obj['config']['client']
     client = get_client(**c_args)
     logger = logging.getLogger(__name__)
-    filter_list = filter_list or '[]'
     raw_options = {
         'repository': repository,
         'name': name,
@@ -519,8 +518,8 @@ def snapshot_singleton(
     help='Do not raise exception if there are no actionable indices'
 )
 @click.option(
-    '--filter_list', callback=validate_filter_json,
-    help='JSON string representing an array of filters.', required=True
+    '--filter_list', callback=validate_filter_json, default='{"filtertype":"none"}',
+    help='JSON string representing an array of filters.'
 )
 @click.pass_context
 def show_indices_singleton(
@@ -599,7 +598,7 @@ def show_indices_singleton(
     help='Do not raise exception if there are no actionable snapshots'
 )
 @click.option(
-    '--filter_list', callback=validate_filter_json,
+    '--filter_list', callback=validate_filter_json, default='{"filtertype":"none"}',
     help='JSON string representing an array of filters.'
 )
 @click.pass_context
@@ -612,7 +611,6 @@ def show_snapshots_singleton(
     c_args = ctx.obj['config']['client']
     client = get_client(**c_args)
     logger = logging.getLogger(__name__)
-    filter_list = filter_list or '[]'
     logger.debug('Validating provided filters: {0}'.format(filter_list))
     clean_filters = {
         'filters': filter_schema_check(action, filter_list)

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -9,6 +9,8 @@ Changelog
 **General**
 
   * Add and increment test versions for Travis CI. #839 (untergeek)
+  * Make `filter_list` optional in snapshot, show_snapshot and show_indices
+    singleton actions. #853 (alexef)
 
 **Bug Fixes**
 


### PR DESCRIPTION
For `snapshot` and `show_snapshot` commands, we usually run them against the entire cluster.

Not sure about providing a string default, it can be fixed at a different level.