### PR TITLE
Fix Replicas and Forcemerge to check closed first

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -570,9 +570,10 @@ class ForceMerge(object):
         """
         forcemerge indices in `index_list.indices`
         """
-        self.index_list.empty_list_check()
+        self.index_list.filter_closed()
         self.index_list.filter_forceMerged(
             max_num_segments=self.max_num_segments)
+        self.index_list.empty_list_check()
         self.loggit.info('forceMerging selected indices')
         try:
             for index_name in self.index_list.indices:
@@ -800,12 +801,12 @@ class Replicas(object):
         """
         Update the replica count of indices in `index_list.indices`
         """
-        self.index_list.empty_list_check()
         self.loggit.debug(
             'Cannot get update replica count of closed indices.  '
             'Omitting any closed indices.'
         )
         self.index_list.filter_closed()
+        self.index_list.empty_list_check()
         self.loggit.info(
             'Setting the replica count to {0} for indices: '
             '{1}'.format(self.count, self.index_list.indices)

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -36,6 +36,8 @@ Changelog
   * Add missing ``period`` filter arguments for ``delete_snapshots``. Reported in 
     #1173 (untergeek)
   * Fix kibana filtertype to catch newer index names. Reported in #1171 (untergeek)
+  * Re-order the closed indices filter for the Replicas action to take place
+    `before` the empty list check. Reported in #1180 by ``@agomerz`` (untergeek)
 
 **General**
 


### PR DESCRIPTION
Ordering of the filter_closed and empty_list_check were resulting in an empty list being passed to the action.

fixes #1180
