### PR TITLE
Catch reindex failures and raise an exception

### DIFF
--- a/curator/exceptions.py
+++ b/curator/exceptions.py
@@ -53,3 +53,8 @@ class FailedRestore(CuratorException):
     """
     Exception raised when a Snapshot Restore does not restore all selected indices
     """
+
+class FailedReindex(CuratorException):
+    """
+    Exception raised when failures are found in the reindex task response
+    """

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -1640,6 +1640,16 @@ def task_check(client, task_id=None):
         )
     task = task_data['task']
     completed = task_data['completed']
+    if task['action'] == 'indices:data/write/reindex':
+        logger.debug('It\'s a REINDEX TASK')
+        logger.debug('TASK_DATA: {0}'.format(task_data))
+        logger.debug('TASK_DATA keys: {0}'.format(list(task_data.keys())))
+        if 'response' in task_data:
+            response = task_data['response']
+            if len(response['failures']) > 0:
+                raise exceptions.FailedReindex(
+                    'Failures found in reindex response: {0}'.format(response['failures'])
+                )
     running_time = 0.000000001 * task['running_time_in_nanos']
     logger.debug('running_time_in_nanos = {0}'.format(running_time))
     descr = task['description']

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -23,6 +23,7 @@ Changelog
   * Allow much older epoch timestamps (rsteneteg) #1296
   * Reindex action respects ``ignore_empty_list`` flag (untergeek) #1297
   * Update ILM index version minimum to 6.6.0 (untergeek)
+  * Catch reindex failures properly. Reported in #1260 (untergeek)
 
 **Documentation**
 


### PR DESCRIPTION
This addresses the failure scenario outlined so clearly in the listed issue.
A similar mapping error was injected as a new integration test to prove that an exception will be raised in the future.

fixes #1260
