### PR TITLE
Fix reported issue where vcruntime140.dll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ index.html
 docs/asciidoc/html_docs
 wheelhouse
 Elastic.ico
+vcruntime140.dll
+msi_guid.txt
 Vagrant/centos/6/.vagrant
 Vagrant/centos/7/.vagrant
 Vagrant/ubuntu/14.04/.vagrant

--- a/setup.py
+++ b/setup.py
@@ -39,13 +39,10 @@ try:
         cert_file = ''
     # Dependencies are automatically detected, but it might need
     # fine tuning.
-    buildOptions = dict(
-        packages = [],
-        excludes = [],
-        include_files = [cert_file],
-    )
+
 
     base = 'Console'
+    msvcrt = ''
 
     icon = None
     if os.path.exists('Elastic.ico'):
@@ -86,6 +83,14 @@ try:
             targetName = "es_repo_mgr.exe",
             icon = icon
         )
+        msvcrt = 'vcruntime140.dll'
+
+    buildOptions = dict(
+        packages = [],
+        excludes = [],
+        include_files = [cert_file, msvcrt],
+        include_msvcr = True, 
+    )
     setup(
         name = "elasticsearch-curator",
         version = get_version(),


### PR DESCRIPTION
isn't copied to the target directory.

This workaround is better than the broken "official" method for cx_freeze.