### PR TITLE
Fix ignore_empty_list with Alias action

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,12 @@ cache:
 jdk:
   - oraclejdk8
 
+before_install:
+  - cp requirements.txt ..
+  - cd ..
+  - pip install -r requirements.txt
+  - cd -
+
 install:
   - pip install -U setuptools
   - pip install -r requirements.txt

--- a/curator/actions.py
+++ b/curator/actions.py
@@ -32,6 +32,9 @@ class Alias(object):
         #: Any extra things to add to the alias, like filters, or routing.
         self.extra_settings = extra_settings
         self.loggit  = logging.getLogger('curator.actions.alias')
+        #: Instance variable.
+        #: Preset default value to `False`.
+        self.warn_if_no_indices = False
 
     def add(self, ilo, warn_if_no_indices=False):
         """
@@ -50,6 +53,7 @@ class Alias(object):
         except NoIndices:
             # Add a warning if there are no indices to add, if so set in options
             if warn_if_no_indices:
+                self.warn_if_no_indices = True
                 self.loggit.warn(
                     'No indices found after processing filters. '
                     'Nothing to add to {0}'.format(self.name)
@@ -83,6 +87,7 @@ class Alias(object):
         except NoIndices:
             # Add a warning if there are no indices to add, if so set in options
             if warn_if_no_indices:
+                self.warn_if_no_indices = True
                 self.loggit.warn(
                     'No indices found after processing filters. '
                     'Nothing to remove from {0}'.format(self.name)
@@ -116,7 +121,10 @@ class Alias(object):
         call.
         """
         if not self.actions:
-            raise ActionError('No "add" or "remove" operations')
+            if not self.warn_if_no_indices:
+                raise ActionError('No "add" or "remove" operations')
+            else:
+                raise NoIndices('No "adds" or "removes" found.  Taking no action')
         self.loggit.debug('Alias actions: {0}'.format(self.actions))
 
         return { 'actions' : self.actions }

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -21,6 +21,9 @@ Changelog
   * Fix reference to unset variable name in log output at
     https://github.com/elastic/curator/blob/v5.5.1/curator/actions.py#L2145
     It should be `idx` instead of `index`. (untergeek).
+  * Alias action should raise `NoIndices` exception if `warn_if_no_indices` is
+    `True`, and no `add` or `remove` sub-actions are found, rather than raising
+    an `ActionError`
 
 **Documentation**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ elasticsearch>=5.5.2,!=6.0.0,<7.0.0
 click>=6.7
 pyyaml>=3.10
 certifi>=2018.4.16
+six==1.11.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ install_requires =
     click>=6.7
     pyyaml>=3.10
     certifi>=2018.4.16
+    six==1.11.0
 
 setup_requires =
     voluptuous>=0.9.3
@@ -32,6 +33,7 @@ setup_requires =
     click>=6.7
     pyyaml>=3.10
     certifi>=2018.4.16
+    six==1.11.0
 
 packages = curator
 include_package_data = True

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ def get_install_requires():
     res.append('pyyaml>=3.10')
     res.append('voluptuous>=0.9.3')
     res.append('certifi>=2018.4.16')
+    res.append('six==1.11.0')
     return res
 
 try:

--- a/test/unit/test_action_alias.py
+++ b/test/unit/test_action_alias.py
@@ -14,7 +14,7 @@ class TestActionAlias(TestCase):
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
-        ilo = curator.IndexList(client)
+        _ = curator.IndexList(client)
         ao = curator.Alias(name='alias')
         self.assertRaises(TypeError, ao.add)
     def test_add_raises_on_invalid_parameter(self):
@@ -23,7 +23,7 @@ class TestActionAlias(TestCase):
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
-        ilo = curator.IndexList(client)
+        _ = curator.IndexList(client)
         ao = curator.Alias(name='alias')
         self.assertRaises(TypeError, ao.add, [])
     def test_add_single(self):
@@ -32,9 +32,9 @@ class TestActionAlias(TestCase):
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
-        ilo = curator.IndexList(client)
+        _ = curator.IndexList(client)
         ao = curator.Alias(name='alias')
-        ao.add(ilo)
+        ao.add(_)
         self.assertEqual(testvars.alias_one_add, ao.actions)
     def test_add_single_with_extra_settings(self):
         client = Mock()
@@ -42,12 +42,12 @@ class TestActionAlias(TestCase):
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
-        ilo = curator.IndexList(client)
+        _ = curator.IndexList(client)
         esd = {
             'filter' : { 'term' : { 'user' : 'kimchy' } }
         }
         ao = curator.Alias(name='alias', extra_settings=esd)
