### PR TITLE
Report 40x errors properly

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -47,6 +47,8 @@ Changelog
   * Catch snapshots without a timestring in the name causing a logic error when
     using the ``count`` filter and ``use_age`` with ``source: name``. Reported
     by (nerophon) in #1366. (untergeek)
+  * Ensure authentication (401), authorization (403), and other 400 errors are
+    logged properly. Reported by (rfalke) in #1413. (untergeek)
 
 **Documentation**
 


### PR DESCRIPTION
When connecting in the `get_client()` function, ensure that all TransportError type exceptions are properly caught and the messages reported properly, too.

Fixes #1413
