### PR TITLE
Exclude closed indices from consideration when using the empty filter

### DIFF
--- a/curator/indexlist.py
+++ b/curator/indexlist.py
@@ -727,6 +727,9 @@ class IndexList(object):
         """
         Filter indices with a document count of zero
 
+        Indices that are closed are automatically excluded from consideration
+        due to closed indices reporting a document count of zero.
+
         :arg exclude: If `exclude` is `True`, this filter will remove matching
             indices from `indices`. If `exclude` is `False`, then only matching
             indices will be kept in `indices`.
@@ -734,6 +737,7 @@ class IndexList(object):
         """
         self.loggit.debug('Filtering empty indices')
         self.empty_list_check()
+        self.filter_closed()
         for index in self.working_list():
             condition = self.index_info[index]['docs'] == 0
             self.loggit.debug('Index {0} doc count: {1}'.format(

--- a/curator/indexlist.py
+++ b/curator/indexlist.py
@@ -736,8 +736,8 @@ class IndexList(object):
             Default is `True`
         """
         self.loggit.debug('Filtering empty indices')
-        self.empty_list_check()
         self.filter_closed()
+        self.empty_list_check()
         for index in self.working_list():
             condition = self.index_info[index]['docs'] == 0
             self.loggit.debug('Index {0} doc count: {1}'.format(

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -19,7 +19,7 @@ Changelog
     Update documentation accordingly. (untergeek)
 
   * Prevent the ``empty`` filtertype from incorrectly matching against closed
-    indices (heyitsmdr)
+    indices #1430 (heyitsmdr)
 
 **Documentation**
 

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -18,6 +18,9 @@ Changelog
     This addresses #1363, and everyone else upgrading to Elasticsearch 7.x.
     Update documentation accordingly. (untergeek)
 
+  * Prevent the ``empty`` filtertype from incorrectly matching against closed
+    indices (heyitsmdr)
+
 **Documentation**
 
   * Grammar correction of ilm.asciidoc #1425 (SlavikCA)

--- a/docs/asciidoc/filters.asciidoc
+++ b/docs/asciidoc/filters.asciidoc
@@ -452,8 +452,9 @@ removed from the actionable list, leaving `index-2017.03.03`,
 -------------
 
 This <<filtertype,filtertype>> will iterate over the actionable list and match
-indices which do not contain any documents.  They will remain in, or be
-removed from the actionable list based on the value of <<fe_exclude,exclude>>.
+indices which do not contain any documents. Indices that are closed are automatically
+removed from consideration. They will remain in, or be removed from the actionable list
+based on the value of <<fe_exclude,exclude>>.
 
 By default the indices matched by the empty filter will be excluded since 
 the exclude setting defaults to True. To include matching indices rather than


### PR DESCRIPTION
## Proposed Changes

- When using the [empty](https://www.elastic.co/guide/en/elasticsearch/client/curator/current/filtertype_empty.html) filtertype, automatically exclude closed indices from consideration. This will allow users to use the empty filtertype in a cluster with closed indices and not accidentally target them.