### PR TITLE
Add timeout_override for delete_snapshots

### DIFF
--- a/curator/defaults/option_defaults.py
+++ b/curator/defaults/option_defaults.py
@@ -277,6 +277,8 @@ def timeout_override(action):
         value = 21600
     elif action == 'close':
         value = 180
+    elif action == 'delete_snapshots':
+        value = 300
     else:
         value = None
 

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -27,6 +27,9 @@ Changelog
     after ``voluptuous`` upgrade to 0.11.1. Reported in #1149, fixed in #1156 (untergeek) 
   * Disallow empty lists as reindex source.  Raise exception if that happens.
     Reported in #1139 (untergeek)
+  * Set a ``timeout_override`` for ``delete_snapshots`` to catch cases where
+    slower repository network and/or disk access can cause a snapshot delete
+    to take longer than the default 30 second client timeout. #1133 (untergeek)
 
 **General**
 

--- a/docs/asciidoc/options.asciidoc
+++ b/docs/asciidoc/options.asciidoc
@@ -2552,18 +2552,16 @@ filters:
 - filtertype: ...
 -------------
 
-Actions <<snapshot,snapshot>>, <<restore,restore>>, and
-    <<forcemerge,forcemerge>> will override this value to `21600` if
-    `timeout_override` is unset.  The <<close,close>> action will override the
-    value to 180 if unset.
+If `timeout_override` is unset in your configuration, some actions will
+try to set a sane default value.
 
-Some actions have a default value for `timeout_override`. The following table
-shows these default values:
+The following table shows these default values:
 
 [cols="m,", options="header"]
 |===
 |Action Name |Default `timeout_override` Value
 |close |180
+|delete_snapshots |300
 |forcemerge |21600
 |restore |21600
 |snapshot |21600


### PR DESCRIPTION
This helps with the case identified in #1133

Fixes #1133


