### PR TITLE
Doc/asciidoctor build

### DIFF
--- a/docs/asciidoc/faq.asciidoc
+++ b/docs/asciidoc/faq.asciidoc
@@ -9,7 +9,6 @@ This section will be updated as more frequently asked questions arise
 * <<faq_partial_delete,Can I delete only certain data from within indices?>>
 * <<faq_strange_chars,Can Curator handle index names with strange characters?>>
 * <<entrypoint-fix,I'm getting `DistributionNotFound` and `entry_point` errors when I try to run Curator.  What am I doing wrong?>>
-* <<faq_aws_iam,Why doesn't Curator 5 work with AWS Elasticsearch?>>
 * <<faq_unicode,Why am I getting an error message about ASCII encoding?>>
 --
 
@@ -212,31 +211,6 @@ acquired and installed for your platform.
 For more information about setuptools, see https://pypi.python.org/pypi/setuptools
 
 This fix originally appeared https://github.com/elastic/curator/issues/56#issuecomment-77843587[here].
-
-'''''
-
-
-[[faq_aws_iam]]
-== Q: Why doesn't Curator work with AWS Elasticsearch?
-
-=== A: Because Curator requires access to the `/_cluster/state/metadata` endpoint.
-
-NOTE: AWS ES 5.3 officially supports Curator for index managment operations. AWS ES
-5.5 exposes the `/_snapshot/_status` endpoint Curator uses, and therefore only AWS ES
-5.5 supports full snapshot operations.  Older versions of AWS ES are not supported
-by Curator versions 4 or 5.
-
-There is some confusion because Curator 3 supported AWS ES, but Curator 4 & 5 do
-not.  Curator 4 & 5 require access to the `/_cluster/state/metadata` endpoint in order
-to pull metadata at IndexList initialization time for _all_ indices.  This
-metadata is used to determine index routing information, index sizing, index
-state (either `open` or `close`), aliases, and more.  Curator 4 switched to
-doing this in order to reduce the number of repetitive client calls that were
-made in the previous versions. Curator 5 uses the same method.
-
-This endpoint was not fully available in AWS ES until version 5.3.  The `/_snapshot/_status`
-endpoint was made available in AWS ES 5.5.
-
 
 '''''
 

--- a/docs/asciidoc/installation.asciidoc
+++ b/docs/asciidoc/installation.asciidoc
@@ -236,7 +236,7 @@ gpgcheck=1
 gpgkey=https://packages.elastic.co/GPG-KEY-elasticsearch
 enabled=1
 --------------------------------------------------
-=========================================
+========================================
 
 [[yum-binary]]
 === Binary Package Installation

--- a/docs/asciidoc/options.asciidoc
+++ b/docs/asciidoc/options.asciidoc
@@ -1376,9 +1376,6 @@ The default value is `True`.
 NOTE: This option is only used by the <<reindex,Reindex action>> when performing
 a remote reindex operation.
 
-WARNING: This feature allows connection to AWS using IAM credentials, but
-    <<faq_aws_iam,Curator 5 does not currently work with AWS>>.
-
 WARNING: This setting will not work unless the `requests-aws4auth` Python module
     has been manually installed first.
 
@@ -1419,9 +1416,6 @@ IMPORTANT: You must set your <<hosts,hosts>> to the proper hostname _with_ port.
 NOTE: This option is only used by the <<reindex,Reindex action>> when performing
 a remote reindex operation.
 
-WARNING: This feature allows connection to AWS using IAM credentials, but
-    <<faq_aws_iam,Curator 5 does not currently work with AWS>>.
-
 WARNING: This setting will not work unless the `requests-aws4auth` Python module
     has been manually installed first.
 
@@ -1461,9 +1455,6 @@ IMPORTANT: You must set your <<hosts,hosts>> to the proper hostname _with_ port.
 
 NOTE: This option is only used by the <<reindex,Reindex action>> when performing
 a remote reindex operation.
-
-WARNING: This feature allows connection to AWS using IAM credentials, but
-    <<faq_aws_iam,Curator 5 does not currently work with AWS>>.
 
 WARNING: This setting will not work unless the `requests-aws4auth` Python module
     has been manually installed first.


### PR DESCRIPTION
This adds a fix needed for the new asciidoctor doc builds, and purges references to AWS Elasticsearch.
