### PR TITLE
Stop overriding verify_certs param in AWS ES

### DIFF
--- a/curator/utils.py
+++ b/curator/utils.py
@@ -866,6 +866,8 @@ def get_client(**kwargs):
             # Override these kwargs
             kwargs['use_ssl'] = True
             kwargs['verify_certs'] = True
+            if kwargs['ssl_no_validate']:
+                kwargs['verify_certs'] = False
             kwargs['connection_class'] = elasticsearch.RequestsHttpConnection
             kwargs['http_auth'] = (
                 AWS4Auth(


### PR DESCRIPTION
Hi!,

I'm configuring curator against an AWS ES using a CNAME registry and it's failing when the certificate is being validated (as the domain name it's different). I can see in the code that curator doesn't respect the value of the `ssl_no_validate` config param in this specific case.

I'm deleting the override as I don't see any reason to force the value to be True 