### PR TITLE
Allow dates in new_index value for rollover action

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -863,7 +863,7 @@ class Rollover(object):
         self.settings   = extra_settings
         #: Instance variable.
         #: Internal reference to `new_index`
-        self.new_index = new_index
+        self.new_index = parse_date_pattern(new_index) if new_index else new_index
         #: Instance variable.
         #: Internal reference to `wait_for_active_shards`
         self.wait_for_active_shards = wait_for_active_shards

--- a/test/integration/test_rollover.py
+++ b/test/integration/test_rollover.py
@@ -310,3 +310,53 @@ class TestCLIRollover(CuratorTestCase):
                     ],
                     )
         self.assertEqual(expected, self.client.indices.get_alias(name=alias))
+    def test_max_age_with_new_name_with_date(self):
+        oldindex  = 'rolltome-000001'
+        newindex  = 'crazy_test-%Y.%m.%d'
+        alias     = 'delamitri'
+        condition = 'max_age'
+        value     = '1s'
+        expected  = {curator.parse_date_pattern(newindex): {u'aliases': {alias: {}}}}
+        self.client.indices.create(
+            index=oldindex,
+            body={ 'aliases': { alias: {} } }
+        )
+        time.sleep(1)
+        self.write_config(
+            self.args['configfile'], testvars.client_config.format(host, port))
+        self.write_config(self.args['actionfile'],
+            testvars.rollover_with_name.format(alias, condition, value, newindex))
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--config', self.args['configfile'],
+                        self.args['actionfile']
+                    ],
+                    )
+        self.assertEqual(expected, self.client.indices.get_alias(name=alias))
+    def test_max_age_old_index_with_date_with_new_index(self):
+        oldindex  = 'crazy_test-2017.01.01'
+        newindex  = 'crazy_test-%Y.%m.%d'
+        alias     = 'delamitri'
+        condition = 'max_age'
+        value     = '1s'
+        expected  = {"%s" % curator.parse_date_pattern(newindex): {u'aliases': {alias: {}}}}
+        self.client.indices.create(
+            index=oldindex,
+            body={ 'aliases': { alias: {} } }
+        )
+        time.sleep(1)
+        self.write_config(
+            self.args['configfile'], testvars.client_config.format(host, port))
+        self.write_config(self.args['actionfile'],
+            testvars.rollover_with_name.format(alias, condition, value, newindex))
+        test = clicktest.CliRunner()
+        result = test.invoke(
+                    curator.cli,
+                    [
+                        '--config', self.args['configfile'],
+                        self.args['actionfile']
+                    ],
+                    )
+        self.assertEqual(expected, self.client.indices.get_alias(name=alias))


### PR DESCRIPTION
Allow usage of date variables in the new_index option for the rollover action.