### PR TITLE
Use cached stats result to lookup names

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -8,8 +8,9 @@ Changelog
 **Bug Fixes**
 
   * The ``restore_check`` function did not work properly with wildcard index
-    patterns.  This has been rectified, and an integration test added to 
+    patterns.  This has been rectified, and an integration test added to
     satisfy this.  Reported in #989 (untergeek)
+  * Re-use cached response for nodes in most_available_node function. #1086 (tschroeder-zendesk)
 
 5.1.1 (8 June 2017)
 
@@ -17,12 +18,12 @@ Changelog
 
   * Mock and cx_Freeze don't play well together.  Packages weren't working, so
     I reverted the string-based comparison as before.
-    
+
 5.1.0 (8 June 2017)
 
 **New Features**
 
-  * Index Settings are here! First requested as far back as #160, it's been 
+  * Index Settings are here! First requested as far back as #160, it's been
     requested in various forms culminating in #656.  The official documentation
     addresses the usage. (untergeek)
   * Remote reindex now adds the ability to migrate from one cluster to another,
@@ -30,12 +31,12 @@ Changelog
     The official documentation shows you how. (untergeek)
   * Added support for naming rollover indices. #970 (jurajseffer)
   * Testing against ES 5.4.1, 5.3.3
-  
+
 **Bug Fixes**
 
-  * Since Curator no longer supports old versions of python, convert tests to 
+  * Since Curator no longer supports old versions of python, convert tests to
     use ``isinstance``. #973 (untergeek)
-  * Fix stray instance of ``is not`` comparison instead of ``!=`` #972 
+  * Fix stray instance of ``is not`` comparison instead of ``!=`` #972
     (untergeek)
   * Increase remote client timeout to 180 seconds for remote reindex. #930
     (untergeek)
@@ -60,7 +61,7 @@ Changelog
 **Bug Fixes**
 
   * Restoring a snapshot on an exceptionally fast cluster/node can create a race
-    race condition where a ``_recovery`` check returns an empty dictionary 
+    race condition where a ``_recovery`` check returns an empty dictionary
     ``{}``, which causes Curator to fail.  Added test and code to correct this.
     Reported in #962. (untergeek)
 
@@ -88,7 +89,7 @@ Changelog
 
 **Bug Fixes**
 
-  * Fixed default values for ``include_global_state`` on the restore 
+  * Fixed default values for ``include_global_state`` on the restore
     action to be in line with defaults in Elasticsearch 5.3
 
 **Documentation**
@@ -103,23 +104,23 @@ The full feature set of 5.0 (including alpha releases) is included here.
 
 **New Features**
 
-  * Reindex is here! The new reindex action has a ton of flexibility. You 
+  * Reindex is here! The new reindex action has a ton of flexibility. You
     can even reindex from remote locations, so long as the remote cluster is
     Elasticsearch 1.4 or newer.
-  * Added the ``period`` filter (#733). This allows you to select indices 
-    or snapshots, based on whether they fit within a period of hours, days, 
+  * Added the ``period`` filter (#733). This allows you to select indices
+    or snapshots, based on whether they fit within a period of hours, days,
     weeks, months, or years.
   * Add dedicated "wait for completion" functionality. This supports health
     checks, recovery (restore) checks, snapshot checks, and operations which
-    support the new tasks API.  All actions which can use this have been 
+    support the new tasks API.  All actions which can use this have been
     refactored to take advantage of this.  The benefit of this new feature is
     that client timeouts will be less likely to happen when performing long
     operations, like snapshot and restore.
 
-    NOTE: There is one caveat: forceMerge does not support this, per the 
+    NOTE: There is one caveat: forceMerge does not support this, per the
     Elasticsearch API. A forceMerge call will hold the client until complete, or
     the client times out.  There is no clean way around this that I can discern.
-  * Elasticsearch date math naming is supported and documented for the 
+  * Elasticsearch date math naming is supported and documented for the
     ``create_index`` action.  An integration test is included for validation.
   * Allow allocation action to unset a key/value pair by using an empty value.
     Requested in #906. (untergeek)
@@ -153,7 +154,7 @@ The full feature set of 5.0 (including alpha releases) is included here.
   * Add missing repository arg to auto-gen API docs. Reported in #888
     (untergeek)
   * Add all new documentation and clean up for v5 specific.
-  
+
 **Breaking Changes**
 
   * IndexList no longer checks to see if there are indices on initialization.
@@ -162,7 +163,7 @@ The full feature set of 5.0 (including alpha releases) is included here.
 5.0.0a1 (23 March 2017)
 -----------------------
 
-This is the first alpha release of Curator 5.  This should not be used for 
+This is the first alpha release of Curator 5.  This should not be used for
 production! There `will` be many more changes before 5.0.0 is released.
 
 **New Features**

--- a/curator/actions.py
+++ b/curator/actions.py
@@ -1901,7 +1901,7 @@ class Shrink(object):
         mvn_id = None
         nodes = self.client.nodes.stats()['nodes']
         for node_id in nodes:
-            name = self.client.nodes.stats()['nodes'][node_id]['name']
+            name = nodes[node_id]['name']
             if self._exclude_node(name):
                 self.loggit.debug('Node "{0}" excluded by node filters'.format(name))
                 continue


### PR DESCRIPTION
Code was doing a client lookup for each name making it very slow to determine which node to use.