### PR TITLE
Release prep for Curator 5.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
   - ES_VERSION=5.2.2
   - ES_VERSION=5.3.3
   - ES_VERSION=5.4.3
-  - ES_VERSION=5.5.2
-  - ES_VERSION=5.6.8
+  - ES_VERSION=5.5.3
+  - ES_VERSION=5.6.15
   - ES_VERSION=6.0.1
   - ES_VERSION=6.1.3
   - ES_VERSION=6.2.4
@@ -21,7 +21,7 @@ env:
   - ES_VERSION=6.5.4
   - ES_VERSION=6.6.2
   - ES_VERSION=6.7.1
-  - ES_VERSION=7.0.0-rc2-linux-x86_64
+  - ES_VERSION=7.0.0-linux-x86_64
 
 os: linux
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2011–2017 Elasticsearch <http://elastic.co> and contributors.
+Copyright 2011–2019 Elasticsearch <http://elastic.co> and contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,21 +3,30 @@
 Changelog
 =========
 
-5.7.0 (? ? ?)
--------------
+5.7.0 (? April 2019)
+--------------------
 
 **New**
 
+  * Support for ``elasticsearch-py`` 7.0.0 (untergeek)
   * Support for Elasticsearch 7.0 #1371 (untergeek)
   * TravisCI testing for Elasticsearch 6.5, 6.6, 6.7, and 7.0 (untergeek)
+  * Allow shrink action to use multiple data paths #1350 (IzekChen)
 
 **Bug Fixes**
 
+  * Fix ``regex`` pattern filter to use ``re.search`` #1355 (matthewdupre)
   * Report rollover results in both dry-run and regular runs. Requested
     in #1313 (untergeek)
   * Hide passwords in DEBUG logs. Requested in #1336 (untergeek)
   * With ILM fully released, Curator tests now correctly use the
     ``allow_ilm_indices`` option. (untergeek)
+
+**Documentation**
+
+  * Many thanks to those who submitted documentation fixes, both factual as
+    well as typos!
+  
 
 5.6.0 (13 November 2018)
 ------------------------

--- a/docs/asciidoc/index.asciidoc
+++ b/docs/asciidoc/index.asciidoc
@@ -1,8 +1,8 @@
-:curator_version: 5.7.0.dev0
+:curator_version: 5.7.0
 :curator_major: 5
 :curator_doc_tree: 5.7
-:es_py_version: 6.3.1
-:es_doc_tree: 6.5
+:es_py_version: 7.0.0
+:es_doc_tree: 7.0
 :pybuild_ver: 3.6.7
 :ref:  http://www.elastic.co/guide/en/elasticsearch/reference/{es_doc_tree}
 

--- a/docs/asciidoc/versions.asciidoc
+++ b/docs/asciidoc/versions.asciidoc
@@ -21,29 +21,33 @@ against unmodified release versions of Elasticsearch. **Modified versions of Ela
 
 The current version of Curator is {curator_version}
 
-[cols="<,<,<,<,<",options="header",grid="cols"]
+[cols="<,<,<,<,<,<",options="header",grid="cols"]
 |===
 |Curator Version
 |ES 1.x
 |ES 2.x
 |ES 5.x
 |ES 6.x
+|ES 7.x
 
 |&emsp14; &emsp14; &emsp14; &emsp14; &emsp14; 3
-|&emsp14; &#9989; footnoteref:[aws_ss,Curator is unable to make snapshots for modified versions of ES which do not allow access to the snapshot status API endpoint.  As a result&comma; Curator is unable to make snapshots in AWS ES.]
-|&emsp14; &#9989; footnoteref:[aws_ss]
+|&emsp14; &#9989;
+|&emsp14; &#9989;
+|&emsp14; &#10060;
 |&emsp14; &#10060;
 |&emsp14; &#10060;
 
 |&emsp14; &emsp14; &emsp14; &emsp14; &emsp14; 4
 |&emsp14; &#10060;
-|&emsp14; &#9989; footnote:[AWS ES (which is different from installing Elasticsearch on your own EC2 instances) version 5.3 officially supports Curator. If using an older version of AWS ES&comma; please see the FAQ question, <<faq_aws_iam,Why doesn't Curator work with AWS Elasticsearch?>>]
-|&emsp14; &#9989; footnote:[Not all of the APIs available in Elasticsearch 5 are available in Curator 4.]
+|&emsp14; &#9989; 
+|&emsp14; &#9989;
+|&emsp14; &#10060;
 |&emsp14; &#10060;
 
 |&emsp14; &emsp14; &emsp14; &emsp14; &emsp14; 5
 |&emsp14; &#10060;
 |&emsp14; &#10060;
+|&emsp14; &#9989;
 |&emsp14; &#9989;
 |&emsp14; &#9989;
 |===

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ Compatibility
 -------------
 
 The Elasticsearch Curator Python API is compatible with the 5.x Elasticsearch versions, 
-and supports Python versions 2.7 and later.
+and supports Python versions 2.7, and 3.5+.
 
 Installation
 ------------
@@ -84,7 +84,7 @@ Contents
 License
 -------
 
-Copyright (c) 2012–2017 Elasticsearch <http://www.elastic.co>
+Copyright (c) 2012–2019 Elasticsearch <http://www.elastic.co>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 voluptuous>=0.9.3
-elasticsearch>=6.1.0,<7.0.0
+elasticsearch>=7.0.0,<8.0.0
 boto3>=1.7.24
 requests_aws4auth>=0.9
 click>=6.7,<7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 [options]
 install_requires = 
     voluptuous>=0.9.3
-    elasticsearch>=6.1.0,<7.0.0
+    elasticsearch>=7.0.0,<8.0.0
     boto3>=1.7.24
     requests_aws4auth>=0.9
     click>=6.7,<7.0
@@ -31,7 +31,7 @@ install_requires =
 
 setup_requires =
     voluptuous>=0.9.3
-    elasticsearch>=6.1.0,<7.0.0
+    elasticsearch>=7.0.0,<8.0.0
     boto3>=1.7.24
     requests_aws4auth>=0.9
     click>=6.7,<7.0

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def get_version():
     return VERSION
 
 def get_install_requires():
-    res = ['elasticsearch>=6.1.0,<7.0.0' ]
+    res = ['elasticsearch>=7.0.0,<8.0.0' ]
     res.append('boto3>=1.7.24')
     res.append('requests_aws4auth>=0.9')
     res.append('click>=6.7,<7.0')


### PR DESCRIPTION
Using `elasticsearch-py` 7.0

Update docs, travis CI, etc.
