### PR TITLE
Add support for AWS IAM authentication using boto3

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -11,6 +11,11 @@ Changelog
     patterns.  This has been rectified, and an integration test added to 
     satisfy this.  Reported in #989 (untergeek)
 
+**New Features**
+
+  * IAM Credentials can now be retrieved from the environment using the Boto3
+    Credentials provider. #1084 (kobuskc)
+
 5.1.1 (8 June 2017)
 
 **Bug Fixes**

--- a/curator/defaults/client_defaults.py
+++ b/curator/defaults/client_defaults.py
@@ -14,7 +14,9 @@ def config_client():
         Optional('client_key', default=None): Any(None, str, unicode),
         Optional('aws_key', default=None): Any(None, str, unicode),
         Optional('aws_secret_key', default=None): Any(None, str, unicode),
-        Optional('aws_region', default=None): Any(None, str, unicode),
+        Optional('aws_token', default=None): Any(None, str, unicode),
+        Optional('aws_sign_request', default=False): Boolean(),
+        Optional('aws_region', default='us-east-1'): Any(None, str, unicode),
         Optional('ssl_no_validate', default=False): Boolean(),
         Optional('http_auth', default=None): Any(None, str, unicode),
         Optional('timeout', default=30): All(

--- a/curator/defaults/client_defaults.py
+++ b/curator/defaults/client_defaults.py
@@ -16,7 +16,7 @@ def config_client():
         Optional('aws_secret_key', default=None): Any(None, str, unicode),
         Optional('aws_token', default=None): Any(None, str, unicode),
         Optional('aws_sign_request', default=False): Boolean(),
-        Optional('aws_region', default='us-east-1'): Any(None, str, unicode),
+        Optional('aws_region'): Any(None, str, unicode),
         Optional('ssl_no_validate', default=False): Boolean(),
         Optional('http_auth', default=None): Any(None, str, unicode),
         Optional('timeout', default=30): All(

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -751,13 +751,16 @@ def get_client(**kwargs):
                     import certifi
                     kwargs['verify_certs'] = True
                     kwargs['ca_certs'] = certifi.where()
-
     try:
         from requests_aws4auth import AWS4Auth
-        from boto3 import session
         kwargs['aws_sign_request'] = False if not 'aws_sign_request' in kwargs \
             else kwargs['aws_sign_request']
         if kwargs['aws_sign_request']:
+            try:
+                from boto3 import session
+            except ImportError as e:
+                logger.debug('Failed to import the "boto3" module.')
+                exit(e)
             session = session.Session()
             credentials = session.get_credentials()
             kwargs['aws_key'] = credentials.access_key
@@ -770,7 +773,6 @@ def get_client(**kwargs):
                 else kwargs['aws_secret_key']
             kwargs['aws_token='] = '' if not 'aws_token' in kwargs \
                 else kwargs['aws_token']
-
         if kwargs['aws_key'] or kwargs['aws_secret_key'] or kwargs['aws_region']:
             if not kwargs['aws_key'] and kwargs['aws_secret_key'] \
                      and kwargs['aws_region']:
@@ -778,7 +780,6 @@ def get_client(**kwargs):
                     'Missing one or more of "aws_key", "aws_secret_key", '
                     'or "aws_region".'
                     )
-
             # Override these kwargs
             kwargs['use_ssl'] = True
             kwargs['verify_certs'] = True
@@ -792,7 +793,6 @@ def get_client(**kwargs):
             logger.debug('"requests_aws4auth" module present, but not used.')
     except ImportError:
         logger.debug('Not using "requests_aws4auth" python module to connect.')
-
     if master_only:
         if len(kwargs['hosts']) > 1:
             raise ConfigurationError(

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -772,7 +772,7 @@ def get_client(**kwargs):
         # We cannot get credentials without the boto3 library, so we cannot continue
         except ImportError as e:
             logger.debug('Failed to import a module: %s' % e)
-            exit('Failed to import a module: %s' % e)
+            raise ImportError('Failed to import a module: %s' % e)
         try:
             session = session.Session()
             credentials = session.get_credentials()
@@ -782,7 +782,7 @@ def get_client(**kwargs):
         # If an attribute doesn't exist, we were not able to retrieve credentials as expected so we can't continue
         except AttributeError:
             logger.debug('Unable to locate AWS credentials')
-            exit('Unable to locate AWS credentials')
+            raise exceptions.NoCredentialsError
     try:
         from requests_aws4auth import AWS4Auth
         if kwargs['aws_key'] or kwargs['aws_secret_key'] or kwargs['aws_region']:

--- a/docs/asciidoc/configuration.asciidoc
+++ b/docs/asciidoc/configuration.asciidoc
@@ -431,8 +431,8 @@ IMPORTANT: You must set your <<hosts,hosts>> to the proper hostname _with_ port.
 
 WARNING: This feature has not been fully tested and should be considered BETA.
 
-WARNING: This setting will not work unless the `requests-aws4auth` and `boto3` Python
-    modules have been manually installed first.
+WARNING: If installing via `pip`, this setting will not work unless the `requests-aws4auth`
+    and `boto3` Python modules have been manually installed first.
 
 WARNING: Credentials found in your environment will replace the data specified in
     <<aws_key,aws_key>> and <<aws_secret_key,aws_secret_key>>
@@ -446,9 +446,11 @@ This should be `True` if you want your requests to be signed with credentials re
     . Boto2 config file (/etc/boto.cfg and ~/.boto)
     . Instance metadata service on an Amazon EC2 instance that has an IAM role configured.
 
+The default value is `False`.
+
 [source,sh]
 -----------
-aws_sign_request:
+aws_sign_request: True
 -----------
 
 IMPORTANT: You must set your <<hosts,hosts>> to the proper hostname _with_ port.

--- a/docs/asciidoc/configuration.asciidoc
+++ b/docs/asciidoc/configuration.asciidoc
@@ -382,6 +382,9 @@ IMPORTANT: You must set your <<hosts,hosts>> to the proper hostname _with_ port.
     It may not work setting <<port,port>> and <<hosts,hosts>> to only a host
     name due to the different connection module used.
 
+IMPORTANT: This feature may be deprecated in a future release. You should consider
+    using <<aws_sign_request,aws_sign_request>> instead.
+
 [[aws_secret_key]]
 === aws_secret_key
 
@@ -401,6 +404,9 @@ IMPORTANT: You must set your <<hosts,hosts>> to the proper hostname _with_ port.
     It may not work setting <<port,port>> and <<hosts,hosts>> to only a host
     name due to the different connection module used.
 
+IMPORTANT: This feature may be deprecated in a future release. You should consider
+    using <<aws_sign_request,aws_sign_request>> instead.
+
 [[aws_region]]
 === aws_region
 
@@ -419,6 +425,37 @@ aws_region:
 IMPORTANT: You must set your <<hosts,hosts>> to the proper hostname _with_ port.
     It may not work setting <<port,port>> and <<hosts,hosts>> to only a host
     name due to the different connection module used.
+
+[[aws_sign_request]]
+=== aws_sign_request
+
+WARNING: This feature has not been fully tested and should be considered BETA.
+
+WARNING: This setting will not work unless the `requests-aws4auth` and `boto3` Python
+    modules have been manually installed first.
+
+WARNING: Credentials found in your environment will replace the data specified in
+    <<aws_key,aws_key>> and <<aws_secret_key,aws_secret_key>>
+
+This should be `True` if you want your requests to be signed with credentials retrieved
+    from your environment. The order in which credentials will be searched for is:
+
+    . Environment variables
+    . Shared credential file (~/.aws/credentials)
+    . AWS config file (~/.aws/config)
+    . Boto2 config file (/etc/boto.cfg and ~/.boto)
+    . Instance metadata service on an Amazon EC2 instance that has an IAM role configured.
+
+[source,sh]
+-----------
+aws_sign_request:
+-----------
+
+IMPORTANT: You must set your <<hosts,hosts>> to the proper hostname _with_ port.
+    It may not work setting <<port,port>> and <<hosts,hosts>> to only a host
+    name due to the different connection module used.
+
+
 
 [[ssl_no_validate]]
 === ssl_no_validate

--- a/unix_packages/build_official_package.sh
+++ b/unix_packages/build_official_package.sh
@@ -141,6 +141,7 @@ tar zxf ${FILE}
 
 ${PIPBIN} install -U --user setuptools
 ${PIPBIN} install -U --user requests_aws4auth
+${PIPBIN} install -U --user boto3
 if [ "${CX_VER}" != "$(${PIPBIN} list | grep cx | awk '{print $2}' | tr -d '()')" ]; then
   cd ${WORKDIR}
   rm -rf ${CX_PATH}

--- a/unix_packages/build_package_from_source.sh
+++ b/unix_packages/build_package_from_source.sh
@@ -138,6 +138,7 @@ fi
 
 ${PIPBIN} install -U --user setuptools
 ${PIPBIN} install -U --user requests_aws4auth
+${PIPBIN} install -U --user boto3
 if [ "${CX_VER}" != "$(${PIPBIN} list | grep cx | awk '{print $2}' | tr -d '()')" ]; then
   cd ${WORKDIR}
   rm -rf ${CX_PATH}


### PR DESCRIPTION
Using the get_credentials definition, we can get credentials from the local environment.

Definition: http://boto3.readthedocs.io/en/latest/reference/core/session.html#boto3.session.Session.get_credentials

Order in which credentials is searched: http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence