### PR TITLE
add extra pip packages to requirements for es aws

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ click>=6.7
 pyyaml>=3.10
 voluptuous>=0.9.3
 certifi>=2017.7.27.1
+boto3>=1.7.28
+requests-aws4auth>=0.9


### PR DESCRIPTION
Fixes #

Errors at runtime when trying to use aws es due to missing deps.

## Proposed Changes

Add required requirements for AWS elasticsearch.
At the moment if you don't install these dependencies and are trying to sign aws requests, the code errors at runtime.
