### PR TITLE
[FEATURE] Add support for returning indices smaller than `disk_space` in space filter

### DIFF
--- a/curator/defaults/filter_elements.py
+++ b/curator/defaults/filter_elements.py
@@ -105,6 +105,10 @@ def timestring(**kwargs):
     else:
         return { Optional('timestring', default=None): Any(str, unicode, None) }
 
+def threshold_behavior(**kwargs):
+    # This setting is only used with the space filtertype and defaults to 'greater_than'.
+    return { Optional('threshold_behavior', default='greater_than'): Any('greater_than', 'less_than') }
+
 def unit(**kwargs):
     # This setting is only used with the age filtertype, or with the space
     # filtertype if use_age is set to True.

--- a/curator/defaults/filtertypes.py
+++ b/curator/defaults/filtertypes.py
@@ -118,6 +118,7 @@ def space(action, config):
         filter_elements.reverse(),
         filter_elements.use_age(),
         filter_elements.exclude(),
+        filter_elements.threshold_behavior(),
     ]
     retval += _age_elements(action, config)
     return retval

--- a/curator/defaults/settings.py
+++ b/curator/defaults/settings.py
@@ -118,6 +118,7 @@ def structural_filter_elements():
         Optional('state'): Any(str, unicode),
         Optional('stats_result'): Any(str, unicode, None),
         Optional('timestring'): Any(str, unicode, None),
+        Optional('threshold_behavior'): Any(str, unicode),
         Optional('unit'): Any(str, unicode),
         Optional('unit_count'): Coerce(int),
         Optional('unit_count_pattern'): Any(str, unicode),

--- a/curator/indexlist.py
+++ b/curator/indexlist.py
@@ -506,6 +506,10 @@ class IndexList(object):
         ``max_value``, or ``min_value``.  The ``name`` `source` requires the
         timestring argument.
 
+        `threshold_behavior`, when set to `greater_than` (default), includes if it the index
+        tests to be larger than `disk_space`. When set to `less_than`, it includes if
+        the index is smaller than `disk_space`
+
         :arg disk_space: Filter indices over *n* gigabytes
         :arg threshold_behavior: Size to filter, either ``greater_than`` or ``less_than``. Defaults
             to ``greater_than`` to preserve backwards compatability.

--- a/docs/asciidoc/filter_elements.asciidoc
+++ b/docs/asciidoc/filter_elements.asciidoc
@@ -23,6 +23,7 @@
 * <<fe_state,state>>
 * <<fe_stats_result,stats_result>>
 * <<fe_timestring,timestring>>
+* <<fe_threshold_behavior,threshold_behavior>>
 * <<fe_unit,unit>>
 * <<fe_unit_count,unit_count>>
 * <<fe_unit_count_pattern,unit_count_pattern>>
@@ -572,6 +573,26 @@ When <<fe_source,source>> is `name`, this setting must be set by the user or an
 exception will be raised, and execution will halt. There is no default value.
 
 include::inc_timestring_regex.asciidoc[]
+
+
+
+[[fe_threshold_behavior]]
+== threshold_behavior
+
+NOTE: This setting is only available in the <<filtertype_space,space>> filtertype.
+  This setting is optional, and defaults to `greater_than` to preserve backwards compatability.
+
+[source,yaml]
+-------------
+- filtertype: space
+  disk_space: 5
+  threshold_behavior: less_than
+-------------
+
+The value for this setting is `greater_than` (default) or `less_than`.
+
+When set to `less_than`, indices in less than `disk_space` gigabytes will be matched.
+When set to `greater_than` (default), indices larger than `disk_space` will be matched.
 
 
 

--- a/docs/asciidoc/filters.asciidoc
+++ b/docs/asciidoc/filters.asciidoc
@@ -642,7 +642,7 @@ that whole unit will be selected, in this case, a month.
 == space
 
 This <<filtertype,filtertype>> will iterate over the actionable list and match
-indices when their cumulative disk consumption exceeds
+indices when their cumulative disk consumption is `greater_than` (default) or `less_than` than
 <<fe_disk_space,disk_space>> gigabytes.  They are first ordered by age,
 or by alphabet, so as to guarantee the oldest indices are deleted first. They
 will remain in, or be removed from the actionable list based on the value of
@@ -802,6 +802,7 @@ messages like these in the output:
 * <<fe_use_age,use_age>>
 * <<fe_source,source>> (required if `use_age` is `True`)
 * <<fe_timestring,timestring>> (required if `source` is `name`)
+* <<fe_threshold_behavior,fe_threshold_behavior>> (default is `greater_than`)
 * <<fe_field,field>> (required if `source` is `field_stats`)
 * <<fe_stats_result,stats_result>> (only used if `source` is `field_stats`)
 * <<fe_exclude,exclude>> (default is `False`)

--- a/test/unit/test_class_index_list.py
+++ b/test/unit/test_class_index_list.py
@@ -617,6 +617,25 @@ class TestIndexListFilterBySpace(TestCase):
             source='name', timestring='%Y.%m.%d.%H'
         )
         self.assertEqual([], sorted(il.indices))
+    def test_filter_threshold_behavior(self):
+        client = Mock()
+        client.info.return_value = {'version': {'number': '5.0.0'} }
+        client.indices.get_settings.return_value = testvars.settings_two
+        client.cluster.state.return_value = testvars.clu_state_two
+        client.indices.stats.return_value = testvars.stats_two
+        client.field_stats.return_value = testvars.fieldstats_two
+        il = curator.IndexList(client)
+        il.filter_by_space(
+            disk_space=1.5, use_age=True,
+            threshold_behavior='less_than'
+        )
+        self.assertEqual(['index-2016.03.04'], sorted(il.indices))
+        il_b = curator.IndexList(client)
+        il_b.filter_by_space(
+            disk_space=1.5, use_age=True,
+            threshold_behavior='greater_than'
+        )
+        self.assertEqual(['index-2016.03.03'], sorted(il_b.indices))
     def test_filter_result_by_date_field_stats_raise(self):
         client = Mock()
         client.info.return_value = {'version': {'number': '5.0.0'} }


### PR DESCRIPTION
Addresses https://github.com/elastic/curator/issues/1066

I'm not attached to the `index_comparison` key at all, and hope there's a better name for it. I'm open to suggestions.
I'm not very familiar with asciidoc, so I hope I did that part right. If you want me to make any changes, just let me know.

Thanks a lot for Curator. It's a great tool, and I make heavy use of it.