### PR TITLE
Fix rollover example text

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -26,6 +26,7 @@ Changelog
 **Documentation**
 
   * Added Reindex example to the sidebar. (Nostalgiac) #1227
+  * Fix Rollover example text and typos. (untergeek)
 
 5.5.4 (23 May 2018)
 -------------------

--- a/docs/asciidoc/examples.asciidoc
+++ b/docs/asciidoc/examples.asciidoc
@@ -707,18 +707,18 @@ actions:
   1:
     action: rollover
     description: >-
-      Rollover the index associated with index 'name', which should be in the
-      form of prefix-000001 (or similar), or prefix-YYYY.MM.DD-1.
+      Rollover the index associated with alias 'aliasname', which should be in the
+      format of prefix-000001 (or similar), or prefix-YYYY.MM.DD-1.
     options:
       disable_action: True
       name: aliasname
       conditions:
         max_age: 1d
         max_docs: 1000000
+        max_size: 50g
       extra_settings:
         index.number_of_shards: 3
         index.number_of_replicas: 1
-      disable_action: True
 -------------
 
 


### PR DESCRIPTION
Wording fixes and a typo. Remove superfluous disable_action line.
