### PR TITLE
Add a verify option to es_repo_mgr create

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -11,6 +11,11 @@ Changelog
     patterns.  This has been rectified, and an integration test added to 
     satisfy this.  Reported in #989 (untergeek)
 
+**General**
+
+  * The ``es_repo_mgr create`` command now can take ``verify`` as an argument
+    (default is True).
+
 5.1.1 (8 June 2017)
 
 **Bug Fixes**

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -11,11 +11,6 @@ Changelog
     patterns.  This has been rectified, and an integration test added to 
     satisfy this.  Reported in #989 (untergeek)
 
-**General**
-
-  * The ``es_repo_mgr create`` command now can take ``verify`` as an argument
-    (default is True).
-
 5.1.1 (8 June 2017)
 
 **Bug Fixes**

--- a/curator/repomgrcli.py
+++ b/curator/repomgrcli.py
@@ -76,11 +76,13 @@ def fs(
 @click.option('--max_snapshot_bytes_per_sec', type=str, default='20mb',
             show_default=True,
             help='Throttles per node snapshot rate (per second).')
+@click.option('--verify', type=bool, default=True, show_default=True,
+            help='Verify repository after creation')
 @click.pass_context
 def s3(
     ctx, repository, bucket, region, base_path, access_key, secret_key,
     compression, chunk_size, max_restore_bytes_per_sec,
-    max_snapshot_bytes_per_sec):
+    max_snapshot_bytes_per_sec, verify):
     """
     Create an S3 repository.
     """

--- a/curator/repomgrcli.py
+++ b/curator/repomgrcli.py
@@ -41,10 +41,13 @@ def show_repos(client):
 @click.option('--max_snapshot_bytes_per_sec', type=str, default='20mb',
             show_default=True,
             help='Throttles per node snapshot rate (per second).')
+@click.option('--skip_repo_fs_check', type=bool, default=False, show_default=True,
+            help='Skip repository verification after creation')
 @click.pass_context
 def fs(
     ctx, repository, location, compression, chunk_size,
-    max_restore_bytes_per_sec, max_snapshot_bytes_per_sec):
+    max_restore_bytes_per_sec, max_snapshot_bytes_per_sec,
+    skip_repo_fs_check):
     """
     Create a filesystem repository.
     """

--- a/curator/repomgrcli.py
+++ b/curator/repomgrcli.py
@@ -76,13 +76,13 @@ def fs(
 @click.option('--max_snapshot_bytes_per_sec', type=str, default='20mb',
             show_default=True,
             help='Throttles per node snapshot rate (per second).')
-@click.option('--verify', type=bool, default=True, show_default=True,
-            help='Verify repository after creation')
+@click.option('--skip_repo_fs_check', type=bool, default=False, show_default=True,
+            help='Skip repository verification after creation')
 @click.pass_context
 def s3(
     ctx, repository, bucket, region, base_path, access_key, secret_key,
     compression, chunk_size, max_restore_bytes_per_sec,
-    max_snapshot_bytes_per_sec, verify):
+    max_snapshot_bytes_per_sec, skip_repo_fs_check):
     """
     Create an S3 repository.
     """

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -1093,6 +1093,8 @@ def create_repository(client, **kwargs):
         raise MissingArgument('Missing required parameter "repository"')
     else:
         repository = kwargs['repository']
+    verify = kwargs.pop('verify', True)
+    params = {'verify': 'true' if verify else 'false'}
 
     try:
         body = create_repo_body(**kwargs)
@@ -1107,7 +1109,7 @@ def create_repository(client, **kwargs):
                     repository
                 )
             )
-            client.snapshot.create_repository(repository=repository, body=body)
+            client.snapshot.create_repository(repository=repository, body=body, params=params)
         else:
             raise FailedExecution(
                 'Unable to create repository {0}.  A repository with that name '

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -1093,8 +1093,8 @@ def create_repository(client, **kwargs):
         raise MissingArgument('Missing required parameter "repository"')
     else:
         repository = kwargs['repository']
-    verify = kwargs.pop('verify', True)
-    params = {'verify': 'true' if verify else 'false'}
+    skip_repo_fs_check = kwargs.pop('skip_repo_fs_check', False)
+    params = {'verify': 'false' if skip_repo_fs_check else 'true'}
 
     try:
         body = create_repo_body(**kwargs)

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -1085,6 +1085,7 @@ def create_repository(client, **kwargs):
         Defaults to value of ``cloud.aws.access_key``.
     :arg secret_key: `S3 only.` The secret key to use for authentication.
         Defaults to value of ``cloud.aws.secret_key``.
+    :arg skip_repo_fs_check: Skip verifying the repo after creation.
 
     :returns: A boolean value indicating success or failure.
     :rtype: bool

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -23,6 +23,11 @@ Changelog
     Requested in #1058 (untergeek)
   * Fixed an integration test that could fail in the waning days of a month.
 
+**General**
+
+  * The ``es_repo_mgr create`` command now can take ``skip_repo_fs_check`` as an
+    argument (default is False).
+
 5.2.0 (1 September 2017)
 ------------------------
 

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -16,17 +16,14 @@ Changelog
     #851 (alexef)
   * Add ``pattern`` to the ``count`` filter.  This is particularly useful
     when working with rollover indices.  Requested in #1044 (untergeek)
+  * The ``es_repo_mgr create`` command now can take ``skip_repo_fs_check`` as
+    an argument (default is False) #1072 (alexef)
 
 **Bug Fixes**
 
   * Delete the target index (if it exists) in the event that a shrink fails.
     Requested in #1058 (untergeek)
   * Fixed an integration test that could fail in the waning days of a month.
-
-**General**
-
-  * The ``es_repo_mgr create`` command now can take ``skip_repo_fs_check`` as an
-    argument (default is False).
 
 5.2.0 (1 September 2017)
 ------------------------


### PR DESCRIPTION
Sometimes (when we want to restore a backup) we don't want to verify the repository after creation.

Adding a flag to es_repo_mgr script, allowing us to disable the check, by passing `--verify false`.