### PR TITLE
New configuration parameter: api_key - used in x-api-key header for r…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ cache:
   pip: true
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 before_install:
   - cp requirements.txt ..
@@ -43,8 +43,8 @@ install:
   - pip install .
 
 script:
-  - sudo apt-get update && sudo apt-get install oracle-java8-installer
+  - sudo apt-get update && sudo apt-get install openjdk-8-jdk
   - java -version
-  - sudo update-alternatives --set java /usr/lib/jvm/java-8-oracle/jre/bin/java
+  - sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
   - java -version
   - ./travis-run.sh

--- a/curator/defaults/client_defaults.py
+++ b/curator/defaults/client_defaults.py
@@ -24,6 +24,7 @@ def config_client():
         Optional('timeout', default=30): All(
             Coerce(int), Range(min=1, max=86400)),
         Optional('master_only', default=False): Boolean(),
+        Optional('api_key', default=None): Any(None, *string_types),
     }
 
 # Configuration file: logging

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -774,6 +774,8 @@ def get_client(**kwargs):
     :arg skip_version_test: If `True`, skip the version check as part of the
         client connection.
     :rtype: :class:`elasticsearch.Elasticsearch`
+    :arg api_key: value to be used in optional X-Api-key header when accessing Elasticsearch
+    :type api_key: str
     """
     if 'url_prefix' in kwargs:
         if (
@@ -894,6 +896,8 @@ def get_client(**kwargs):
             )
     try:
         client = elasticsearch.Elasticsearch(**kwargs)
+        if 'api_key' in kwargs and kwargs['api_key'] is not None:
+            client.transport.connection_pool.connection.headers.update({'x-api-key': kwargs['api_key']})
         if skip_version_test:
             logger.warn(
                 'Skipping Elasticsearch version verification. This is '

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,16 @@
 Changelog
 =========
 
+5.7.7 (? ? ?)
+------------------
+
+**New**
+
+  * New client configuration option: api_key - used in the X-Api-key header in
+    requests to Elasticsearch when set, which may be required if ReadonlyREST
+    plugin is configured to require api-key. Requested in #1409 (vetler)
+
+
 5.7.6 (6 May 2019)
 ------------------
 

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -315,6 +315,16 @@ class TestGetClient(TestCase):
             curator.get_client, **kwargs
         )
 
+    def test_api_key_not_set(self):
+        kwargs = { 'api_key': None }
+        self.assertIsNotNone(curator.get_client(**kwargs))
+
+    def test_api_key_set(self):
+        kwargs = { 'api_key': 'some-api-key' }
+        client = curator.get_client(**kwargs)
+        self.assertEqual('some-api-key', client.transport.connection_pool.connection.headers.get('x-api-key'))
+
+
 class TestShowDryRun(TestCase):
     # For now, since it's a pain to capture logging output, this is just a
     # simple code coverage run

--- a/travis-run.sh
+++ b/travis-run.sh
@@ -75,7 +75,7 @@ common_node_settings() {
 
 setup_es https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ES_VERSION.tar.gz
 
-java_home='/usr/lib/jvm/java-8-oracle'
+java_home='/usr/lib/jvm/java-8-openjdk-amd64/jre'
 
 ## Get major and minor version numbers
 MAJORVER=$(echo $ES_VERSION | awk -F\. '{print $1}')


### PR DESCRIPTION
Fixes #1409

## Proposed Changes

  - adds the `api_key` option to `config.yml`
  - if `api_key` is set, adds the `x-api-key` header to HTTP requests 

