### PR TITLE
Update urllib3 upper pin to <1.26

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 voluptuous>=0.9.3
 elasticsearch==7.1.0
-urllib3>=1.24.2,<1.25
+urllib3>=1.24.2,<1.26
 requests>=2.20.0
 boto3>=1.9.142
 requests_aws4auth>=0.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 install_requires = 
     voluptuous>=0.9.3
     elasticsearch==7.1.0
-    urllib3>=1.24.2,<1.25
+    urllib3>=1.24.2,<1.26
     requests>=2.20.0
     boto3>=1.9.142
     requests_aws4auth>=0.9
@@ -36,7 +36,7 @@ install_requires =
 setup_requires =
     voluptuous>=0.9.3
     elasticsearch==7.1.0
-    urllib3>=1.24.2,<1.25
+    urllib3>=1.24.2,<1.26
     requests>=2.20.0
     boto3>=1.9.142
     requests_aws4auth>=0.9

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def get_version():
 
 def get_install_requires():
     res = ['elasticsearch==7.1.0' ]
-    res.append('urllib3>=1.24.2,<1.25')
+    res.append('urllib3>=1.24.2,<1.26')
     res.append('requests>=2.20.0')
     res.append('boto3>=1.9.142')
     res.append('requests_aws4auth>=0.9')


### PR DESCRIPTION
Fixes #1560 Fixed #1559 

## Proposed Changes

- Change the upper bound on `urllib3` to <1.26 to allow `botocore` 1.19.x to install without dependency conflicts.
