### PR TITLE
add skip_flush option for close action

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -254,12 +254,14 @@ class Allocation(object):
             utils.report_failure(e)
 
 class Close(object):
-    def __init__(self, ilo, delete_aliases=False):
+    def __init__(self, ilo, delete_aliases=False, skip_flush=False):
         """
         :arg ilo: A :class:`curator.indexlist.IndexList` object
         :arg delete_aliases: If `True`, will delete any associated aliases
             before closing indices.
         :type delete_aliases: bool
+        :arg skip_flush: If `True`, will not flush indices before closing.
+        :type skip_flush: bool
         """
         utils.verify_index_list(ilo)
         #: Instance variable.
@@ -268,6 +270,9 @@ class Close(object):
         #: Instance variable.
         #: Internal reference to `delete_aliases`
         self.delete_aliases = delete_aliases
+        #: Instance variable.
+        #: Internal reference to `skip_flush`
+        self.skip_flush = skip_flush
         #: Instance variable.
         #: The Elasticsearch Client object derived from `ilo`
         self.client     = ilo.client
@@ -304,8 +309,9 @@ class Close(object):
                             'Some indices may not have had aliases.  Exception:'
                             ' {0}'.format(e)
                         )
-                self.client.indices.flush_synced(
-                    index=utils.to_csv(l), ignore_unavailable=True)
+                if not self.skip_flush:
+                    self.client.indices.flush_synced(
+                        index=utils.to_csv(l), ignore_unavailable=True)
                 self.client.indices.close(
                     index=utils.to_csv(l), ignore_unavailable=True)
         except Exception as e:

--- a/curator/cli_singletons/close.py
+++ b/curator/cli_singletons/close.py
@@ -4,15 +4,17 @@ from curator.cli_singletons.utils import get_width, validate_filter_json
 
 @click.command(context_settings=get_width())
 @click.option('--delete_aliases', is_flag=True, help='Delete all aliases from indices to be closed')
+@click.option('--skip_flush', is_flag=True, help='Skip flush phase for indices to be closed')
 @click.option('--ignore_empty_list', is_flag=True, help='Do not raise exception if there are no actionable indices')
 @click.option('--allow_ilm_indices/--no-allow_ilm_indices', help='Allow Curator to operate on Index Lifecycle Management monitored indices.', default=False, show_default=True)
 @click.option('--filter_list', callback=validate_filter_json, help='JSON array of filters selecting indices to act on.', required=True)
 @click.pass_context
-def close(ctx, delete_aliases, ignore_empty_list, allow_ilm_indices, filter_list):
+def close(ctx, delete_aliases, skip_flush, ignore_empty_list, allow_ilm_indices, filter_list):
     """
     Close Indices
     """
-    manual_options = { 
+    manual_options = {
+        'skip_flush': skip_flush,
         'delete_aliases': delete_aliases,
         'allow_ilm_indices': allow_ilm_indices,
     }

--- a/curator/defaults/option_defaults.py
+++ b/curator/defaults/option_defaults.py
@@ -42,6 +42,9 @@ def delete_after():
 def delete_aliases():
     return { Optional('delete_aliases', default=False): Any(bool, All(Any(*string_types), Boolean())) }
 
+def skip_flush():
+    return { Optional('skip_flush', default=False): Any(bool, All(Any(*string_types), Boolean())) }
+
 def disable_action():
     return { Optional('disable_action', default=False): Any(bool, All(Any(*string_types), Boolean())) }
 

--- a/curator/validators/options.py
+++ b/curator/validators/options.py
@@ -17,7 +17,10 @@ def action_specific(action):
             option_defaults.wait_interval(action),
             option_defaults.max_wait(action),
         ],
