### PR TITLE
Add information about the current package version

### DIFF
--- a/docs/asciidoc/installation.asciidoc
+++ b/docs/asciidoc/installation.asciidoc
@@ -219,7 +219,7 @@ enabled=1
 [[yum-binary]]
 === Binary Package Installation
 
-Starting with version 4.1.2, Curator comes with a binary version.  What this
+Starting with version 4.1.2, Curator is only distributed as binary version. If you have installed an older version you won't get any updates until you manually install the `elasticsearch-curator` package.  What this
 really means is that the source is compiled, and all required libraries are
 bundled with the `curator` binary, so there are no conflicts.
 


### PR DESCRIPTION
The latest version of `python-elasticsearch-curator` in the Debian/Ubuntu repo is 4.1.2 which isn't compatible with ES 5.1.1.
I learned the hard way that it dies on startup without logging to the configured logfile because it isn't compatible and the ES cluster filled up the disk.