### PR TITLE
Update urllib3, requests requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.6-alpine3.6 as builder
 
-RUN apk --no-cache add build-base tar musl-utils openssl-dev
-RUN pip3 install setuptools cx_Freeze==6.0b1 requests-aws4auth boto3
+RUN apk --no-cache upgrade && apk --no-cache add build-base tar musl-utils openssl-dev
+RUN pip3 install setuptools cx_Freeze==6.0b1
 
 COPY . .
 RUN ln -s /lib/libc.musl-x86_64.so.1 ldd

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 voluptuous>=0.9.3
 elasticsearch>=7.0.0,<8.0.0
-urllib3>=1.21,<1.23
-requests==2.18.4
+urllib3>=1.24.2,<1.25
+requests>=2.20.0
 boto3>=1.7.24
 requests_aws4auth>=0.9
 click>=6.7,<7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,8 +22,8 @@ classifiers =
 install_requires = 
     voluptuous>=0.9.3
     elasticsearch>=7.0.0,<8.0.0
-    urllib3>=1.21,<1.23
-    requests==2.18.4
+    urllib3>=1.24.2,<1.25
+    requests>=2.20.0
     boto3>=1.7.24
     requests_aws4auth>=0.9
     click>=6.7,<7.0
@@ -34,8 +34,8 @@ install_requires =
 setup_requires =
     voluptuous>=0.9.3
     elasticsearch>=7.0.0,<8.0.0
-    urllib3>=1.21,<1.23
-    requests==2.18.4
+    urllib3>=1.24.2,<1.25
+    requests>=2.20.0
     boto3>=1.7.24
     requests_aws4auth>=0.9
     click>=6.7,<7.0

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ def get_version():
 
 def get_install_requires():
     res = ['elasticsearch>=7.0.0,<8.0.0' ]
-    res.append('urllib3>=1.21,<1.23')
-    res.append('requests==2.18.4')
+    res.append('urllib3>=1.24.2,<1.25')
+    res.append('requests>=2.20.0')
     res.append('boto3>=1.7.24')
     res.append('requests_aws4auth>=0.9')
     res.append('click>=6.7,<7.0')


### PR DESCRIPTION
We need to urllib3 >= 1.24.2 and requests >= 2.20.0 to address the
following CVEs.

urllib3:
CVE-2018-20060 9.8 Fixed >= 1.23
CVE-2019-11324 7.5 Fixed >= 1.24.2

requests:
CVE-2018-18074 9.8 Fixed >= 2.20.0

Additionally cleanup the Dockerfile to no longer pre-install
dependencies that are already covered in requirements.txt to avoid
re-installing/conflicting dependencies.

Fixes: #1394

Fixes #

## Proposed Changes

  - Adjust requirements to address above CVEs.
