### PR TITLE
format error correctly

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -1882,6 +1882,7 @@ class Shrink(object):
             raise ActionError(
                 'Node "{0}" has multiple data paths and cannot be used '
                 'for shrink operations.'
+                .format(self.shrink_node)
             )
         self.shrink_node_avail = (
             self.client.nodes.stats()['nodes'][node_id]['fs']['total']['available_in_bytes']


### PR DESCRIPTION
replace {0} with self.shrink_node

Previously, logging looked like this, because the string was never formatted:
```2017-09-20 16:51:15,396 INFO      Node "{0}" has multiple data paths and will not be used for shrink operations.```