### PR TITLE
Fix 'filter_kibana' to use correctly 'exclude' argument

### DIFF
--- a/curator/indexlist.py
+++ b/curator/indexlist.py
@@ -608,6 +608,8 @@ class IndexList(object):
                     '.kibana', '.marvel-kibana', 'kibana-int', '.marvel-es-data'
                 ]:
                 self.__excludify(True, exclude, index)
+            else:
+                self.__excludify(False, exclude, index)
 
     def filter_forceMerged(self, max_num_segments=None, exclude=True):
         """

--- a/test/unit/test_class_index_list.py
+++ b/test/unit/test_class_index_list.py
@@ -601,6 +601,18 @@ class TestIndexListFilterKibana(TestCase):
         il.indices = ['.kibana', '.marvel-kibana', 'kibana-int', '.marvel-es-data', 'dummy']
         il.filter_kibana()
         self.assertEqual(['dummy'], il.indices)
+    def test_filter_kibana_positive_include(self):
+        client = Mock()
+        client.info.return_value = {'version': {'number': '5.0.0'} }
+        client.indices.get_settings.return_value = testvars.settings_two
+        client.cluster.state.return_value = testvars.clu_state_two
+        client.indices.stats.return_value = testvars.stats_two
+        client.field_stats.return_value = testvars.fieldstats_two
+        il = curator.IndexList(client)
+        # Establish the object per requirements, then overwrite
+        il.indices = ['.kibana', '.marvel-kibana', 'kibana-int', '.marvel-es-data', 'dummy']
+        il.filter_kibana(exclude=False)
+        self.assertEqual(['.kibana', '.marvel-kibana', 'kibana-int', '.marvel-es-data'], il.indices)    
     def test_filter_kibana_positive_exclude(self):
         client = Mock()
         client.info.return_value = {'version': {'number': '5.0.0'} }


### PR DESCRIPTION
Exclude=False was not keeping only matching indices.

Note: PR opened against 5.x per author request in PR #1106