### PR TITLE
Mock library added

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ click>=6.7
 pyyaml>=3.10
 voluptuous>=0.9.3
 certifi>=2017.4.17
+mock

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ def get_install_requires():
     res.append('pyyaml>=3.10')
     res.append('voluptuous>=0.9.3')
     res.append('certifi>=2017.4.17')
+    res.append('mock')
     return res
 
 try:


### PR DESCRIPTION
Curator couldn't be installed when mock wasn't present in the python path. Adding it as a requirement and as a dependency installation can be performed succesfully without the user having to "pip install mock".

Congratulations on your development!