### PR TITLE
Use yaml.safe_load instead of yaml.load to prevent avoid code execution

### DIFF
--- a/curator/utils.py
+++ b/curator/utils.py
@@ -50,7 +50,7 @@ def get_yaml(path):
 
     raw = read_file(path)
     try:
-        cfg = yaml.safe_load(raw)
+        cfg = yaml.load(raw)
     except yaml.scanner.ScannerError as e:
         raise ConfigurationError(
             'Unable to parse YAML file. Error: {0}'.format(e))

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -50,7 +50,7 @@ def get_yaml(path):
 
     raw = read_file(path)
     try:
-        cfg = yaml.load(raw)
+        cfg = yaml.safe_load(raw)
     except yaml.scanner.ScannerError as e:
         raise ConfigurationError(
             'Unable to parse YAML file. Error: {0}'.format(e))

--- a/test/unit/test_class_index_list.py
+++ b/test/unit/test_class_index_list.py
@@ -770,7 +770,7 @@ class TestIterateFiltersIndex(TestCase):
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
         ilo = curator.IndexList(client)
-        config = yaml.load(testvars.pattern_ft)['actions'][1]
+        config = yaml.safe_load(testvars.pattern_ft)['actions'][1]
         ilo.iterate_filters(config)
         self.assertEqual(['a-2016.03.03'], ilo.indices)
     def test_age_filtertype(self):
@@ -780,7 +780,7 @@ class TestIterateFiltersIndex(TestCase):
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
         ilo = curator.IndexList(client)
-        config = yaml.load(testvars.age_ft)['actions'][1]
+        config = yaml.safe_load(testvars.age_ft)['actions'][1]
         ilo.iterate_filters(config)
         self.assertEqual(['index-2016.03.03'], ilo.indices)
     def test_space_filtertype(self):
@@ -791,7 +791,7 @@ class TestIterateFiltersIndex(TestCase):
         client.indices.stats.return_value = testvars.stats_four
         client.field_stats.return_value = testvars.fieldstats_four
         ilo = curator.IndexList(client)
-        config = yaml.load(testvars.space_ft)['actions'][1]
+        config = yaml.safe_load(testvars.space_ft)['actions'][1]
         ilo.iterate_filters(config)
         self.assertEqual(['a-2016.03.03'], ilo.indices)
     def test_forcemerge_filtertype(self):
@@ -802,7 +802,7 @@ class TestIterateFiltersIndex(TestCase):
         client.indices.stats.return_value = testvars.stats_one
         client.indices.segments.return_value = testvars.shards
         ilo = curator.IndexList(client)
-        config = yaml.load(testvars.forcemerge_ft)['actions'][1]
+        config = yaml.safe_load(testvars.forcemerge_ft)['actions'][1]
         ilo.iterate_filters(config)
         self.assertEqual([testvars.named_index], ilo.indices)
     def test_allocated_filtertype(self):
@@ -812,7 +812,7 @@ class TestIterateFiltersIndex(TestCase):
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
         ilo = curator.IndexList(client)
-        config = yaml.load(testvars.allocated_ft)['actions'][1]
+        config = yaml.safe_load(testvars.allocated_ft)['actions'][1]
         ilo.iterate_filters(config)
         self.assertEqual(['index-2016.03.04'], ilo.indices)
     def test_kibana_filtertype(self):
@@ -828,7 +828,7 @@ class TestIterateFiltersIndex(TestCase):
             '.kibana', '.marvel-kibana', 'kibana-int', '.marvel-es-data',
             'dummy'
         ]
-        config = yaml.load(testvars.kibana_ft)['actions'][1]
+        config = yaml.safe_load(testvars.kibana_ft)['actions'][1]
         ilo.iterate_filters(config)
         self.assertEqual(['dummy'], ilo.indices)
     def test_opened_filtertype(self):
@@ -839,7 +839,7 @@ class TestIterateFiltersIndex(TestCase):
         client.indices.stats.return_value = testvars.stats_four
         client.field_stats.return_value = testvars.fieldstats_four
         ilo = curator.IndexList(client)
-        config = yaml.load(testvars.opened_ft)['actions'][1]
+        config = yaml.safe_load(testvars.opened_ft)['actions'][1]
         ilo.iterate_filters(config)
         self.assertEqual(['c-2016.03.05'], ilo.indices)
     def test_closed_filtertype(self):
