### PR TITLE
use isinstance instead of type() in verify_client_object

### DIFF
--- a/curator/utils.py
+++ b/curator/utils.py
@@ -87,7 +87,7 @@ def verify_client_object(test):
     if str(type(test)) == "<class 'mock.Mock'>" or \
         str(type(test)) == "<class 'mock.mock.Mock'>":
         pass
-    elif not type(test) == type(elasticsearch.Elasticsearch()):
+    elif not isinstance(test, elasticsearch.Elasticsearch):
         raise TypeError(
             'Not a client object. Type: {0}'.format(type(test))
         )

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -602,3 +602,20 @@ class TestValidateFilters(TestCase):
             'delete_indices',
             [{'filtertype': 'state', 'state': 'SUCCESS'}]
         )
+
+
+class TestVerifyClientObject(TestCase):
+
+    def test_is_client_object(self):
+        test = elasticsearch.Elasticsearch()
+        self.assertIsNone(curator.verify_client_object(test))
+
+    def test_is_not_client_object(self):
+        test = 'not a client object'
+        self.assertRaises(TypeError, curator.verify_client_object, test)
+
+    def test_is_a_subclass_client_object(self):
+        class ElasticsearchSubClass(elasticsearch.Elasticsearch):
+            pass
+        test = ElasticsearchSubClass()
+        self.assertIsNone(curator.verify_client_object(test))


### PR DESCRIPTION
Using isinstance is more robust and allow library user to subclass elasticsearch.Elasticsearch
Also add unittest for verify_client_object function
submitted following https://github.com/elastic/curator/issues/861