-        'close' : [ option_defaults.delete_aliases() ],
+        'close' : [
+            option_defaults.delete_aliases(),
+            option_defaults.skip_flush()
+        ],
         'cluster_routing' : [
             option_defaults.routing_type(),
             option_defaults.cluster_routing_setting(),

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -11,6 +11,9 @@ Changelog
   * New client configuration option: api_key - used in the X-Api-key header in
     requests to Elasticsearch when set, which may be required if ReadonlyREST
     plugin is configured to require api-key. Requested in #1409 (vetler)
+  * Add ``skip_flush`` option to the ``close`` action. This should be useful
+    when trying to close indices with unassigned shards (e.g. before restore).
+    Raised in #1412. (psypuff)
 
 **Bug Fixes**
 

--- a/docs/asciidoc/actions.asciidoc
+++ b/docs/asciidoc/actions.asciidoc
@@ -176,6 +176,7 @@ action: close
 description: "Close selected indices"
 options:
   delete_aliases: False
+  skip_flush: False
 filters:
 - filtertype: ...
 -------------
@@ -190,6 +191,7 @@ aliases beforehand.
 === Optional settings
 
 * <<option_delete_aliases,delete_aliases>>
+* <<option_skip_flush,skip_flush>>
 * <<option_ignore_empty,ignore_empty_list>>
 * <<option_timeout_override,timeout_override>>
 * <<option_continue,continue_if_exception>>

--- a/docs/asciidoc/examples.asciidoc
+++ b/docs/asciidoc/examples.asciidoc
@@ -134,6 +134,7 @@ actions:
       Close indices older than 30 days (based on index name), for logstash-
       prefixed indices.
     options:
+      skip_flush: False
       delete_aliases: False
       disable_action: True
     filters:

--- a/docs/asciidoc/options.asciidoc
+++ b/docs/asciidoc/options.asciidoc
@@ -12,6 +12,7 @@ Options are settings used by <<actions,actions>>.
 * <<option_count,count>>
 * <<option_delay,delay>>
 * <<option_delete_aliases,delete_aliases>>
+* <<option_skip_flush,skip_flush>>
 * <<option_disable,disable_action>>
 * <<option_extra_settings,extra_settings>>
 * <<option_ignore_empty,ignore_empty_list>>
@@ -263,6 +264,27 @@ filters:
 
 The value for this setting determines whether aliases will be deleted from
 indices before closing.
+
+The default value is `False`.
+
+[[option_skip_flush]]
+== skip_flush
+
+NOTE: This setting is only used by the <<close,close action>>, and is
+    optional.
+
+[source,yaml]
+-------------
+action: close
+description: "Close selected indices"
+options:
+  skip_flush: False
+filters:
+- filtertype: ...
+-------------
+
+If `skip_flush` is set to `True`, Curator will not flush indices to disk
+before closing. This may be useful for closing red indices before restoring.
 
 The default value is `False`.
 

--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -129,11 +129,11 @@ class CuratorTestCase(TestCase):
         # pylint: disable=E1123
         self.client.cluster.health(wait_for_status='yellow')
 
-    def create_index(self, name, shards=1, wait_for_yellow=True, ilm_policy=None):
+    def create_index(self, name, shards=1, wait_for_yellow=True, ilm_policy=None, wait_for_active_shards=1):
         request_body={'settings': {'number_of_shards': shards, 'number_of_replicas': 0}}
         if ilm_policy is not None:
             request_body['settings']['index'] = {'lifecycle': {'name': ilm_policy}}
-        self.client.indices.create(index=name, body=request_body)
+        self.client.indices.create(index=name, body=request_body, wait_for_active_shards=wait_for_active_shards)
         if wait_for_yellow:
             self.wfy()
 

--- a/test/integration/testvars.py
+++ b/test/integration/testvars.py
@@ -397,6 +397,20 @@ close_delete_aliases = ('---\n'
 '        kind: prefix\n'
 '        value: my\n')
 
+close_skip_flush = ('---\n'
+'actions:\n'
+'  1:\n'
+'    description: "Close indices as filtered"\n'
+'    action: close\n'
+'    options:\n'
+'      skip_flush: True\n'
+'      continue_if_exception: False\n'
+'      disable_action: False\n'
+'    filters:\n'
+'      - filtertype: pattern\n'
+'        kind: prefix\n'
+'        value: my\n')
+
 delete_proto = ('---\n'
 'actions:\n'
 '  1:\n'

--- a/test/unit/test_action_close.py
+++ b/test/unit/test_action_close.py
@@ -51,6 +51,17 @@ class TestActionClose(TestCase):
         ilo = curator.IndexList(client)
         co = curator.Close(ilo, delete_aliases=True)
         self.assertIsNone(co.do_action())
+    def test_do_action_with_skip_flush(self):
+        client = Mock()
+        client.info.return_value = {'version': {'number': '5.0.0'} }
+        client.indices.get_settings.return_value = testvars.settings_one
+        client.cluster.state.return_value = testvars.clu_state_one
+        client.indices.stats.return_value = testvars.stats_one
+        client.indices.flush_synced.return_value = testvars.synced_pass
+        client.indices.close.return_value = None
+        ilo = curator.IndexList(client)
+        co = curator.Close(ilo, skip_flush=True)
+        self.assertIsNone(co.do_action())
     def test_do_action_raises_exception(self):
         client = Mock()
         client.info.return_value = {'version': {'number': '5.0.0'} }


### PR DESCRIPTION
Fixes #1412

## Proposed Changes

  - Added a `skip_flush` option for the `close` action, defaults to `False`.
