### PR TITLE
Added mock library to requirements.txt 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ click>=6.7
 pyyaml>=3.10
 voluptuous>=0.9.3
 certifi>=2017.4.17
+mock


### PR DESCRIPTION
Curator couldn't be installed when mock wasn't present in the python path. I have added it as a requirement to requirements.txt, so that installation can be performed succesfully without the user having to "pip install mock".

Congratulations on your development!