### PR TITLE
Ensure APT sources.list line only use arch=amd64

### DIFF
--- a/docs/asciidoc/installation.asciidoc
+++ b/docs/asciidoc/installation.asciidoc
@@ -110,7 +110,7 @@ Add the following in your `/etc/apt/sources.list.d/` directory in a file with a
 
 ["source","sh",subs="attributes,callouts"]
 --------------------------------------------------
-deb http://packages.elastic.co/curator/{curator_major}/debian stable main
+deb [arch=amd64] http://packages.elastic.co/curator/{curator_major}/debian stable main
 --------------------------------------------------
 
 After running `sudo apt-get update`, the repository is ready for use.


### PR DESCRIPTION
The APT repository doesn't include information for arch=i386, so ensure the deb line doesn't try to index files for i386.