### PR TITLE
#1439: Modify prefix and suffix filter regex patterns to behave like substring matches, and abstract out duplicated code related to this change

### DIFF
--- a/curator/defaults/settings.py
+++ b/curator/defaults/settings.py
@@ -12,15 +12,6 @@ def version_min():
 def config_file():
     return path.join(path.expanduser('~'), '.curator', 'curator.yml')
 
-# Default filter patterns (regular expressions)
-def regex_map():
-    return {
-        'timestring': r'^.*{0}.*$',
-        'regex': r'{0}',
-        'prefix': r'^{0}.*$',
-        'suffix': r'^.*{0}$',
-    }
-
 def date_regex():
     return {
         'Y' : '4',

--- a/curator/indexlist.py
+++ b/curator/indexlist.py
@@ -427,23 +427,7 @@ class IndexList(object):
             Default is `False`
         """
         self.loggit.debug('Filtering indices by regex')
-        if kind not in [ 'regex', 'prefix', 'suffix', 'timestring' ]:
-            raise ValueError('{0}: Invalid value for kind'.format(kind))
-
-        # Stop here if None or empty value, but zero is okay
-        if value == 0:
-            pass
-        elif not value:
-            raise ValueError(
-                '{0}: Invalid value for "value". '
-                'Cannot be "None" type, empty, or False'
-            )
-
-        if kind == 'timestring':
-            regex = settings.regex_map()[kind].format(utils.get_date_regex(value))
-        else:
-            regex = settings.regex_map()[kind].format(value)
-
+        regex = utils.build_regex(kind, value)
         self.empty_list_check()
         pattern = re.compile(regex)
         for index in self.working_list():

--- a/curator/snapshotlist.py
+++ b/curator/snapshotlist.py
@@ -218,23 +218,7 @@ class SnapshotList(object):
             matching snapshots will be kept in `snapshots`.
             Default is `False`
         """
-        if kind not in [ 'regex', 'prefix', 'suffix', 'timestring' ]:
-            raise ValueError('{0}: Invalid value for kind'.format(kind))
-
-        # Stop here if None or empty value, but zero is okay
-        if value == 0:
-            pass
-        elif not value:
-            raise ValueError(
-                '{0}: Invalid value for "value". '
-                'Cannot be "None" type, empty, or False'
-            )
-
-        if kind == 'timestring':
-            regex = settings.regex_map()[kind].format(utils.get_date_regex(value))
-        else:
-            regex = settings.regex_map()[kind].format(value)
-
+        regex = utils.build_regex(kind, value)
         self.empty_list_check()
         pattern = re.compile(regex)
         for snapshot in self.working_list():

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -200,6 +200,37 @@ def get_date_regex(timestring):
     logger.debug("regex = {0}".format(regex))
     return regex
 
+# Default filter patterns (regular expressions)
+def build_regex(kind, value):
+    """
+    Return a regex pattern based on the kind and value.
+
+    :arg kind: Can be one of: ``suffix``, ``prefix``, ``regex``, or
+        ``timestring``. This option controls the kind of regex pattern
+        to build.
+    :arg value: Depends on `kind`. It is the strftime string if `kind` is
+        ``timestring``. It's used to build the regular expression for other
+        kinds.  If `kind` is ``prefix`` or ``suffix``, the value is
+        converted so that the regex behaves like a substring search.
+    """
+    if value == 0:
+        pass
+    elif not value:
+        raise ValueError(
+            '{0}: Invalid value for "value". '
+            'Cannot be "None" type, empty, or False'
+        )
+    if kind == 'timestring':
+        return r'^.*{0}.*$'.format(get_date_regex(value))
+    elif kind == 'prefix':
+        return r'^{0}.*$'.format(re.escape(str(value)))
+    elif kind == 'suffix':
+        return r'^.*{0}$'.format(re.escape(str(value)))
+    elif kind == 'regex':
+        return r'{0}'.format(value)
+    else:
+        raise ValueError('{0}: Invalid value for kind'.format(kind))
+
 def get_datetime(index_timestamp, timestring):
     """
     Return the datetime extracted from the index name, which is the index

--- a/docs/asciidoc/inc_kinds.asciidoc
+++ b/docs/asciidoc/inc_kinds.asciidoc
@@ -2,7 +2,7 @@ The different <<fe_kind,`kinds`>> are described as follows:
 
 === prefix
 
-To match all indices starting with `logstash-`:
+To match all indices starting with the substring `logstash-`:
 
 [source,yaml]
 -------------
@@ -11,7 +11,7 @@ To match all indices starting with `logstash-`:
  value: logstash-
 -------------
 
-To match all indices _except_ those starting with `logstash-`:
+To match all indices _except_ those starting with the substring `logstash-`:
 
 [source,yaml]
 -------------
@@ -23,7 +23,7 @@ To match all indices _except_ those starting with `logstash-`:
 
 === suffix
 
-To match all indices ending with `-prod`:
+To match all indices ending with the substring `-prod`:
 
 [source,yaml]
 -------------
@@ -32,7 +32,7 @@ To match all indices ending with `-prod`:
  value: -prod
 -------------
 
-To match all indices _except_ those ending with `-prod`:
+To match all indices _except_ those ending with the substring `-prod`:
 
 [source,yaml]
 -------------


### PR DESCRIPTION
Hello,

This is my first pull request.  This pull request is for elastic/curator issue #1439.

The Curator documentation is not clear about 'prefix' and 'suffix' filters being regular-expression based
To me, the documentation seems to imply that prefix and suffix patterns are substring matches, so this pull request turns the prefix and suffix filters into substring matches.

This pull request makes the following changes:
   - Common pattern filter code in curator/snapshotlist.py and curator/indexlist.py has been coalesced and moved to curator/utils.py
   - The regex patterns in curator/defaults/settings.py have been moved to curator/utils.py (the regex_map() function has been removed)
   - The new code in curator/utils.py for the pattern prefix and suffix searches escapes regex characters so the regex pattern behaves like a substring search
   - Clarifies in docs/asciidoc/inc_kinds.asciidoc that 'prefix' and 'suffix' matches are substring matches

If these changes aren't satisfactory, please give me some ideas about changes that would be acceptable.

Regarding running 'python setup.py test':
  - In my development environment, I'm using ElasticSearch version 7.1.
    The official elactic/curator 'python setup.py test' XML summary output at the bottom reports quite a few failures (the total "Coverage" is 72%) -- I'm not sure what I need to adjust in my environment to get everything to pass...
    some of the errors are unicode vs non-unicode string mismatches; other errors are errors like "AssertionError: 0 != 5".
  - I've run 'python setup.py test' on the modifications in this pull request, and the test_... lines at the top of the output are identical to that of the official elactic/curator 'python setup.py test' output on my system.
    Said another way: The tests that pass for the official code still pass with my changes.
  - The XML failure summary for my repo doesn't match the XML failure summary for the official elactic/curator repo (in my development environment) for the four python files that I've modified, but the results are similar.

  -  As such, someone with a full working development environment should re-run 'python setup.py test' to validate my changes.

Thank you,

 Daniel
