### PR TITLE
Better explain the sub-option permit_masters

### DIFF
--- a/docs/asciidoc/options.asciidoc
+++ b/docs/asciidoc/options.asciidoc
@@ -1050,11 +1050,15 @@ The current sub-options are as follows:
 
 === permit_masters
 
+This option indicates whether the shrink action can select master eligible nodes when using
+`DETERMINISTIC` as the value for <<option_shrink_node,shrink_node>>. The default value is 
+`False`. Please note that this will exclude the elected master, as well as other
+master-eligible nodes.
+
 [IMPORTANT]
 =====================================
-The `permit_masters` sub-option has a default value of `False`.  If you have a small cluster
-with only master/data nodes, you must set `permit_masters` to `True` in order to select one
-of those nodes as a potential <<option_shrink_node,shrink_node>>.
+If you have a small cluster with only master/data nodes, you must set `permit_masters` to 
+`True` in order to select one of those nodes as a potential <<option_shrink_node,shrink_node>>.
 =====================================
 
 === exclude_nodes


### PR DESCRIPTION
Add information about the option hitting master-eligible nodes along with the elected master.

As discussed in https://github.com/elastic/curator/issues/1068