### PR TITLE
Fix typo in index settings example action file

### DIFF
--- a/docs/asciidoc/examples.asciidoc
+++ b/docs/asciidoc/examples.asciidoc
@@ -353,7 +353,7 @@ actions:
       disable_action: True
       index_settings:
         index:
-          block:
+          blocks:
             write: True
       ignore_unavailable: False
       preserve_existing: False


### PR DESCRIPTION
I think this should be 'index.blocks.write' so 'blocks' with an 's'.
This just tripped me when trying out the new features in 5.1.2.