### PR TITLE
Update wget version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN pip3 install -r requirements.txt
 RUN python3 setup.py build_exe
 
 FROM alpine:3.6
-RUN apk --no-cache upgrade && apk --no-cache add ca-certificates
+RUN apk --no-cache upgrade && apk --no-cache add ca-certificates && update-ca-certificates && apk --no-cache add wget
 COPY --from=builder build/exe.linux-x86_64-3.6 /curator/
 USER nobody:nobody
 ENTRYPOINT ["/curator/curator"]


### PR DESCRIPTION
Fixes wget errors when getting https pages

- Run update-ca-certificates and upate wget package. Without these changes you get the following error when try to get a HTTPS site

$ wget https://site.org
wget: error getting response: Connection reset by peer

