### PR TITLE
Curator 5.6 is not compatible with ES 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,9 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 
 env:
-  - ES_VERSION=5.0.2
-  - ES_VERSION=5.1.2
-  - ES_VERSION=5.2.2
-  - ES_VERSION=5.3.3
-  - ES_VERSION=5.4.3
-  - ES_VERSION=5.5.3
   - ES_VERSION=5.6.16
   - ES_VERSION=6.0.1
   - ES_VERSION=6.1.3
@@ -27,6 +22,9 @@ env:
   - ES_VERSION=7.1.1-linux-x86_64
   - ES_VERSION=7.2.1-linux-x86_64
   - ES_VERSION=7.3.1-linux-x86_64
+  - ES_VERSION=7.4.2-linux-x86_64
+  - ES_VERSION=7.5.2-linux-x86_64
+  - ES_VERSION=7.6.1-linux-x86_64
 
 os: linux
 

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -12,6 +12,8 @@ Changelog
     away in the next major release. Moving forward, you should use ``username``
     and ``password``. This should work in ``curator``, ``curator_cli``, and
     ``es_repo_mgr``.
+  * Removed tests for all 5.x branches of Elasticsearch but the final (5.6).
+  * Added tests for missing 7.x branches of Elasticsearch
 
 **Bug Fixes**
 
@@ -19,6 +21,7 @@ Changelog
     the APIs are not changed (yet—-that comes in the next major release).
   * Dockerfile has been updated to produce a working version with Python 3.7
     and Curator 5.8.1
+  * Pin (for now) Elasticsearch Python module to 7.1.0
 
 5.8.1 (25 September 2019)
 -------------------------

--- a/docs/asciidoc/actions.asciidoc
+++ b/docs/asciidoc/actions.asciidoc
@@ -15,6 +15,7 @@ once created, can only be deleted.
 * <<delete_indices,Delete Indices>>
 * <<delete_snapshots,Delete Snapshots>>
 * <<forcemerge,forceMerge>>
+* <<freeze,Freeze>>
 * <<index_settings,Index Settings>>
 * <<open,Open>>
 * <<reindex,Reindex>>
@@ -23,6 +24,7 @@ once created, can only be deleted.
 * <<rollover,Rollover>>
 * <<shrink,Shrink>>
 * <<snapshot,Snapshot>>
+* <<unfreeze,Unfreeze>>
 --
 
 [[alias]]
@@ -533,6 +535,37 @@ filters:
 
 TIP: See an example of this action in an <<actionfile,actionfile>>
     <<ex_forcemerge,here>>.
+
+[[freeze]]
+== Freeze
+
+[source,yaml]
+-------------
+action: freeze
+description: "freeze selected indices"
+options:
+  continue_if_exception: False
+filters:
+- filtertype: ...
+-------------
+
+NOTE: Empty values and commented lines will result in the default value, if any,
+    being selected.  If a setting is set, but not used by a given action, it
+    will be ignored.
+
+This action freezes the selected indices.
+In order to use this action, it is required to have at least a Basic license.
+See https://www.elastic.co/subscriptions[Subscriptions].
+
+=== Optional settings
+
+* <<option_ignore_empty,ignore_empty_list>>
+* <<option_timeout_override,timeout_override>>
+* <<option_continue,continue_if_exception>>
+* <<option_disable,disable_action>>
+
+TIP: See an example of this action in an <<actionfile,actionfile>>
+    <<ex_freeze,here>>.
 
 
 [[index_settings]]
@@ -1172,3 +1205,35 @@ read about them and change them accordingly.
 
 TIP: See an example of this action in an <<actionfile,actionfile>>
     <<ex_snapshot,here>>.
+    
+[[unfreeze]]
+== Unfreeze
+
+[source,yaml]
+-------------
+action: unfreeze
+description: "unfreeze selected indices"
+options:
+  continue_if_exception: False
+filters:
+- filtertype: ...
+-------------
+
+NOTE: Empty values and commented lines will result in the default value, if any,
+    being selected.  If a setting is set, but not used by a given action, it
+    will be ignored.
+
+This action unfreezes the selected indices.
+In order to use this action, it is required to have at least a Basic license.
+See https://www.elastic.co/subscriptions[Subscriptions].
+
+=== Optional settings
+
+* <<option_ignore_empty,ignore_empty_list>>
+* <<option_timeout_override,timeout_override>>
+* <<option_continue,continue_if_exception>>
+* <<option_disable,disable_action>>
+
+TIP: See an example of this action in an <<actionfile,actionfile>>
+    <<ex_unfreeze,here>>.
+

--- a/docs/asciidoc/examples.asciidoc
+++ b/docs/asciidoc/examples.asciidoc
@@ -15,6 +15,7 @@ You can use <<envvars,environment variables>> in your configuration files.
 * <<ex_delete_indices,delete_indices>>
 * <<ex_delete_snapshots,delete_snapshots>>
 * <<ex_forcemerge,forcemerge>>
+* <<ex_freeze,freeze>>
 * <<ex_open,open>>
 * <<ex_reindex,reindex>>
 * <<ex_replicas,replicas>>
@@ -22,7 +23,7 @@ You can use <<envvars,environment variables>> in your configuration files.
 * <<ex_rollover,rollover>>
 * <<ex_shrink,shrink>>
 * <<ex_snapshot,snapshot>>
-
+* <<ex_unfreeze,unfreeze>>
 --
 
 [[ex_alias]]
@@ -335,6 +336,45 @@ actions:
     - filtertype: forcemerged
       max_num_segments: 2
       exclude:
