### PR TITLE
[DOCS] Update restore snapshot index setting links

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -1812,7 +1812,7 @@ class Restore(object):
         :type rename_replacement: str
         :arg extra_settings: Extra settings, including shard count and settings
             to omit. For more information see
-            https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_changing_index_settings_during_restore
+            https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshots-restore-snapshot.html#change-index-settings-during-restore
         :type extra_settings: dict, representing the settings.
         :arg wait_for_completion: Wait (or not) for the operation
             to complete before returning.  (default: `True`)

--- a/docs/asciidoc/actions.asciidoc
+++ b/docs/asciidoc/actions.asciidoc
@@ -918,7 +918,7 @@ actions:
 
 In this case, the number of replicas will be applied to the restored indices.
 
-For more information see the {ref}/modules-snapshots.html#_changing_index_settings_during_restore[official Elasticsearch Documentation].
+For more information see the {ref}/snapshots-restore-snapshot.html#change-index-settings-during-restore[official Elasticsearch Documentation].
 
 === Required settings
 

--- a/docs/asciidoc/options.asciidoc
+++ b/docs/asciidoc/options.asciidoc
@@ -358,7 +358,7 @@ options:
 
 === <<restore,restore>>
 
-See the {ref}/modules-snapshots.html#_changing_index_settings_during_restore[official Elasticsearch Documentation].
+See the {ref}/snapshots-restore-snapshot.html#change-index-settings-during-restore[official Elasticsearch Documentation].
 
 [source,yaml]
 -------------


### PR DESCRIPTION
Updates several links to the [Changing index settings during restore](https://www.elastic.co/guide/en/elasticsearch/reference/master/snapshots-restore-snapshot.html#change-index-settings-during-restore) section of the ES reference. These work due to a redirect, but this will improve the UX.