@@ -850,7 +850,7 @@ class TestIterateFiltersIndex(TestCase):
         client.indices.stats.return_value = testvars.stats_four
         client.field_stats.return_value = testvars.fieldstats_four
         ilo = curator.IndexList(client)
-        config = yaml.load(testvars.closed_ft)['actions'][1]
+        config = yaml.safe_load(testvars.closed_ft)['actions'][1]
         ilo.iterate_filters(config)
         self.assertEqual(
             ['a-2016.03.03','b-2016.03.04','d-2016.03.06'], sorted(ilo.indices))
@@ -861,7 +861,7 @@ class TestIterateFiltersIndex(TestCase):
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
         ilo = curator.IndexList(client)
-        config = yaml.load(testvars.none_ft)['actions'][1]
+        config = yaml.safe_load(testvars.none_ft)['actions'][1]
         ilo.iterate_filters(config)
         self.assertEqual(
             ['index-2016.03.03', 'index-2016.03.04'], sorted(ilo.indices))
@@ -872,7 +872,7 @@ class TestIterateFiltersIndex(TestCase):
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
         ilo = curator.IndexList(client)
-        config = yaml.load(testvars.invalid_ft)['actions'][1]
+        config = yaml.safe_load(testvars.invalid_ft)['actions'][1]
         self.assertRaises(
             curator.ConfigurationError,
             ilo.iterate_filters, config

--- a/test/unit/test_class_snapshot_list.py
+++ b/test/unit/test_class_snapshot_list.py
@@ -304,7 +304,7 @@ class TestIterateFiltersSnaps(TestCase):
         client.snapshot.get.return_value = testvars.snapshots
         client.snapshot.get_repository.return_value = testvars.test_repo
         slo = curator.SnapshotList(client, repository=testvars.repo_name)
-        config = yaml.load(testvars.invalid_ft)['actions'][1]
+        config = yaml.safe_load(testvars.invalid_ft)['actions'][1]
         self.assertRaises(
             curator.ConfigurationError,
             slo.iterate_filters, config
@@ -314,7 +314,7 @@ class TestIterateFiltersSnaps(TestCase):
         client.snapshot.get.return_value = testvars.snapshots
         client.snapshot.get_repository.return_value = testvars.test_repo
         slo = curator.SnapshotList(client, repository=testvars.repo_name)
-        config = yaml.load(testvars.snap_age_ft)['actions'][1]
+        config = yaml.safe_load(testvars.snap_age_ft)['actions'][1]
         slo.iterate_filters(config)
         self.assertEqual(
             ['snap_name', 'snapshot-2015.03.01'], sorted(slo.snapshots))
@@ -323,7 +323,7 @@ class TestIterateFiltersSnaps(TestCase):
         client.snapshot.get.return_value = testvars.snapshots
         client.snapshot.get_repository.return_value = testvars.test_repo
         slo = curator.SnapshotList(client, repository=testvars.repo_name)
-        config = yaml.load(testvars.snap_pattern_ft)['actions'][1]
+        config = yaml.safe_load(testvars.snap_pattern_ft)['actions'][1]
         slo.iterate_filters(config)
         self.assertEqual(
             ['snap_name', 'snapshot-2015.03.01'], sorted(slo.snapshots))
@@ -332,7 +332,7 @@ class TestIterateFiltersSnaps(TestCase):
         client.snapshot.get.return_value = testvars.snapshots
         client.snapshot.get_repository.return_value = testvars.test_repo
         slo = curator.SnapshotList(client, repository=testvars.repo_name)
-        config = yaml.load(testvars.snap_none_ft)['actions'][1]
+        config = yaml.safe_load(testvars.snap_none_ft)['actions'][1]
         slo.iterate_filters(config)
         self.assertEqual(
             ['snap_name', 'snapshot-2015.03.01'], sorted(slo.snapshots))


### PR DESCRIPTION
Ref: https://github.com/yaml/pyyaml/issues/5

To keep us on the safe side before https://github.com/yaml/pyyaml/pull/74 makes it’s way downstream.

Edit: CI build issues seem to be unrelated to my PR. I will sign the CLA later.