### PR TITLE
Update Dockerfile to python:2.7.15-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Docker Definition for ElasticSearch Curator
 
-FROM python:2.7.8-slim
+FROM python:2.7.15-slim
 MAINTAINER Christian R. Vozar <christian@rogueethic.com>
 
 RUN pip install --quiet elasticsearch-curator


### PR DESCRIPTION

## Proposed Changes

  - update Dockerfile FROM line to current 2.7.15-slim base image.

I could also change it to `python:2.7-slim` so that it updates when there are patches...