### PR TITLE
Fix YAML linting/error display

### DIFF
--- a/curator/utils.py
+++ b/curator/utils.py
@@ -46,15 +46,15 @@ def get_yaml(path):
         else:
             envvar = proto
         return os.environ[envvar] if envvar in os.environ else default
-    yaml.add_constructor('!single', single_constructor)
 
-    raw = read_file(path)
+    yaml.add_constructor('!single', single_constructor)
+    
     try:
-        cfg = yaml.load(raw)
-    except yaml.scanner.ScannerError as e:
-        raise exceptions.ConfigurationError(
-            'Unable to parse YAML file. Error: {0}'.format(e))
-    return cfg
+        return yaml.load(read_file(path))
+    except yaml.scanner.ScannerError as err:
+        print('Unable to read/parse YAML file: {0}'.format(path))
+        print(err)
+        sys.exit(1)
 
 def test_client_options(config):
     """

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -11,6 +11,11 @@ Changelog
   * The ``empty`` filter has been exposed for general use.  This filter matches
     indices with no documents. (jrask) #1264
 
+**Bug Fixes**
+
+  * Fix YAML linting so that YAML errors are caught and displayed on the
+    command line. Reported in #1237 (untergeek)
+
 **Documentation**
 
   * Added Reindex example to the sidebar. (Nostalgiac) #1227

--- a/test/unit/test_cli_methods.py
+++ b/test/unit/test_cli_methods.py
@@ -57,8 +57,9 @@ class TestCLI_B(CLITestCase):
         self.assertEqual('localhost', cfg['client']['hosts'])
         self.assertEqual(9200, cfg['client']['port'])
     def test_read_file_corrupt_fail(self):
-        self.assertRaises(curator.ConfigurationError,
-            curator.get_yaml, self.args['invalid_yaml'])
+        with self.assertRaises(SystemExit) as get:
+            curator.get_yaml(self.args['invalid_yaml'])
+        self.assertEqual(get.exception.code, 1)
     def test_read_file_missing_fail(self):
         self.assertRaises(
             curator.FailedExecution,


### PR DESCRIPTION
This should have been here a long time ago.  It kind of was, but something about how Click was being used and the other methods being wrapped caused it to be hidden.

This brings what was hidden back into plain sight.

Fixes #1237 
