### PR TITLE
Fix Documentation- Curator 5.6 is not compatible with ES 7.2

### DIFF
--- a/docs/asciidoc/versions.asciidoc
+++ b/docs/asciidoc/versions.asciidoc
@@ -39,12 +39,19 @@ The current version of Curator is {curator_version}
 
 |&emsp14; &emsp14; &emsp14; &emsp14; &emsp14; 4
 |&emsp14; &#10060;
-|&emsp14; &#9989; 
+|&emsp14; &#9989;
 |&emsp14; &#9989;
 |&emsp14; &#10060;
 |&emsp14; &#10060;
 
-|&emsp14; &emsp14; &emsp14; &emsp14; &emsp14; 5
+|&emsp14; &emsp14; &emsp14; &emsp14; &emsp14; 5.6-
+|&emsp14; &#10060;
+|&emsp14; &#10060;
+|&emsp14; &#9989;
+|&emsp14; &#9989;
+|&emsp14; &#10060;
+
+|&emsp14; &emsp14; &emsp14; &emsp14; &emsp14; 5.7+
 |&emsp14; &#10060;
 |&emsp14; &#10060;
 |&emsp14; &#9989;


### PR DESCRIPTION
As mentioned in https://github.com/elastic/curator/issues/1478 

> Shows that Curator 5 is compatible with ES 7. However, a customer running Curator 5.6 found that it was not compatible with ES 7.2.
> 
> Obviously this is because ES 7.2 (or indeed any 7.x) didn't exist when Curator 5.6 was released. However, the Matrix seems to suggest that ANY Curator 5 will work with ES 7.x. Now, if I change the docs version to Curator 5.6, then the ES 7.x column disappears, so it's correct. But a Google search tends to take you to the latest doc, so I can understand how the customer made the mistake.

Fixes #1478 

Split the matrix for 5 into two sections --> 5.6- and 5.7+ and updated the compatibility for ES7.x

  -
