### PR TITLE
Clarify inclusive filtering for allocated filter

### DIFF
--- a/docs/asciidoc/filters.asciidoc
+++ b/docs/asciidoc/filters.asciidoc
@@ -231,6 +231,11 @@ indices based on their shard routing allocation settings.  They will remain in,
 or be removed from the actionable list based on the value of
 <<fe_exclude,exclude>>.
 
+
+By default the indices matched by the `allocated` filter will be excluded since the `exclude` setting defaults to `True`.
+
+To include matching indices rather than exclude, set the `exclude` setting to `False`.
+
 === Required settings
 
 * <<fe_key,key>>


### PR DESCRIPTION
Doc fix to make it more obvious how to include the matched indices.

It might not currently be as obvious as it could be:
- https://discuss.elastic.co/t/curator-allocated-filtertype-does-not-seem-to-work/118899/8
- https://discuss.elastic.co/t/curator-allocation-filters/128437

So hopefully this reduces some amount of headscratching.