### PR TITLE
Fix note about 'forcemerged' filter

### DIFF
--- a/docs/asciidoc/examples.asciidoc
+++ b/docs/asciidoc/examples.asciidoc
@@ -306,9 +306,9 @@ actions:
     description: >-
       forceMerge logstash- prefixed indices older than 2 days (based on index
       creation_date) to 2 segments per shard.  Delay 120 seconds between each
-      forceMerge operation to allow the cluster to quiesce.
-      This action will ignore indices already forceMerged to the same or fewer
-      number of segments per shard, so the 'forcemerged' filter is unneeded.
+      forceMerge operation to allow the cluster to quiesce. Skip indices that
+      have already been forcemerged to the minimum number of segments to avoid
+      reprocessing.
     options:
       max_num_segments: 2
       delay: 120
@@ -325,6 +325,9 @@ actions:
       direction: older
       unit: days
       unit_count: 2
+      exclude:
+    - filtertype: forcemerged
+      max_num_segments: 2
       exclude:
 -------------
 


### PR DESCRIPTION
This filter appears to still be required, at least in my experience. This action will continue to re-process indices that have already been force merged. Perhaps this documentation refers to a forthcoming release.