### PR TITLE
Fix shrink action to count only primary shard sizes

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -2044,7 +2044,7 @@ class Shrink(object):
 
     def _check_space(self, idx, dry_run=False):
         # Disk watermark calculation is already baked into `available_in_bytes`
-        size = utils.index_size(self.client, idx)
+        size = utils.index_size(self.client, idx, value='primaries')
         padded = (size * 2) + (32 * 1024)
         if padded < self.shrink_node_avail:
             self.loggit.debug('Sufficient space available for 2x the size of index "{0}".  Required: {1}, available: {2}'.format(idx, padded, self.shrink_node_avail))

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -1808,8 +1808,16 @@ def node_roles(client, node_id):
     """
     return client.nodes.info()['nodes'][node_id]['roles']
 
-def index_size(client, idx):
-    return client.indices.stats(index=idx)['indices'][idx]['total']['store']['size_in_bytes']
+def index_size(client, idx, value='total'):
+    """
+    Return the sum of either `primaries` or `total` shards for index ``idx``
+
+    :arg client: An :class:`elasticsearch.Elasticsearch` client object
+    :arg idx: An Elasticsearch index
+    :arg value: One of either `primaries` or `total`
+    :rtype: integer
+    """
+    return client.indices.stats(index=idx)['indices'][idx][value]['store']['size_in_bytes']
 
 def single_data_path(client, node_id):
     """

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -21,9 +21,13 @@ Changelog
     to be reindexed, the post-action check to ensure the target index exists
     is not needed. This new version will skip that validation if no documents
     are processed (issue #1170). (afharo)
-
   * Prevent the ``empty`` filtertype from incorrectly matching against closed
     indices #1430 (heyitsmdr)
+  * Fix ``index_size`` function to be able to report either for either the
+    ``total`` of all shards (default) or just ``primaries``. Added as a keyword
+    arg to preserve existing behavior. This was needed to fix sizing 
+    calculations for the Shrink action, which should only count ``primaries``.
+    Raised in #1429 (untergeek).
 
 **Documentation**
 


### PR DESCRIPTION
It was considering replicas until this fix.

Fixes #1431
