### PR TITLE
Increase remote client timeout from default

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -1001,6 +1001,10 @@ class Reindex(object):
                     '{0}'.format(rclient_info['host'])
                 )
 
+            # Let's set a decent remote timeout for initially reading
+            # the indices on the other side, and collecting their metadata
+            remote_timeout = 180
+            
             # The rest only applies if using filters for remote indices
             if self.body['source']['index'] == 'REINDEX_SELECTION':
                 self.loggit.debug('Filtering indices from remote')
@@ -1016,7 +1020,8 @@ class Reindex(object):
                     'client_key={7} '
                     'aws_key={8} '
                     'aws_secret_key={9} '
-                    'aws_region={10}'
+                    'aws_region={10} '
+                    'timeout={11} '
                     'skip_version_test=True'.format(
                         rhost,
                         rhttp_auth,
@@ -1028,7 +1033,8 @@ class Reindex(object):
                         remote_client_key,
                         remote_aws_key,
                         remote_aws_secret_key,
-                        remote_aws_region
+                        remote_aws_region,
+                        remote_timeout
                     )
                 )
 
@@ -1046,6 +1052,7 @@ class Reindex(object):
                         aws_secret_key=remote_aws_secret_key,
                         aws_region=remote_aws_region,
                         skip_version_test=True,
+                        timeout=remote_timeout
                     )
                 except Exception as e:
                     self.loggit.error(

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -15,6 +15,8 @@ Changelog
     use ``isinstance``. #973 (untergeek)
   * Fix stray instance of ``is not`` comparison instead of ``!=`` #972 
     (untergeek)
+  * Increase remote client timeout to 180 seconds for remote reindex. #930
+    (untergeek)
 
 5.0.4 (16 May 2017)
 


### PR DESCRIPTION
The default is 10 seconds, which may not be enough for remote reindex to pull all of the indices and metadata (especially over a remote connection).

Setting it to 180 seconds.

fixes #930