### PR TITLE
Adjust the docs for the empty filtertype to mention impact on closed indices

### DIFF
--- a/docs/asciidoc/filters.asciidoc
+++ b/docs/asciidoc/filters.asciidoc
@@ -452,7 +452,7 @@ removed from the actionable list, leaving `index-2017.03.03`,
 -------------
 
 This <<filtertype,filtertype>> will iterate over the actionable list and match
-indices which do not contain any documents.  They will remain in, or be
+indices which either do not contain any documents or has been closed. They will remain in, or be
 removed from the actionable list based on the value of <<fe_exclude,exclude>>.
 
 By default the indices matched by the empty filter will be excluded since 

--- a/docs/asciidoc/filters.asciidoc
+++ b/docs/asciidoc/filters.asciidoc
@@ -452,7 +452,7 @@ removed from the actionable list, leaving `index-2017.03.03`,
 -------------
 
 This <<filtertype,filtertype>> will iterate over the actionable list and match
-indices which either do not contain any documents or has been closed. They will remain in, or be
+indices which either do not contain any documents or have been closed. They will remain in, or be
 removed from the actionable list based on the value of <<fe_exclude,exclude>>.
 
 By default the indices matched by the empty filter will be excluded since 


### PR DESCRIPTION
The `empty` filtertype for curator will match not only on empty indices but also indices that have been closed which were not empty at the time of closing.