### PR TITLE
Document substitute strftime symbols for ISO Weeks

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -15,6 +15,9 @@ Changelog
 
 **Documentation**
 
+  * Document substitute strftime symbols for doing ISO Week timestrings added in
+    #932. (untergeek)
+
 5.0.1 (10 April 2017)
 
 **Bug Fixes**

--- a/docs/asciidoc/filter_elements.asciidoc
+++ b/docs/asciidoc/filter_elements.asciidoc
@@ -520,17 +520,7 @@ set to `True`.
 This setting must be a valid Python strftime string.  It is used to match and
 extract the timestamp in an index or snapshot name.
 
-The identifiers that Curator currently recognizes include:
-
-* `Y`: A 4 digit year
-* `y`: A 2 digit year
-* `m`: The 2 digit month
-* `W`: The 2 digit week of the year
-* `d`: The 2 digit day of the month
-* `H`: The 2 digit hour of the day, in 24 hour notation
-* `M`: The 2 digit minute of the hour
-* `S`: The 2 digit number of second of the minute
-* `j`: The 3 digit day of the year
+include::inc_strftime_table.asciidoc[]
 
 These identifiers may be combined with each other, and/or separated from each
 other with hyphens `-`, periods `.`, underscores `_`, or other characters valid

--- a/docs/asciidoc/inc_strftime_table.asciidoc
+++ b/docs/asciidoc/inc_strftime_table.asciidoc
@@ -1,0 +1,17 @@
+The identifiers that Curator currently recognizes include:
+
+[width="50%", cols="<m,,", options="header"]
+|===
+|Unit|Value|Note
+|%Y|4 digit year|
+|%G|4 digit year| use instead of `%Y` when doing ISO Week calculations
+|%y|2 digit year|
+|%m|2 digit month|
+|%W|2 digit week of the year|
+|%V|2 digit week of the year| use instead of `%W` when doing ISO Week calculations
+|%d|2 digit day of the month|
+|%H|2 digit hour| 24 hour notation
+|%M|2 digit minute|
+|%S|2 digit second|
+|%j|3 digit day of the year|
+|===

--- a/docs/asciidoc/options.asciidoc
+++ b/docs/asciidoc/options.asciidoc
@@ -775,17 +775,21 @@ depending on which action makes use of `name`.
 This setting may contain a valid Python strftime string.  Curator will
 extract the strftime identifiers and replace them with the corresponding values.
 
-The Python strftime identifiers that Curator currently recognizes include:
+The identifiers that Curator currently recognizes include:
 
-* `Y`: A 4 digit year
-* `y`: A 2 digit year
-* `m`: The 2 digit month
-* `W`: The 2 digit week of the year
-* `d`: The 2 digit day of the month
-* `H`: The 2 digit hour of the day, in 24 hour notation
-* `M`: The 2 digit minute of the hour
-* `S`: The 2 digit number of second of the minute
-* `j`: The 3 digit day of the year
+[width="50%", cols="<m,", options="header"]
+|===
+|Unit|Value
+|%Y| 4 digit year
+|%y| 2 digit year
+|%m| 2 digit month
+|%W| 2 digit week of the year
+|%d| 2 digit day of the month
+|%H| 2 digit hour of the day, in 24 hour notation
+|%M| 2 digit minute of the hour
+|%S| 2 digit second of the minute
+|%j| 3 digit day of the year
+|===
 
 
 === <<alias,alias>>


### PR DESCRIPTION
fixes #933 