### PR TITLE
[DOCS] Fix broken link

### DIFF
--- a/docs/asciidoc/options.asciidoc
+++ b/docs/asciidoc/options.asciidoc
@@ -1820,7 +1820,7 @@ and put it after `restored_index`.  For example, if I was restoring
 `index-2017.03.01`, the resulting index would be renamed to
 `restored_index-2017.03.01`.
 
-Read more about this setting at {ref}/modules-snapshots.html#_restore
+Read more about this setting at {ref}/modules-snapshots.html#restore-snapshot
 
 There is no default value.
 


### PR DESCRIPTION
Related to #1426.

With https://github.com/elastic/elasticsearch/pull/43493, we added an explicit anchor ID for the restore section here:
https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html#restore-snapshot

As a result, all of these links that used the auto-generated anchor ID break:

> INFO:build_docs:Bad cross-document links:
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/curator/5.7/option_rename_replacement.html:
INFO:build_docs:   - en/elasticsearch/reference/7.0/modules-snapshots.html#_restoreINFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/curator/5.x/option_rename_replacement.html:
INFO:build_docs:   - en/elasticsearch/reference/7.0/modules-snapshots.html#_restore
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/curator/current/option_rename_replacement.html:
INFO:build_docs:   - en/elasticsearch/reference/7.0/modules-snapshots.html#_restore