### PR TITLE
cx_Freeze 6.0b1 issue with cacert.pem and build_exe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.6-alpine3.6 as builder
 
 RUN apk --no-cache upgrade && apk --no-cache add build-base tar musl-utils openssl-dev
-RUN pip3 install setuptools cx_Freeze==6.0b1
+RUN pip3 install setuptools cx_Freeze==6.0
 
 COPY . .
 RUN ln -s /lib/libc.musl-x86_64.so.1 ldd

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,5 @@ FROM alpine:3.6
 RUN apk --no-cache upgrade && apk --no-cache add ca-certificates && update-ca-certificates && apk --no-cache add wget
 COPY --from=builder build/exe.linux-x86_64-3.6 /curator/
 USER nobody:nobody
+ENV LD_LIBRARY_PATH=/curator/lib
 ENTRYPOINT ["/curator/curator"]


### PR DESCRIPTION
Fixes #1464

cx_Freeze `6.0b1` seems to have an issue with the cacert.pem from `certifi`, upgrading to `6.0` seemed to fix the issue.

Before:
```
2019-11-05 05:26:36,564 INFO      Preparing Action ID: 1, "delete_indices"
2019-11-05 05:26:36,565 INFO      Creating client object and testing connection
2019-11-05 05:26:36,569 INFO      Instantiating client object
2019-11-05 05:26:36,569 ERROR     Unable to connect to Elasticsearch cluster. Error: Please install requests to use RequestsHttpConnection.
2019-11-05 05:26:36,569 CRITICAL  Curator cannot proceed. Exiting.
```

After:
```
2019-11-05 05:35:07,268 INFO      Preparing Action ID: 1, "delete_indices"
2019-11-05 05:35:07,268 INFO      Creating client object and testing connection
2019-11-05 05:35:07,272 INFO      Instantiating client object
2019-11-05 05:35:07,273 INFO      Testing client connectivity
2019-11-05 05:35:07,288 INFO      Successfully created Elasticsearch client object with provided settings
2019-11-05 05:35:07,298 INFO      Trying Action ID: 1, "delete_indices": test-index indices deletion
2019-11-05 05:35:07,581 INFO      DRY-RUN MODE.  No changes will be made.
2019-11-05 05:35:07,581 INFO      (CLOSED) indices may be shown that may not be acted on by action "delete_indices".
2019-11-05 05:35:07,581 INFO      Action ID: 1, "delete_indices" completed.
2019-11-05 05:35:07,581 INFO      Job completed.
```

## Proposed Changes
  - change cx_Freeze from `6.0b1` to `6.0`
