### PR TITLE
Added filtertype 'empty' to support filter empty indices

### DIFF
--- a/curator/defaults/filtertypes.py
+++ b/curator/defaults/filtertypes.py
@@ -138,3 +138,8 @@ def state(action, config):
         filter_elements.state(),
         filter_elements.exclude(),
     ]
+
+def empty(action, config):
+    return [
+        filter_elements.exclude(),
+    ]

--- a/curator/defaults/settings.py
+++ b/curator/defaults/settings.py
@@ -72,6 +72,7 @@ def index_filtertypes():
         'age',
         'closed',
         'count',
+        'empty',
         'forcemerged',
         'ilm',
         'kibana',

--- a/curator/indexlist.py
+++ b/curator/indexlist.py
@@ -96,6 +96,7 @@ class IndexList(object):
             'allocated': self.filter_allocated,
             'closed': self.filter_closed,
             'count': self.filter_by_count,
+            'empty': self.filter_empty,
             'forcemerged': self.filter_forceMerged,
             'ilm': self.filter_ilm,
             'kibana': self.filter_kibana,

--- a/docs/asciidoc/filters.asciidoc
+++ b/docs/asciidoc/filters.asciidoc
@@ -15,6 +15,7 @@ The index filtertypes are:
 * <<filtertype_allocated,allocated>>
 * <<filtertype_closed,closed>>
 * <<filtertype_count,count>>
+* <<filtertype_empty,empty>>
 * <<filtertype_forcemerged,forcemerged>>
 * <<filtertype_kibana,kibana>>
 * <<filtertype_none,none>>
@@ -69,6 +70,7 @@ The index filtertypes are:
 * <<filtertype_allocated,allocated>>
 * <<filtertype_closed,closed>>
 * <<filtertype_count,count>>
+* <<filtertype_empty,empty>>
 * <<filtertype_forcemerged,forcemerged>>
 * <<filtertype_kibana,kibana>>
 * <<filtertype_none,none>>
@@ -440,6 +442,26 @@ removed from the actionable list, leaving `index-2017.03.03`,
 * <<fe_field,field>> (required if `source` is `field_stats`)
 * <<fe_stats_result,stats_result>> (only used if `source` is `field_stats`)
 
+
+[[filtertype_empty]]
+== empty
+[source,yaml]
+-------------
+- filtertype: empty
+  exclude: False
+-------------
+
+This <<filtertype,filtertype>> will iterate over the actionable list and match
+indices which does not contain any documents.  They will remain in, or be
+removed from the actionable list based on the value of <<fe_exclude,exclude>>.
+
+By default the indices matched by the empty filter will be excluded since 
+the exclude setting defaults to True. To include matching indices rather than
+exclude, set the exclude setting to False.
+
+=== Optional settings
+
+* <<fe_exclude,exclude>> (default is `True`)
 
 
 [[filtertype_forcemerged]]


### PR DESCRIPTION
## Proposed Changes
Added filtertype: empty to support filtering of empty indices.

The function was already created, I have only exposed it as a filtertype and added documentation.