### PR TITLE
Test if target index is alias for reindex action

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -1138,7 +1138,10 @@ class Reindex(object):
                 )
                 # Verify the destination index is there after the fact
                 post_run = get_indices(self.client)
-                if self.body['dest']['index'] not in post_run:
+                alias_instead = self.client.exists_alias(
+                    name=self.body['dest']['index'])
+                if self.body['dest']['index'] not in post_run \
+                        and not alias_instead:
                     self.loggit.error(
                         'Index "{0}" not found after reindex operation. Check '
                         'Elasticsearch logs for more '

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,18 @@
 Changelog
 =========
 
+5.0.2 (? ? ?)
+
+**Bug Fixes**
+
+  * Nasty bug in schema validation fixed where boolean options or filter flags
+    would validate as ``True`` if non-boolean types were submitted.
+    Reported in #945. (untergeek)
+  * Check for presence of alias after reindex, in case the reindex was to an
+    alias. Reported in #941. (untergeek)
+
+**Documentation**
+
 5.0.1 (10 April 2017)
 
 **Bug Fixes**


### PR DESCRIPTION
Since you can reindex to an alias, the previous behavior was to test for the absence of an index.  The fix is to have an `and` condition that also tests for the absence of an alias named the same as the target.

fixes #941