### PR TITLE
Fix doc links to field_stats API

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -35,6 +35,8 @@ Changelog
 **Documentation**
 
   * Correct a misunderstanding about the nature of rollover conditions. #1144 (untergeek)
+  * Correct links to the field_stats API, as it is non-existent in Elasticsearch
+    6.x. (untergeek)
 
 5.4.1 (6 December 2017)
 -----------------------

--- a/docs/asciidoc/filter_elements.asciidoc
+++ b/docs/asciidoc/filter_elements.asciidoc
@@ -374,10 +374,13 @@ The value of this setting must be a timestamp field name.  This field must be
 present in the indices being filtered or an exception will be raised, and
 execution will halt.
 
-`field_stats` uses the {ref}/search-field-stats.html[Field Stats API] to
-calculate either the `min_value` or the `max_value` of the <<fe_field,`field`>>
+In Curator 5.3 and older, source `field_stats` uses the
+http://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-field-stats.html[Field Stats API]
+to calculate either the `min_value` or the `max_value` of the <<fe_field,`field`>>
 as the <<fe_stats_result,`stats_result`>>, and then use that value for age
-comparisons.
+comparisons.  In 5.4 and above, even though it is still called `field_stats`, it
+uses an aggregation to calculate the same values, as the `field_stats` API is
+no longer used in Elasticsearch 6.x and up.
 
 This setting is only used when <<fe_source,source>> is `field_stats`.
 
@@ -406,7 +409,7 @@ NOTE: This setting is only available in the <<filtertype_age,period>> filtertype
 
 The value of this setting must be `True` or `False`.
 
-`field_stats` uses the {ref}/search-field-stats.html[Field Stats API] to
+`field_stats` uses an aggregation query to
 calculate either the `min_value` and the `max_value` of the <<fe_field,`field`>>
 as the <<fe_stats_result,`stats_result`>>.  If `intersect` is `True`, then
 only indices where the `min_value` _and_ the `max_value` are within the `range_from`

--- a/docs/asciidoc/inc_sources.asciidoc
+++ b/docs/asciidoc/inc_sources.asciidoc
@@ -33,10 +33,13 @@ include::inc_timestring_regex.asciidoc[]
 
 NOTE: `source` can only be `field_stats` when filtering indices.
 
-`field_stats` uses the {ref}/search-field-stats.html[Field Stats API] to
-calculate either the `min_value` or the `max_value` of the <<fe_field,`field`>>
+In Curator 5.3 and older, source `field_stats` uses the
+http://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-field-stats.html[Field Stats API]
+to calculate either the `min_value` or the `max_value` of the <<fe_field,`field`>>
 as the <<fe_stats_result,`stats_result`>>, and then use that value for age
-comparisons.
+comparisons.  In 5.4 and above, even though it is still called `field_stats`, it
+uses an aggregation to calculate the same values, as the `field_stats` API is
+no longer used in Elasticsearch 6.x and up.
 
 <<fe_field,`field`>> must be of type `date` in Elasticsearch.
 


### PR DESCRIPTION
Which no longer appears in 6.x
