### PR TITLE
Fix epoch 0 name-based filtering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - ES_VERSION=5.0.2
   - ES_VERSION=5.1.2
   - ES_VERSION=5.2.2
-  - ES_VERSION=5.3.0
+  - ES_VERSION=5.3.2
 
 os: linux
 

--- a/curator/indexlist.py
+++ b/curator/indexlist.py
@@ -230,7 +230,7 @@ class IndexList(object):
         ts = TimestringSearch(timestring)
         for index in self.working_list():
             epoch = ts.get_epoch(index)
-            if epoch:
+            if isinstance(epoch, int):
                 self.index_info[index]['age']['name'] = epoch
 
     def _get_field_stats_dates(self, field='@timestamp'):

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -12,6 +12,9 @@ Changelog
     Reported in #945. (untergeek)
   * Check for presence of alias after reindex, in case the reindex was to an
     alias. Reported in #941. (untergeek)
+  * Fix an edge case where an index named with `1970.01.01` could not be sorted
+    by index-name age. Reported in #951. (untergeek)
+  * Update tests to include ES 5.3.2
 
 **Documentation**
 

--- a/test/integration/test_delete_indices.py
+++ b/test/integration/test_delete_indices.py
@@ -163,3 +163,39 @@ class TestCLIDeleteIndices(CuratorTestCase):
                     ],
                     )
         self.assertEqual(-1, result.exit_code)
+    def test_name_epoch_zero(self):
+        self.create_index('epoch_zero-1970.01.01')
+        self.write_config(
+            self.args['configfile'], testvars.client_config.format(host, port))
+        self.write_config(self.args['actionfile'],
+            testvars.delete_proto.format(
+                'age', 'name', 'older', '\'%Y.%m.%d\'', 'days', 5, ' ', ' ', ' '
+            )
+        )
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--config', self.args['configfile'],
+                        self.args['actionfile']
+                    ],
+                    )
+        self.assertEquals(0, len(curator.get_indices(self.client)))
+    def test_name_negative_epoch(self):
+        self.create_index('index-1969.12.31')
+        self.write_config(
+            self.args['configfile'], testvars.client_config.format(host, port))
+        self.write_config(self.args['actionfile'],
+            testvars.delete_proto.format(
+                'age', 'name', 'older', '\'%Y.%m.%d\'', 'days', 5, ' ', ' ', ' '
+            )
+        )
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--config', self.args['configfile'],
+                        self.args['actionfile']
+                    ],
+                    )
+        self.assertEquals(0, len(curator.get_indices(self.client)))


### PR DESCRIPTION
This edge case is addressed by testing to see if a value is integer, rather than truthiness.

fixes #951