### PR TITLE
Remote reindex issues addressed

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -1011,7 +1011,8 @@ class Reindex(object):
                     'client_key={7} '
                     'aws_key={8} '
                     'aws_secret_key={9} '
-                    'aws_region={10}'.format(
+                    'aws_region={10}'
+                    'skip_version_test=True'.format(
                         rhost,
                         rhttp_auth,
                         remote_url_prefix,
@@ -1039,6 +1040,7 @@ class Reindex(object):
                         aws_key=remote_aws_key,
                         aws_secret_key=remote_aws_secret_key,
                         aws_region=remote_aws_region,
+                        skip_version_test=True,
                     )
                 except Exception as e:
                     self.loggit.error(

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -11,7 +11,8 @@ production! There `will` be many more changes before 5.0.0 is released.
 **New Features**
 
   * Reindex is here! The new reindex action has a ton of flexibility. You 
-    can even reindex from remote locations!
+    can even reindex from remote locations, so long as the remote cluster is
+    Elasticsearch 1.4 or newer.
 
   * Added the ``period`` filter (#733). This allows you to select indices 
     or snapshots, based on whether they fit within a period of hours, days, 
@@ -35,7 +36,7 @@ production! There `will` be many more changes before 5.0.0 is released.
 
   * Bumped ``click`` (python module) version dependency to 6.7
   * Bumped ``urllib3`` (python module) version dependency to 1.20
-  * Bumped ``elasticsearch`` (python module) version dependency to 5.2
+  * Bumped ``elasticsearch`` (python module) version dependency to 5.3
   * Refactored a ton of code to be cleaner and hopefully more consistent.
 
 **Bug Fixes**

--- a/docs/asciidoc/actions.asciidoc
+++ b/docs/asciidoc/actions.asciidoc
@@ -568,6 +568,17 @@ Optional settings
 TIP: See an example of this action in an <<actionfile,actionfile>>
     <<ex_reindex,here>>.
 
+=== Compatibility
+
+Generally speaking, the Curator should be able to perform a remote reindex from
+any version of Elasticsearch, 1.4 and newer. Strictly speaking, the Reindex API
+in Elasticsearch _is_ able to reindex from older clusters, but Curator cannot be
+used to facilitate this due to Curator's dependency on changes released in 1.4.
+
+However, there is a https://github.com/elastic/elasticsearch/pull/23805[known bug]
+with Elasticsearch 5.3.0 not being able to reindex from remote clusters older
+than 2.0.  The patch is available in Elasticsearch 5.3.1.  Earlier versions of
+Elasticsearch 5.x do not suffer from this bug.
 
 
 [[replicas]]

--- a/test/integration/test_reindex.py
+++ b/test/integration/test_reindex.py
@@ -125,7 +125,8 @@ class TestCLIReindex(CuratorTestCase):
 
         # Build remote client
         try:
-            rclient = curator.get_client(host=rhost, port=rport)
+            rclient = curator.get_client(
+                host=rhost, port=rport, skip_version_test=True)
         except:
             raise SkipTest(
                 'Unable to connect to host at {0}:{1}'.format(rhost, rport))
@@ -201,7 +202,8 @@ class TestCLIReindex(CuratorTestCase):
 
         # Build remote client
         try:
-            rclient = curator.get_client(host=rhost, port=rport)
+            rclient = curator.get_client(
+                host=rhost, port=rport, skip_version_test=True)
         except:
             raise SkipTest(
                 'Unable to connect to host at {0}:{1}'.format(rhost, rport))


### PR DESCRIPTION
Document 5.3.0's issues with ES versions older than 2.0, and that a fix is in 5.3.1. Allow Curator to connect to older clusters by adding "skip_version_test" to the get_client method, and only use it in the remote reindex section.