### PR TITLE
Issue 1209 - don't fail on empty action when ignore_empty_list is True

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -143,8 +143,10 @@ class Alias(object):
                     )
                 )
         except ActionError as e:
-            if opts['ignore_empty_list'] or opts['warn_if_no_indices']:
+            if opts['ignore_empty_list']:
                 self.loggit.info('DRY-RUN: alias: No changes to be made. `ignore_empty_list` is true, skipping.')
+            elif opts['warn_if_no_indices']:
+                self.loggit.warn('DRY-RUN: alias: No changes to be made. `warn_if_no_indices` is true, skipping.')
             else:
                 report_failure(e)
 
@@ -157,8 +159,10 @@ class Alias(object):
             self.loggit.info('Alias actions: {0}'.format(self.body()))
             self.client.indices.update_aliases(body=self.body())
         except ActionError as e:
-            if opts['ignore_empty_list'] or opts['warn_if_no_indices']:
+            if opts['ignore_empty_list']:
                 pass
+            elif opts['warn_if_no_indices']:
+                self.loggit.warn('Alias: No changes to be made. `warn_if_no_indices` is true, skipping.')
             else:
                 report_failure(e)
         except Exception as e:

--- a/curator/actions.py
+++ b/curator/actions.py
@@ -143,7 +143,7 @@ class Alias(object):
                     )
                 )
         except ActionError as e:
-            if opts['ignore_empty_list']:
+            if opts['ignore_empty_list'] or opts['warn_if_no_indices']:
                 self.loggit.info('DRY-RUN: alias: No changes to be made. `ignore_empty_list` is true, skipping.')
             else:
                 report_failure(e)
@@ -157,7 +157,7 @@ class Alias(object):
             self.loggit.info('Alias actions: {0}'.format(self.body()))
             self.client.indices.update_aliases(body=self.body())
         except ActionError as e:
-            if opts['ignore_empty_list']:
+            if opts['ignore_empty_list'] or opts['warn_if_no_indices']:
                 pass
             else:
                 report_failure(e)

--- a/curator/actions.py
+++ b/curator/actions.py
@@ -143,9 +143,7 @@ class Alias(object):
                     )
                 )
         except ActionError as e:
-            if opts['ignore_empty_list']:
-                self.loggit.info('DRY-RUN: alias: No changes to be made. `ignore_empty_list` is true, skipping.')
-            elif opts['warn_if_no_indices']:
+            if opts['warn_if_no_indices']:
                 self.loggit.warn('DRY-RUN: alias: No changes to be made. `warn_if_no_indices` is true, skipping.')
             else:
                 report_failure(e)
@@ -159,9 +157,7 @@ class Alias(object):
             self.loggit.info('Alias actions: {0}'.format(self.body()))
             self.client.indices.update_aliases(body=self.body())
         except ActionError as e:
-            if opts['ignore_empty_list']:
-                pass
-            elif opts['warn_if_no_indices']:
+            if opts['warn_if_no_indices']:
                 self.loggit.warn('Alias: No changes to be made. `warn_if_no_indices` is true, skipping.')
             else:
                 report_failure(e)

--- a/curator/actions.py
+++ b/curator/actions.py
@@ -158,7 +158,7 @@ class Alias(object):
             self.client.indices.update_aliases(body=self.body())
         except ActionError as e:
             if opts['warn_if_no_indices']:
-                self.loggit.warn('Alias: No changes to be made. `warn_if_no_indices` is true, skipping.')
+                raise NoIndices()
             else:
                 report_failure(e)
         except Exception as e:

--- a/curator/cli.py
+++ b/curator/cli.py
@@ -94,10 +94,10 @@ def process_action(client, config, **kwargs):
         action_obj = action_class(ilo, **mykwargs)
     ### Do the action
     if 'dry_run' in kwargs and kwargs['dry_run'] == True:
-        action_obj.do_dry_run()
+        action_obj.do_dry_run(opts)
     else:
         logger.debug('Doing the action here.')
-        action_obj.do_action()
+        action_obj.do_action(opts)
 
 def run(config, action_file, dry_run=False):
     """


### PR DESCRIPTION
Fixes #1209 

## Proposed Changes
I think this should use `ignore_empty_list` but I'm not sure what is the semantic difference compared to `warn_if_no_indices`. Maybe should check for both?