### PR TITLE
Compaaring strings using the 'is' operator causes a syntax warning.

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -148,7 +148,7 @@ class Alias(object):
                 '"{3}"'.format(
                     job.rstrip('e'),
                     index,
-                    'to' if job is 'add' else 'from',
+                    'to' if job == 'add' else 'from',
                     alias
                 )
             )


### PR DESCRIPTION
https://realpython.com/lessons/warnings-about-dangerous-syntax/

