### PR TITLE
Fixed ISO week parsing code in utils

### DIFF
--- a/curator/utils.py
+++ b/curator/utils.py
@@ -252,22 +252,19 @@ def fix_epoch(epoch):
 
 def _handle_iso_week_number(date, timestring, index_timestamp):
     date_iso = date.isocalendar()
-    iso_week_str = "{Y}{W}".format(Y=date_iso[0], W=date_iso[1])
+    iso_week_str = "{Y:04d}{W:02d}".format(Y=date_iso[0], W=date_iso[1])
     greg_week_str = datetime.strftime(date, "%Y%W")
 
-    # Handle edge cases between ISO week number and Greg week number
-    if iso_week_str != greg_week_str:
-        # Edge case 1: ISO week number is bigger than Greg week number.
-        # Ex: year 2014, all ISO week numbers were 1 more than in Greg.
-        if iso_week_str > greg_week_str:
-            # Simply remove one week
-            date = date - timedelta(days=7)
+    # Edge case 1: ISO week number is bigger than Greg week number.
+    # Ex: year 2014, all ISO week numbers were 1 more than in Greg.
+    if (iso_week_str > greg_week_str or
         # Edge case 2: 2010-01-01 in ISO: 2009.W53, in Greg: 2010.W00
-        # For Greg converting 2009.W53 gives 2010-01-04, converting back to same timestring gives:
-        # 2010.W01.
-        elif datetime.strftime(date, timestring) != index_timestamp:
-            # Also remove one week in this case
-            date = date - timedelta(days=7)
+        # For Greg converting 2009.W53 gives 2010-01-04, converting back
+        # to same timestring gives: 2010.W01.
+            datetime.strftime(date, timestring) != index_timestamp):
+
+        # Remove one week in this case
+        date = date - timedelta(days=7)
     return date
 
 def datetime_to_epoch(mydate):

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -115,10 +115,20 @@ class TestGetIndexTime(TestCase):
             ('2014-42', '%Y-%W', datetime(2014, 10, 20)),
             ('2014-42', '%G-%V', datetime(2014, 10, 13)),
             ('2014-43', '%G-%V', datetime(2014, 10, 20)),
+            # 
+            ('2008-52', '%G-%V', datetime(2008, 12, 22)),
+            ('2008-52', '%Y-%W', datetime(2008, 12, 29)),
+            ('2009-01', '%Y-%W', datetime(2009, 1, 5)),
+            ('2009-01', '%G-%V', datetime(2008, 12, 29)),
             # The case when both ISO and Greg are same week number
             ('2017-16', '%Y-%W', datetime(2017, 4, 17)),
             ('2017-16', '%G-%V', datetime(2017, 4, 17)),
-            # In Greg week 53 doesn't exist, it converts to week 1 of next year.
+            # Weeks were leading 0 is needed for week number
+            ('2017-02', '%Y-%W', datetime(2017, 1, 9)),
+            ('2017-02', '%G-%V', datetime(2017, 1, 9)),
+            ('2010-01', '%G-%V', datetime(2010, 1, 4)),
+            ('2010-01', '%Y-%W', datetime(2010, 1, 4)),
+            # In Greg week 53 for year 2009 doesn't exist, it converts to week 1 of next year.
             ('2009-53', '%Y-%W', datetime(2010, 1, 4)),
             ('2009-53', '%G-%V', datetime(2009, 12, 28)),
                 ]:


### PR DESCRIPTION
Related to https://github.com/elastic/curator/pull/932

I realized I had a mistake in my code. When comparing two strings, the result was always false for 9 first weeks in the year, because I was not adding leading 0's to the week number, and behaviour was incorrect. I added new tests to demonstrate it.

I had also to remove the comparison to support the case of the ISO leap year (53 weeks, but 52 in Gregorian). Ex:2009 week 53.
```
>>> week53 = datetime.strptime("2009.W531", "%Y.W%W%w")
>>> week53
datetime.datetime(2010, 1, 4, 0, 0)
# Converting back to Gregorian gives first week
>>> datetime.strftime(week53, "%Y.W%W%w")
'2010.W011'
# ISO calendar gives also first week. The comparison will return false (they are equal) and not adjust the date.
>>> week53.isocalendar()
(2010, 1, 1)
```
The above example was working because the iso_week_str was missing a leading 0. In conclusion, it is not because iso week number and gregorian week number are the same means that they are correct! We have always to compare gregorian string with the original one.

Sorry for the mistake. Feel free to add any other tests!

Thanks :)