### PR TITLE
Last minute addition to log an error

### DIFF
--- a/curator/utils.py
+++ b/curator/utils.py
@@ -880,8 +880,12 @@ def get_client(**kwargs):
         logger.debug('Not using "requests_aws4auth" python module to connect.')
     if master_only:
         if len(kwargs['hosts']) > 1:
+            logger.error(
+                '"master_only" cannot be true if more than one host is '
+                'specified. Hosts = {0}'.format(kwargs['hosts'])
+            )
             raise ConfigurationError(
-                '"master_only" cannot be True if more than one host is '
+                '"master_only" cannot be true if more than one host is '
                 'specified. Hosts = {0}'.format(kwargs['hosts'])
             )
     try:

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -40,6 +40,8 @@ Changelog
 **General**
 
   * Deprecate testing for Python 3.4.  It is no longer being supported by Python.
+  * Increase logging to show error when ``master_only`` is true and there are 
+    multiple hosts.
 
 **Documentation**
 


### PR DESCRIPTION
The exception is being raised, but no message shown when multiple hosts are specified and `master_only` is set to true.

