### PR TITLE
Dockerfile that builds from source and produces slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.6-alpine3.6 as builder
 
 RUN apk --no-cache add build-base tar musl-utils openssl-dev
-RUN pip3 install setuptools cx_Freeze==6.0b1 requests-aws4auth
+RUN pip3 install setuptools cx_Freeze==6.0b1 requests-aws4auth boto3
 
 COPY . .
 RUN ln -s /lib/libc.musl-x86_64.so.1 ldd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,16 @@
-# Docker Definition for ElasticSearch Curator
+FROM python:3.6-alpine3.6 as builder
 
-FROM python:2.7.8-slim
-MAINTAINER Christian R. Vozar <christian@rogueethic.com>
+RUN apk --no-cache add build-base tar musl-utils openssl-dev
+RUN pip3 install setuptools cx_Freeze==6.0b1 requests-aws4auth
 
-RUN pip install --quiet elasticsearch-curator
+COPY . .
+RUN ln -s /lib/libc.musl-x86_64.so.1 ldd
+RUN ln -s /lib /lib64
+RUN pip3 install -r requirements.txt 
+RUN python3 setup.py build_exe
 
-ENTRYPOINT [ "/usr/local/bin/curator" ]
+FROM alpine:3.6
+RUN apk --no-cache upgrade && apk --no-cache add ca-certificates
+COPY --from=builder build/exe.linux-x86_64-3.6 /curator/
+USER nobody:nobody
+ENTRYPOINT ["/curator/curator"]


### PR DESCRIPTION
Tested and verified working against the 5.4 branch. Does however not work against master right now, because build_exe isn't working in master.
We publish our image here: https://quay.io/repository/lalamove/elasticsearch-curator