### PR TITLE
Access the repositories over https

### DIFF
--- a/docs/asciidoc/installation.asciidoc
+++ b/docs/asciidoc/installation.asciidoc
@@ -134,14 +134,14 @@ for example `curator.list`
 
 ["source","sh",subs="attributes,callouts"]
 --------------------------------------------------
-deb [arch=amd64] http://packages.elastic.co/curator/{curator_major}/debian stable main
+deb [arch=amd64] https://packages.elastic.co/curator/{curator_major}/debian stable main
 --------------------------------------------------
 
 or
 
 ["source","sh",subs="attributes,callouts"]
 --------------------------------------------------
-deb [arch=amd64] http://packages.elastic.co/curator/{curator_major}/debian9 stable main
+deb [arch=amd64] https://packages.elastic.co/curator/{curator_major}/debian9 stable main
 --------------------------------------------------
 
 After running `sudo apt-get update`, the repository is ready for use.


### PR DESCRIPTION
It seems preferable to access the packages over SSL. Just tried it myself for the deb 8 packages, and it works fine.