### PR TITLE
curator version compatibility

### DIFF
--- a/docs/asciidoc/versions.asciidoc
+++ b/docs/asciidoc/versions.asciidoc
@@ -45,6 +45,12 @@ The current version of Curator is {curator_version}
 |&emsp14; &#10060;
 |&emsp14; &#10060;
 |&emsp14; &#9989;
+|&emsp14; &#10060;
+
+|&emsp14; &emsp14; &emsp14; &emsp14; &emsp14; 5.4+
+|&emsp14; &#10060;
+|&emsp14; &#10060;
+|&emsp14; &#9989;
 |&emsp14; &#9989;
 |===
 


### PR DESCRIPTION
hello,
according to curator compatibility matrix (https://github.com/elastic/curator) elasticsearch 6 is compatible with curator 5.4+.

Fixes #

## Proposed Changes

  -
  -
  -
