### PR TITLE
Use re.search() not re.match() in pattern filter so regex doesn't have to be a prefix

### DIFF
--- a/curator/indexlist.py
+++ b/curator/indexlist.py
@@ -448,7 +448,7 @@ class IndexList(object):
         pattern = re.compile(regex)
         for index in self.working_list():
             self.loggit.debug('Filter by regex: Index: {0}'.format(index))
-            match = pattern.match(index)
+            match = pattern.search(index)
             if match:
                 self.__excludify(True, exclude, index)
             else:

--- a/curator/snapshotlist.py
+++ b/curator/snapshotlist.py
@@ -233,7 +233,7 @@ class SnapshotList(object):
         self.empty_list_check()
         pattern = re.compile(regex)
         for snapshot in self.working_list():
-            match = pattern.match(snapshot)
+            match = pattern.search(snapshot)
             self.loggit.debug('Filter by regex: Snapshot: {0}'.format(snapshot))
             if match:
                 self.__excludify(True, exclude, snapshot)

--- a/test/unit/test_class_index_list.py
+++ b/test/unit/test_class_index_list.py
@@ -138,6 +138,24 @@ class TestIndexListRegexFilters(TestCase):
         )
         il.filter_by_regex(kind='prefix', value='ind', exclude=True)
         self.assertEqual([], il.indices)
+    def test_filter_by_regex_middle(self):
+        client = Mock()
+        client.info.return_value = {'version': {'number': '5.0.0'} }
+        client.indices.get_settings.return_value = testvars.settings_two
+        client.cluster.state.return_value = testvars.clu_state_two
+        client.indices.stats.return_value = testvars.stats_two
+        il = curator.IndexList(client)
+        self.assertEqual(
+            [u'index-2016.03.03', u'index-2016.03.04'],
+            sorted(il.indices)
+        )
+        il.filter_by_regex(kind='regex', value='dex')
+        self.assertEqual(
+            [u'index-2016.03.03', u'index-2016.03.04'],
+            sorted(il.indices)
+        )
+        il.filter_by_regex(kind='regex', value='dex', exclude=True)
+        self.assertEqual([], il.indices)
     def test_filter_by_regex_timestring(self):
         client = Mock()
         client.info.return_value = {'version': {'number': '5.0.0'} }

--- a/test/unit/test_class_snapshot_list.py
+++ b/test/unit/test_class_snapshot_list.py
@@ -108,6 +108,22 @@ class TestSnapshotListRegexFilters(TestCase):
         )
         sl.filter_by_regex(kind='prefix', value='sna', exclude=True)
         self.assertEqual([], sl.snapshots)
+    def test_filter_by_regex_middle(self):
+        client = Mock()
+        client.snapshot.get.return_value = testvars.snapshots
+        client.snapshot.get_repository.return_value = testvars.test_repo
+        sl = curator.SnapshotList(client, repository=testvars.repo_name)
+        self.assertEqual(
+            [u'snap_name', u'snapshot-2015.03.01'],
+            sorted(sl.snapshots)
+        )
+        sl.filter_by_regex(kind='regex', value='shot')
+        self.assertEqual(
+            [u'snapshot-2015.03.01'],
+            sorted(sl.snapshots)
+        )
+        sl.filter_by_regex(kind='regex', value='shot', exclude=True)
+        self.assertEqual([], sl.snapshots)
     def test_filter_by_regex_prefix_exclude(self):
         client = Mock()
         client.snapshot.get.return_value = testvars.snapshots


### PR DESCRIPTION
Fixes #1354 

Issue says it all really: currently regex pattern filters only match against the start of the index name.  The prefix / suffix patterns are fine because they get wrapped with ^<prefix>.*$ etc.