-        ao.add(ilo)
+        ao.add(_)
         self.assertEqual(testvars.alias_one_add_with_extras, ao.actions)
     def test_remove_single(self):
         client = Mock()
@@ -56,9 +56,9 @@ class TestActionAlias(TestCase):
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
         client.indices.get_alias.return_value = testvars.settings_1_get_aliases
-        ilo = curator.IndexList(client)
+        _ = curator.IndexList(client)
         ao = curator.Alias(name='my_alias')
-        ao.remove(ilo)
+        ao.remove(_)
         self.assertEqual(testvars.alias_one_rm, ao.actions)
     def test_add_multiple(self):
         client = Mock()
@@ -66,9 +66,9 @@ class TestActionAlias(TestCase):
         client.indices.get_settings.return_value = testvars.settings_two
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
-        ilo = curator.IndexList(client)
+        _ = curator.IndexList(client)
         ao = curator.Alias(name='alias')
-        ao.add(ilo)
+        ao.add(_)
         cmp = sorted(ao.actions, key=lambda k: k['add']['index'])
         self.assertEqual(testvars.alias_two_add, cmp)
     def test_remove_multiple(self):
@@ -78,20 +78,32 @@ class TestActionAlias(TestCase):
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
         client.indices.get_alias.return_value = testvars.settings_2_get_aliases
-        ilo = curator.IndexList(client)
+        _ = curator.IndexList(client)
         ao = curator.Alias(name='my_alias')
-        ao.remove(ilo)
+        ao.remove(_)
         cmp = sorted(ao.actions, key=lambda k: k['remove']['index'])
         self.assertEqual(testvars.alias_two_rm, cmp)
-    def test_raise_on_empty_body(self):
+    def test_raise_action_error_on_empty_body(self):
         client = Mock()
         client.info.return_value = {'version': {'number': '5.0.0'} }
         client.indices.get_settings.return_value = testvars.settings_one
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
-        ilo = curator.IndexList(client)
+        _ = curator.IndexList(client)
         ao = curator.Alias(name='alias')
         self.assertRaises(curator.ActionError, ao.body)
+    def test_raise_no_indices_on_empty_body_when_warn_if_no_indices(self):
+        client = Mock()
+        client.info.return_value = {'version': {'number': '5.0.0'} }
+        client.indices.get_settings.return_value = testvars.settings_one
+        client.cluster.state.return_value = testvars.clu_state_one
+        client.indices.stats.return_value = testvars.stats_one
+        _ = curator.IndexList(client)
+        # empty it, so there can be no body
+        _.indices = []
+        ao = curator.Alias(name='alias')
+        ao.add(_, warn_if_no_indices=True)
+        self.assertRaises(curator.NoIndices, ao.body)
     def test_do_dry_run(self):
         client = Mock()
         client.info.return_value = {'version': {'number': '5.0.0'} }
@@ -99,9 +111,9 @@ class TestActionAlias(TestCase):
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
         client.indices.update_aliases.return_value = testvars.alias_success
-        ilo = curator.IndexList(client)
+        _ = curator.IndexList(client)
         ao = curator.Alias(name='alias')
-        ao.add(ilo)
+        ao.add(_)
         self.assertIsNone(ao.do_dry_run())
     def test_do_action(self):
         client = Mock()
@@ -110,9 +122,9 @@ class TestActionAlias(TestCase):
         client.cluster.state.return_value = testvars.clu_state_one
         client.indices.stats.return_value = testvars.stats_one
         client.indices.update_aliases.return_value = testvars.alias_success
-        ilo = curator.IndexList(client)
+        _ = curator.IndexList(client)
         ao = curator.Alias(name='alias')
-        ao.add(ilo)
+        ao.add(_)
         self.assertIsNone(ao.do_action())
     def test_do_action_raises_exception(self):
         client = Mock()
@@ -122,7 +134,7 @@ class TestActionAlias(TestCase):
         client.indices.stats.return_value = testvars.stats_one
         client.indices.update_aliases.return_value = testvars.alias_success
         client.indices.update_aliases.side_effect = testvars.four_oh_one
-        ilo = curator.IndexList(client)
+        _ = curator.IndexList(client)
         ao = curator.Alias(name='alias')
-        ao.add(ilo)
+        ao.add(_)
         self.assertRaises(curator.FailedExecution, ao.do_action)


### PR DESCRIPTION
If `ignore_empty_list` is `true`, Curator should respect that and not raise an `ActionError`

Did some virtualenv testing and found that not specifying `six` in requirements.txt resulted in execution errors.

Restored the `before_install` block to `.travis.yml`.  Before this, it worked for _each_ run, _except_ for the elasticsearch 6.2.4 tests, which I cannot explain.  Best to keep it, since it works.

fixes #1209
