### PR TITLE
[docs] clarification on prefix and suffix kinds

### DIFF
--- a/docs/asciidoc/inc_kinds.asciidoc
+++ b/docs/asciidoc/inc_kinds.asciidoc
@@ -21,6 +21,8 @@ To match all indices _except_ those starting with `logstash-`:
  exclude: True
 -------------
 
+Note: Internally _regex_ pattern is constructed from prefix value as `^{0}.*$`. Special characters should be escaped with backslash to match literally.
+
 === suffix
 
 To match all indices ending with `-prod`:
@@ -41,6 +43,8 @@ To match all indices _except_ those ending with `-prod`:
  value: -prod
  exclude: True
 -------------
+
+Note: Internally _regex_ pattern is constructed from suffix value as `^.*{0}$`. Specials character should be escaped with backslash to match literally.
 
 === timestring
 


### PR DESCRIPTION
Clarify that values of `prefix` and `suffix` filter kinds are not taken literally but rather a regexp is constructed from them.
This is important difference if index names are using dots (or other special characters).
For example, with  prefix of `value: project.prod-a.` the index `project.prod-admin-portal.2020.10.15` is matched. By reading the documentation this is unexpected as the impression is that prefix and suffix should be used literally.