+-------------
+
+[[ex_freeze]]
+== freeze
+
+[source,yaml]
+-------------
+---
+# Remember, leave a key empty if there is no value.  None will be a string,
+# not a Python "NoneType"
+#
+# Also remember that all examples have 'disable_action' set to True.  If you
+# want to use this action as a template, be sure to set this to False after
+# copying it.
+actions:
+  1:
+    action: freeze
+    description: >-
+      Freeze indices older than 30 days but younger than 60 days (based on index
+      name), for logstash- prefixed indices.
+    options:
+      disable_action: True
+    filters:
+    - filtertype: pattern
+      kind: prefix
+      value: logstash-
+      exclude:
+    - filtertype: age
+      source: name
+      direction: older
+      timestring: '%Y.%m.%d'
+      unit: days
+      unit_count: 30
+    - filtertype: age
+      source: name
+      direction: younger
+      timestring: '%Y.%m.%d'
+      unit: days
+      unit_count: 60
 -------------
 
 
@@ -822,4 +862,45 @@ actions:
       unit: days
       unit_count: 1
 -------------
+
+
+[[ex_unfreeze]]
+== unfreeze
+
+[source,yaml]
+-------------
+---
+# Remember, leave a key empty if there is no value.  None will be a string,
+# not a Python "NoneType"
+#
+# Also remember that all examples have 'disable_action' set to True.  If you
+# want to use this action as a template, be sure to set this to False after
+# copying it.
+actions:
+  1:
+    action: unfreeze
+    description: >-
+      Unfreeze indices older than 30 days but younger than 60 days (based on index
+      name), for logstash- prefixed indices.
+    options:
+      disable_action: True
+    filters:
+    - filtertype: pattern
+      kind: prefix
+      value: logstash-
+      exclude:
+    - filtertype: age
+      source: name
+      direction: older
+      timestring: '%Y.%m.%d'
+      unit: days
+      unit_count: 30
+    - filtertype: age
+      source: name
+      direction: younger
+      timestring: '%Y.%m.%d'
+      unit: days
+      unit_count: 60
+-------------
+
 

--- a/docs/asciidoc/versions.asciidoc
+++ b/docs/asciidoc/versions.asciidoc
@@ -39,12 +39,19 @@ The current version of Curator is {curator_version}
 
 |&emsp14; &emsp14; &emsp14; &emsp14; &emsp14; 4
 |&emsp14; &#10060;
-|&emsp14; &#9989; 
+|&emsp14; &#9989;
 |&emsp14; &#9989;
 |&emsp14; &#10060;
 |&emsp14; &#10060;
 
-|&emsp14; &emsp14; &emsp14; &emsp14; &emsp14; 5
+|&emsp14; &emsp14; &emsp14; &emsp14; &emsp14; 5.6-
+|&emsp14; &#10060;
+|&emsp14; &#10060;
+|&emsp14; &#9989;
+|&emsp14; &#9989;
+|&emsp14; &#10060;
+
+|&emsp14; &emsp14; &emsp14; &emsp14; &emsp14; 5.7+
 |&emsp14; &#10060;
 |&emsp14; &#10060;
 |&emsp14; &#9989;

--- a/examples/actions/unfreeze.yml
+++ b/examples/actions/unfreeze.yml
@@ -7,9 +7,9 @@
 # copying it.
 actions:
   1:
-    action: open
+    action: unfreeze
     description: >-
-      Open indices older than 30 days but younger than 60 days (based on index
+      Unfreeze indices older than 30 days but younger than 60 days (based on index
       name), for logstash- prefixed indices.
     options:
       timeout_override:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 voluptuous>=0.9.3
-elasticsearch>=7.0.4,<8.0.0
+elasticsearch==7.1.0
 urllib3>=1.24.2,<1.25
 requests>=2.20.0
 boto3>=1.9.142

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,11 +17,13 @@ classifiers =
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
 
 [options]
 install_requires = 
     voluptuous>=0.9.3
-    elasticsearch>=7.0.4,<8.0.0
+    elasticsearch==7.1.0
     urllib3>=1.24.2,<1.25
     requests>=2.20.0
     boto3>=1.9.142
@@ -33,7 +35,7 @@ install_requires =
 
 setup_requires =
     voluptuous>=0.9.3
-    elasticsearch>=7.0.4,<8.0.0
+    elasticsearch==7.1.0
     urllib3>=1.24.2,<1.25
     requests>=2.20.0
     boto3>=1.9.142

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def get_version():
     return VERSION
 
 def get_install_requires():
-    res = ['elasticsearch>=7.0.4,<8.0.0' ]
+    res = ['elasticsearch==7.1.0' ]
     res.append('urllib3>=1.24.2,<1.25')
     res.append('requests>=2.20.0')
     res.append('boto3>=1.9.142')
@@ -133,6 +133,7 @@ try:
             "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
         ],
         test_suite = "test.run_tests.run_all",
         tests_require = ["mock", "nose", "coverage", "nosexcover"],


### PR DESCRIPTION
As mentioned in #1478

> Shows that Curator 5 is compatible with ES 7. However, a customer running Curator 5.6 found that it was not compatible with ES 7.2.
> 
> Obviously this is because ES 7.2 (or indeed any 7.x) didn't exist when Curator 5.6 was released. However, the Matrix seems to suggest that ANY Curator 5 will work with ES 7.x. Now, if I change the docs version to Curator 5.6, then the ES 7.x column disappears, so it's correct. But a Google search tends to take you to the latest doc, so I can understand how the customer made the mistake.

Fixes #1478

Split the matrix for 5 into two sections --> 5.6- and 5.7+ and updated the compatibility for ES7.x