### PR TITLE
Fix the hang of the shring method with ES 7.x

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -2095,8 +2095,8 @@ class Shrink(object):
             'settings': {
                 'index.number_of_shards' : number_of_shards,
                 'index.number_of_replicas' : number_of_replicas,
-                "index.routing.allocation.require._name": None,
-                "index.blocks.write": None
+                'index.routing.allocation.require._name': None,
+                'index.blocks.write': None
             }
         }
         if extra_settings:

--- a/curator/actions.py
+++ b/curator/actions.py
@@ -2091,16 +2091,23 @@ class Shrink(object):
         self.number_of_shards = number_of_shards
         self.wait_for_active_shards = wait_for_active_shards
         self.shrink_node_name = None
+
         self.body = {
             'settings': {
                 'index.number_of_shards' : number_of_shards,
                 'index.number_of_replicas' : number_of_replicas,
-                'index.routing.allocation.require._name': None,
-                'index.blocks.write': None
             }
         }
+
         if extra_settings:
             self._merge_extra_settings(extra_settings)
+
+        if utils.get_version(self.client) > (6, 0, 1):
+            self._merge_extra_settings({
+                'settings': {
+                    'index.routing.allocation.require._name': None,
+                    'index.blocks.write': None
+                }})
 
     def _merge_extra_settings(self, extra_settings):
         self.loggit.debug(

--- a/curator/actions.py
+++ b/curator/actions.py
@@ -2095,6 +2095,8 @@ class Shrink(object):
             'settings': {
                 'index.number_of_shards' : number_of_shards,
                 'index.number_of_replicas' : number_of_replicas,
+                "index.routing.allocation.require._name": None,
+                "index.blocks.write": None
             }
         }
         if extra_settings:

--- a/curator/actions.py
+++ b/curator/actions.py
@@ -2102,7 +2102,7 @@ class Shrink(object):
         if extra_settings:
             self._merge_extra_settings(extra_settings)
 
-        if utils.get_version(self.client) > (6, 0, 1):
+        if utils.get_version(self.client) >= (6, 1, 0):
             self._merge_extra_settings({
                 'settings': {
                     'index.routing.allocation.require._name': None,


### PR DESCRIPTION
Fixes #

## Proposed Changes

Related to issue #1494.

With this fix, when we're shrinking we're doing as shown by the ES [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/indices-shrink-index.html#_shrinking_an_index) : 

```
POST /my_source_index/_shrink/my_target_index
{
  "settings": {
    "index.routing.allocation.require._name": null, 
    "index.blocks.write": null 
  }
}
```
Hence, the shrink index operation doesn't hang anymore because of the routing requirement.

It seems that all tests be played against a single ES instance.
This use case requires a cluster in order to reproduce this error with integration tests (need help).