### PR TITLE
Update CI and changelog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 
@@ -13,8 +12,10 @@ env:
   - ES_VERSION=5.3.3
   - ES_VERSION=5.4.3
   - ES_VERSION=5.5.2
-  - ES_VERSION=5.6.5
-  - ES_VERSION=6.0.0
+  - ES_VERSION=5.6.8
+  - ES_VERSION=6.0.1
+  - ES_VERSION=6.1.3
+  - ES_VERSION=6.2.2
 
 os: linux
 

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -15,11 +15,17 @@ Changelog
     finished being relocated and it will not wait for the cluster to 
     rebalance. #1129 (tschroeder-zendesk)
   * Work around for extremely large cluster states. #1142 (rewiko)
+  * Add CI tests for Elasticsearch versions 6.1 and 6.2 (untergeek)
 
 **Bug Fixes**
 
   * Fix missing node information in log line. #1142 (untergeek)
+  * Fix default options in code that were causing schema validation errors
+    after ``voluptuous`` upgrade to 0.11.1. Reported in #1149, fixed in #1156 (untergeek) 
 
+**General**
+
+  * Deprecate testing for Python 3.4.  It is no longer being supported by Python.
 
 5.4.1 (6 December 2017)
 -----------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
 

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,6 @@ try:
             "Operating System :: OS Independent",
             "Programming Language :: Python",
             "Programming Language :: Python :: 2.7",
-            "Programming Language :: Python :: 3.4",
             "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",
         ],

--- a/travis-run.sh
+++ b/travis-run.sh
@@ -44,6 +44,7 @@ java_home='/usr/lib/jvm/java-8-oracle'
 LC=elasticsearch/localcluster
 mkdir -p $LC
 cp elasticsearch/config/log4j2.properties $LC
+cp elasticsearch/config/jvm.options $LC
 echo 'network.host: 127.0.0.1' > $LC/elasticsearch.yml
 echo 'http.port: 9200' >> $LC/elasticsearch.yml
 echo 'cluster.name: local' >> $LC/elasticsearch.yml
@@ -56,6 +57,7 @@ echo 'reindex.remote.whitelist: localhost:9201' >> $LC/elasticsearch.yml
 RC=elasticsearch/remotecluster
 mkdir -p $RC
 cp elasticsearch/config/log4j2.properties $RC
+cp elasticsearch/config/jvm.options $RC
 echo 'network.host: 127.0.0.1' > $RC/elasticsearch.yml
 echo 'http.port: 9201' >> $RC/elasticsearch.yml
 echo 'cluster.name: remote' >> $RC/elasticsearch.yml


### PR DESCRIPTION
This updates tested versions and removes support for Python 3.4, which is no longer supported or updated.