### PR TITLE
allow old epoch timestamps with 11-13 digits as epoch + milliseconds

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -83,3 +83,4 @@ Contributors:
 * Timothy Schroder (tschroeder-zendesk)
 * Jared Carey (jpcarey)
 * Juraj Seffer (jurajseffer)
+* Roger Steneteg (rsteneteg)

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -235,11 +235,12 @@ def fix_epoch(epoch):
         even nanoseconds.
     :rtype: int
     """
-    if not isinstance(epoch, int):
-        raise ValueError('Invalid epoch datatype received, expected an int')
+    try:
+        # No decimals allowed
+        epoch = int(epoch)
+    except Exception as ex:
+        raise ValueError('Invalid epoch received, unable to convert {} to int'.format(epoch))
 
-    # No decimals allowed
-    epoch = int(epoch)
     # If we're still using this script past January, 2038, we have bigger
     # problems than my hacky math here...
     if len(str(epoch)) <= 10:

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -235,19 +235,17 @@ def fix_epoch(epoch):
         even nanoseconds.
     :rtype: int
     """
+    if not isinstance(epoch, int):
+        raise ValueError('Invalid epoch datatype received, expected an int')
+
     # No decimals allowed
     epoch = int(epoch)
     # If we're still using this script past January, 2038, we have bigger
     # problems than my hacky math here...
     if len(str(epoch)) <= 10:
         return epoch
-    elif len(str(epoch)) == 13:
+    elif len(str(epoch)) > 10 and len(str(epoch)) <= 13:
         return int(epoch/1000)
-    elif len(str(epoch)) > 10 and len(str(epoch)) < 13:
-        raise ValueError(
-            'Unusually formatted epoch timestamp.  '
-            'Should be 10, 13, or more digits'
-        )
     else:
         orders_of_magnitude = len(str(epoch)) - 10
         powers_of_ten = 10**orders_of_magnitude

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -154,8 +154,7 @@ class TestFixEpoch(TestCase):
                 ]:
             self.assertEqual(epoch, curator.fix_epoch(long_epoch))
     def test_fix_epoch_raise(self):
-        for invalid_type in [None, "1459287636"]:
-            self.assertRaises(ValueError, curator.fix_epoch, invalid_type)
+            self.assertRaises(ValueError, curator.fix_epoch, None)
 
 class TestGetPointOfReference(TestCase):
     def test_get_point_of_reference(self):

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -143,16 +143,19 @@ class TestGetDateRegex(TestCase):
 class TestFixEpoch(TestCase):
     def test_fix_epoch(self):
         for long_epoch, epoch in [
+            (1459287636, 1459287636),
+            (14592876369, 14592876),
+            (145928763699, 145928763),
             (1459287636999, 1459287636),
             (1459287636000000, 1459287636),
             (145928763600000000, 1459287636),
             (145928763600000001, 1459287636),
             (1459287636123456789, 1459287636),
-            (1459287636999, 1459287636),
                 ]:
             self.assertEqual(epoch, curator.fix_epoch(long_epoch))
     def test_fix_epoch_raise(self):
-        self.assertRaises(ValueError, curator.fix_epoch, 12345678901)
+        for invalid_type in [None, "1459287636"]:
+            self.assertRaises(ValueError, curator.fix_epoch, invalid_type)
 
 class TestGetPointOfReference(TestCase):
     def test_get_point_of_reference(self):


### PR DESCRIPTION
Fixes #1295 

## Proposed Changes
Classify all timestamp with 11 to 13 digits as epoch + milliseconds
