### PR TITLE
Fix warnings in Python 3.8

### DIFF
--- a/curator/indexlist.py
+++ b/curator/indexlist.py
@@ -883,7 +883,7 @@ class IndexList(object):
         source='creation_date', timestring=None, field=None,
         stats_result='min_value', exclude=True):
         # pylint: disable=W1401
-        """
+        r"""
         Remove indices from the actionable list beyond the number `count`,
         sorted reverse-alphabetically by default.  If you set `reverse` to
         `False`, it will be sorted alphabetically.

--- a/test/integration/test_count_pattern.py
+++ b/test/integration/test_count_pattern.py
@@ -51,7 +51,7 @@ class TestCLICountPattern(CuratorTestCase):
         self.write_config(
             self.args['actionfile'],
             delete_count_pattern.format(
-                '\'^(a|b|c)-\d$\'', 'false', 'name', '\'%Y.%m.%d\'', 'true', 1
+                r'\'^(a|b|c)-\d$\'', 'false', 'name', '\'%Y.%m.%d\'', 'true', 1
             )
         )
         test = clicktest.CliRunner()
@@ -77,7 +77,7 @@ class TestCLICountPattern(CuratorTestCase):
         self.write_config(
             self.args['actionfile'],
             delete_count_pattern.format(
-                '\'^(a|b)-\d{4}\.\d{2}\.\d{2}$\'', 'true', 'name', '\'%Y.%m.%d\'', 'true', 1
+                r'\'^(a|b)-\d{4}\.\d{2}\.\d{2}$\'', 'true', 'name', '\'%Y.%m.%d\'', 'true', 1
             )
         )
         test = clicktest.CliRunner()


### PR DESCRIPTION
Fixes #1511 

## Proposed Changes

* Fix deprecation warnings over invalid escape sequences using raw strings
* Fix syntax warning over using is for literal comparison with ==
