### PR TITLE
Ensure proper API call is used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - "2.7"
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -1164,7 +1164,7 @@ def find_snapshot_tasks(client):
     :rtype: bool
     """
     retval = False
-    tasklist = client.tasks.get()
+    tasklist = client.tasks.list()
     for node in tasklist['nodes']:
         for task in tasklist['nodes'][node]['tasks']:
             activity = tasklist['nodes'][node]['tasks'][task]['action']

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -14,6 +14,8 @@ Changelog
     ``es_repo_mgr``.
   * Removed tests for all 5.x branches of Elasticsearch but the final (5.6).
   * Added tests for missing 7.x branches of Elasticsearch
+  * Remove tests for Python 3.5 
+  * Fix hang of Shrink action in ES 7.x in #1528 (jclegras)
 
 **Bug Fixes**
 
@@ -21,7 +23,18 @@ Changelog
     the APIs are not changed (yet—-that comes in the next major release).
   * Dockerfile has been updated to produce a working version with Python 3.7
     and Curator 5.8.1
-  * Pin (for now) Elasticsearch Python module to 7.1.0
+  * Pin (for now) Elasticsearch Python module to 7.1.0. This will be updated
+    when an updated release of the module fixes the `cluster.state` API call
+    regression at https://github.com/elastic/elasticsearch-py/issues/1141
+  * Fix ``client.tasks.get`` API call to be ``client.tasks.list`` when no index
+    name is provided.  See
+    https://github.com/elastic/elasticsearch-py/issues/1110
+
+**Documentation**
+
+  * Add Freeze/Unfreeze documentation in #1497 (lucabelluccini)
+  * Update compatibility matrix in #1522 (jibsonline)
+  * Add ECS logging output in #1529 (m1keil)
 
 5.8.1 (25 September 2019)
 -------------------------

--- a/test/unit/test_action_delete_snapshots.py
+++ b/test/unit/test_action_delete_snapshots.py
@@ -29,7 +29,7 @@ class TestActionDeleteSnapshots(TestCase):
         client = Mock()
         client.snapshot.get.return_value = testvars.snapshots
         client.snapshot.get_repository.return_value = testvars.test_repo
-        client.tasks.get.return_value = testvars.no_snap_tasks
+        client.tasks.list.return_value = testvars.no_snap_tasks
         client.snapshot.delete.return_value = None
         slo = curator.SnapshotList(client, repository=testvars.repo_name)
         do = curator.DeleteSnapshots(slo)
@@ -39,7 +39,7 @@ class TestActionDeleteSnapshots(TestCase):
         client.snapshot.get.return_value = testvars.snapshots
         client.snapshot.get_repository.return_value = testvars.test_repo
         client.snapshot.delete.return_value = None
-        client.tasks.get.return_value = testvars.no_snap_tasks
+        client.tasks.list.return_value = testvars.no_snap_tasks
         client.snapshot.delete.side_effect = testvars.fake_fail
         slo = curator.SnapshotList(client, repository=testvars.repo_name)
         do = curator.DeleteSnapshots(slo)
@@ -48,7 +48,7 @@ class TestActionDeleteSnapshots(TestCase):
         client = Mock()
         client.snapshot.get.return_value = testvars.inprogress
         client.snapshot.get_repository.return_value = testvars.test_repo
-        client.tasks.get.return_value = testvars.no_snap_tasks
+        client.tasks.list.return_value = testvars.no_snap_tasks
         slo = curator.SnapshotList(client, repository=testvars.repo_name)
         do = curator.DeleteSnapshots(slo, retry_interval=0, retry_count=1)
         self.assertRaises(curator.FailedExecution, do.do_action)

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -576,7 +576,7 @@ class TestSafeToSnap(TestCase):
         client = Mock()
         client.snapshot.get.return_value = testvars.inprogress
         client.snapshot.get_repository.return_value = testvars.test_repo
-        client.tasks.get.return_value = testvars.no_snap_tasks
+        client.tasks.list.return_value = testvars.no_snap_tasks
         self.assertFalse(
             curator.safe_to_snap(
                 client, repository=testvars.repo_name,
@@ -587,7 +587,7 @@ class TestSafeToSnap(TestCase):
         client = Mock()
         client.snapshot.get.return_value = testvars.snapshots
         client.snapshot.get_repository.return_value = testvars.test_repo
-        client.tasks.get.return_value = testvars.snap_task
+        client.tasks.list.return_value = testvars.snap_task
         self.assertFalse(
             curator.safe_to_snap(
                 client, repository=testvars.repo_name,
@@ -598,7 +598,7 @@ class TestSafeToSnap(TestCase):
         client = Mock()
         client.snapshot.get.return_value = testvars.snapshots
         client.snapshot.get_repository.return_value = testvars.test_repo
-        client.tasks.get.return_value = testvars.no_snap_tasks
+        client.tasks.list.return_value = testvars.no_snap_tasks
         self.assertTrue(
             curator.safe_to_snap(
                 client, repository=testvars.repo_name,


### PR DESCRIPTION
In older releases (< 7.5) of ES Python module, `client.tasks.get()` will return a list of all tasks. However, starting in 7.5, this results in a failed API call. See https://github.com/elastic/elasticsearch-py/issues/1110

Correct behavior is to use `client.tasks.list()` when no task id is provided.
