### PR TITLE
support regional STS endpoint usage, add AWS EKS IRSA dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN pip3 install -r requirements.txt
 RUN python3 setup.py build_exe
 
 FROM alpine:3.7
-RUN apk --no-cache upgrade && apk --no-cache add openssl-dev
+RUN apk --no-cache upgrade && apk --no-cache add openssl-dev expat
 COPY --from=builder build/exe.linux-x86_64-3.7 /curator/
 
 USER nobody:nobody

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -869,7 +869,10 @@ def try_boto_session(data):
             LOGGER.error('Unable to sign AWS requests. Failed to import a module: {0}'.format(err))
             raise ImportError('Failed to import a module: {0}'.format(err))
         try:
-            session = session.Session()
+            if 'aws_region' in data:
+                session = session.Session(region_name=data['aws_region'])
+            else:
+                session = session.Session()
             credentials = session.get_credentials()
             data['aws_key'] = credentials.access_key
             data['aws_secret_key'] = credentials.secret_key

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1437,6 +1437,22 @@ class Test_try_boto_session(TestCase):
         type(boto3_mock.get_credentials).token = PropertyMock(return_value=token)
         returned = curator.utils.try_boto_session(test_data)
         self.assertTrue('test_value', returned['other'])
+    @patch.object(boto3.Session, 'get_credentials')
+    def test_credentials_obtained_success_with_region(self, boto3_mock):
+        """Test that credentials are passed successfully if a ``Session()`` is established"""
+        test_data = self.empty()
+        test_data['aws_sign_request'] = True
+        test_data['aws_region'] = 'us-west-1'
+        access = 'sample_access_key'
+        secret = 'sample_secret_key'
+        token = 'sample_token'
+        test_tuple = [('aws_access_key', access), ('aws_secret_key', secret), ('aws_token', token)]
+        boto3_mock.get_credentials.return_value = (access, secret, token)
+        type(boto3_mock.get_credentials).access_key = PropertyMock(return_value=access)
+        type(boto3_mock.get_credentials).secret_key = PropertyMock(return_value=secret)
+        type(boto3_mock.get_credentials).token = PropertyMock(return_value=token)
+        returned = curator.utils.try_boto_session(test_data)
+        self.assertTrue('test_value', returned['other'])
 
 class Test_try_aws_auth(TestCase):
     """


### PR DESCRIPTION
Fixes #1535

## Proposed Changes

  - use aws_region variable in boto3 session if available
  - add XML dependency to parse sts web token responses