### PR TITLE
Specify which github repo and project to get the package from

### DIFF
--- a/docs/asciidoc/installation.asciidoc
+++ b/docs/asciidoc/installation.asciidoc
@@ -303,9 +303,9 @@ That might look like this:
 
 [source,sh]
 --------------------------------------
-wget https://github.com/username/project/archive/#.#.#.tar.gz -O package.tar.gz
-tar zxf package.tar.gz
-cd package-#.#.#
+wget https://github.com/elastic/curator/archive/v#.#.#.tar.gz -O curator.tar.gz
+tar zxf curator.tar.gz
+cd curator-#.#.#
 python setup.py install
 --------------------------------------
 


### PR DESCRIPTION

## Proposed Changes
https://www.elastic.co/guide/en/elasticsearch/client/curator/5.8/python-source.html
The instructions for installing from source don't specify which github repository or project to download the tarball from - there's just a generic `username/project` in the url.

Changed to show the actual username (`elastic`) and the project (`curator`).
