### PR TITLE
Fix documentation for extra_settings in restore

### DIFF
--- a/docs/asciidoc/actions.asciidoc
+++ b/docs/asciidoc/actions.asciidoc
@@ -861,8 +861,7 @@ actions:
       # If indices is blank, all indices in the snapshot will be restored
       indices:
       extra_settings:
-        settings:
-          number_of_shards: 1
+        index_settings:
           number_of_replicas: 0
         mappings:
           type1:

--- a/docs/asciidoc/options.asciidoc
+++ b/docs/asciidoc/options.asciidoc
@@ -259,6 +259,8 @@ options:
 
 === <<restore,restore>>
 
+{ref}/current/modules-snapshots.html#_changing_index_settings_during_restore[Elasticsearch Documentation]
+
 [source,yaml]
 -------------
 actions:
@@ -276,8 +278,7 @@ actions:
       # If indices is blank, all indices in the snapshot will be restored
       indices:
       extra_settings:
-        settings:
-          number_of_shards: 1
+        index_settings:
           number_of_replicas: 0
         mappings:
           type1:


### PR DESCRIPTION
Changing index settings should be under the header `index_settings` rather than merely `settings` like with other actions.

This is clear in the [official Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_changing_index_settings_during_restore).

fixes #1015