### PR TITLE
Catch empty/None values for snapshots without ages

### DIFF
--- a/curator/snapshotlist.py
+++ b/curator/snapshotlist.py
@@ -163,7 +163,12 @@ class SnapshotList(object):
         temp = {}
         for snap in snapshot_list:
             if self.age_keyfield in self.snapshot_info[snap]:
-                temp[snap] = self.snapshot_info[snap][self.age_keyfield]
+                # This fixes #1366. Catch None is a potential age value.
+                if self.snapshot_info[snap][self.age_keyfield]:
+                    temp[snap] = self.snapshot_info[snap][self.age_keyfield]
+                else:
+                    msg = ' snapshot %s has no age' % snap
+                    self.__excludify(True, True, snap, msg)
             else:
                 msg = (
                     '{0} does not have age key "{1}" in SnapshotList '

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -354,7 +354,7 @@ def get_point_of_reference(unit, count, epoch=None):
     return epoch - multiplier * count
 
 def get_unit_count_from_name(index_name, pattern):
-    if (pattern == None):
+    if pattern is None:
         return None
     match = pattern.search(index_name)
     if match:

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -44,6 +44,9 @@ Changelog
     log message were vague indications that a client connection was attempted.
     This is a step in the right direction, as it explicitly exits with a 1 exit
     code for different conditions now. (untergeek)
+  * Catch snapshots without a timestring in the name causing a logic error when
+    using the ``count`` filter and ``use_age`` with ``source: name``. Reported
+    by (nerophon) in #1366. (untergeek)
 
 **Documentation**
 


### PR DESCRIPTION
This prevents the error described in #1366 where this value did not exist.

Fixes #1366
