### PR TITLE
raise exception when unable to create index

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -582,7 +582,9 @@ class CreateIndex(object):
             if err.error in match_list and self.ignore_existing:
                 self.loggit.warn('Index %s already exists.' % self.name)
             else:
-                raise exceptions.FailedExecution('Index %s already exists.' % self.name)
+                raise exceptions.FailedExecution(
+                    'Unable to create index \"{0}\". Exception: {1}'.format(self.name, err)
+                )
         except Exception as err:
             utils.report_failure(err)
 


### PR DESCRIPTION
Fixes https://github.com/elastic/curator/issues/1525

## Proposed Changes

Raise an exception for an failure to create index, and report the cause of the exception