### PR TITLE
Add a restore action to curator_cli

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -11,6 +11,11 @@ Changelog
     patterns.  This has been rectified, and an integration test added to 
     satisfy this.  Reported in #989 (untergeek)
 
+**New features**
+
+  * Add a ``restore`` function to ``curator_cli`` singleton. Mentioned in
+    #851 (alexef)
+
 5.1.1 (8 June 2017)
 
 **Bug Fixes**

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -11,11 +11,6 @@ Changelog
     patterns.  This has been rectified, and an integration test added to 
     satisfy this.  Reported in #989 (untergeek)
 
-**New features**
-
-  * Add a ``restore`` function to ``curator_cli`` singleton. Mentioned in
-    #851 (alexef)
-
 5.1.1 (8 June 2017)
 
 **Bug Fixes**

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -12,6 +12,8 @@ Changelog
     that fit `within` the period, rather than just their start dates.  This
     is now possible with ``intersect``.  See more in the documentation.
     Requested in #1045. (untergeek)
+  * Add a ``restore`` function to ``curator_cli`` singleton. Mentioned in
+    #851 (alexef)
 
 **Bug Fixes**
 


### PR DESCRIPTION
- same options as snapshot supported, plus rename_pattern and rename_replacement
- tested against elasticsearch 5x

part of #851 