### PR TITLE
Fix crashes in restore of "large" number of indices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN pip3 install setuptools cx_Freeze==6.0b1
 COPY . .
 RUN ln -s /lib/libc.musl-x86_64.so.1 ldd
 RUN ln -s /lib /lib64
-RUN pip3 install -r requirements.txt 
+RUN pip3 install -r requirements.txt
 RUN python3 setup.py build_exe
 
 FROM alpine:3.6

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -1636,18 +1636,21 @@ def restore_check(client, index_list):
     :arg client: An :class:`elasticsearch.Elasticsearch` client object
     :arg index_list: The list of indices to verify having been restored.
     """
-    try:
-        response = client.indices.recovery(index=to_csv(index_list), human=True)
-    except Exception as e:
-        raise exceptions.CuratorException(
-            'Unable to obtain recovery information for specified indices. '
-            'Error: {0}'.format(e)
-        )
-    # This should address #962, where perhaps the cluster state hasn't yet
-    # had a chance to add a _recovery state yet, so it comes back empty.
-    if response == {}:
-        logger.info('_recovery returned an empty response. Trying again.')
-        return False
+    response = {}
+    for chunk in chunk_index_list(index_list):
+        try:
+            chunk_response = client.indices.recovery(index=chunk, human=True)
+        except Exception as e:
+            raise exceptions.CuratorException(
+                'Unable to obtain recovery information for specified indices. '
+                'Error: {0}'.format(e)
+            )
+        # This should address #962, where perhaps the cluster state hasn't yet
+        # had a chance to add a _recovery state yet, so it comes back empty.
+        if chunk_response == {}:
+            logger.info('_recovery returned an empty response. Trying again.')
+            return False
+        response.update(chunk_response)
     # Fixes added in #989
     logger.info('Provided indices: {0}'.format(index_list))
     logger.info('Found indices: {0}'.format(list(response.keys())))

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -52,6 +52,8 @@ Changelog
     by (nerophon) in #1366. (untergeek)
   * Ensure authentication (401), authorization (403), and other 400 errors are
     logged properly. Reported by (rfalke) in #1413. (untergeek)
+  * Fix crashes in restore of "large" number of indices reported by breml in
+    #1360. (anandsinghkunwar)
 
 **Documentation**
 


### PR DESCRIPTION
Fixes #1360 

## Proposed Changes

- Changed to query all indices instead of a comma separated list of indices.
- The logic checks restoration of only the indices passed as a list, out of
  the status of all indices
