### PR TITLE
Address API change in ES 5.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ env:
   - ES_VERSION=5.1.2
   - ES_VERSION=5.2.2
   - ES_VERSION=5.3.3
-  - ES_VERSION=5.4.1
+  - ES_VERSION=5.4.3
+  - ES_VERSION=5.5.1
 
 os: linux
 

--- a/curator/indexlist.py
+++ b/curator/indexlist.py
@@ -681,7 +681,22 @@ class IndexList(object):
 
     def filter_by_alias(self, aliases=None, exclude=False):
         """
-        Match indices which are associated with the alias identified by `name`
+        Match indices which are associated with the alias or list of aliases 
+        identified by `aliases`.
+
+        An update to Elasticsearch 5.5.0 changes the behavior of this from 
+        previous 5.x versions:
+        https://www.elastic.co/guide/en/elasticsearch/reference/5.5/breaking-changes-5.5.html#breaking_55_rest_changes
+
+        What this means is that indices must appear in all aliases in list
+        `aliases` or a 404 error will result, leading to no indices being 
+        matched.  In older versions, if the index was associated with even one 
+        of the aliases in `aliases`, it would result in a match.
+
+        It is unknown if this behavior affects anyone.  At the time this was 
+        written, no users have been bit by this.  The code could be adapted
+        to manually loop if the previous behavior is desired.  But if no users
+        complain, this will become the accepted/expected behavior.
 
         :arg aliases: A list of alias names.
         :type aliases: list

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -6,6 +6,18 @@ Changelog
 5.1.2 (? ? ?)
 -------------
 
+**Errata**
+
+  * An update to Elasticsearch 5.5.0 changes the behavior of 
+    ``filter_by_aliases``, differing from previous 5.x versions.
+
+    If a list of aliases is provided, indices must appear in _all_ listed 
+    aliases or a 404 error will result, leading to no indices being matched.  
+    In older versions, if the index was associated with even one of the 
+    aliases in aliases, it would result in a match.
+
+    Tests and documentation have been updated to address these changes.
+
 **Bug Fixes**
 
   * Support date math in reindex operations better.  It did work previously,

--- a/docs/asciidoc/filter_elements.asciidoc
+++ b/docs/asciidoc/filter_elements.asciidoc
@@ -36,6 +36,8 @@ You can use <<envvars,environment variables>> in your configuration files.
 [[fe_aliases]]
 == aliases
 
+include::inc_filter_by_aliases.asciidoc[]
+
 NOTE: This setting is used only when using the <<filtertype_alias,alias>>
     filter.
 
@@ -78,7 +80,6 @@ filters:
 
 There is no default value. This setting must be set by the user or an
 exception will be raised, and execution will halt.
-
 
 
 [[fe_allocation_type]]

--- a/docs/asciidoc/filters.asciidoc
+++ b/docs/asciidoc/filters.asciidoc
@@ -197,6 +197,8 @@ indices based on whether they are associated with the given
 remain in, or be removed from the actionable list based on the value of
 <<fe_exclude,exclude>>.
 
+include::inc_filter_by_aliases.asciidoc[]
+
 === Required settings
 
 * <<fe_aliases,aliases>>

--- a/docs/asciidoc/index.asciidoc
+++ b/docs/asciidoc/index.asciidoc
@@ -2,7 +2,7 @@
 :curator_major: 5
 :curator_doc_tree: 5.1
 :es_py_version: 5.4.0
-:es_doc_tree: 5.4
+:es_doc_tree: 5.5
 :pybuild_ver: 3.6.1
 :ref:  http://www.elastic.co/guide/en/elasticsearch/reference/{es_doc_tree}
 

--- a/test/integration/test_integrations.py
+++ b/test/integration/test_integrations.py
@@ -52,7 +52,11 @@ class TestFilters(CuratorTestCase):
                         self.args['actionfile']
                     ],
                     )
-        self.assertEquals(1, len(curator.get_indices(self.client)))
+        ver = curator.get_version(self.client)
+        if ver >= (5,5,0):
+            self.assertEquals(2, len(curator.get_indices(self.client)))
+        else:
+            self.assertEquals(1, len(curator.get_indices(self.client)))
     def test_filter_by_alias_bad_aliases(self):
         alias = 'testalias'
         self.write_config(


### PR DESCRIPTION
Mostly documentation, but allow one test to respond differently based on which version of ES it sees.

fixes #1021