### PR TITLE
Update pyyaml to 5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ requests>=2.20.0
 boto3>=1.9.142
 requests_aws4auth>=0.9
 click>=6.7,<7.0
-pyyaml==3.13
+pyyaml==5.1
 certifi>=2019.9.11
 six>=1.11.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.8
 
 [options]
-install_requires = 
+install_requires =
     voluptuous>=0.9.3
     elasticsearch==7.1.0
     urllib3>=1.24.2,<1.26
@@ -29,7 +29,7 @@ install_requires =
     boto3>=1.9.142
     requests_aws4auth>=0.9
     click>=6.7,<7.0
-    pyyaml==3.13
+    pyyaml==5.1
     certifi>=2019.9.11
     six>=1.11.0
 
@@ -41,7 +41,7 @@ setup_requires =
     boto3>=1.9.142
     requests_aws4auth>=0.9
     click>=6.7,<7.0
-    pyyaml==3.13
+    pyyaml==5.1
     certifi>=2019.9.11
     six>=1.11.0
 
@@ -54,7 +54,7 @@ tests_require =
     nosexcover
 
 [options.entry_points]
-console_scripts = 
+console_scripts =
     curator = curator.cli:cli
     curator_cli = curator.curator_cli:main
     es_repo_mgr = curator.repomgrcli:repo_mgr_cli

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def get_install_requires():
     res.append('boto3>=1.9.142')
     res.append('requests_aws4auth>=0.9')
     res.append('click>=6.7,<7.0')
-    res.append('pyyaml==3.13')
+    res.append('pyyaml==5.1')
     res.append('voluptuous>=0.9.3')
     res.append('certifi>=2019.9.11')
     res.append('six>=1.11.0')
@@ -98,7 +98,7 @@ try:
             packages = [],
             excludes = [],
             include_files = [cert_file, msvcrt],
-            include_msvcr = True, 
+            include_msvcr = True,
         )
 
     setup(


### PR DESCRIPTION
This commit updates pyyaml version from 3.13 to 5.1 to fix
CVE-2017-18342[0].

[0]: https://github.com/advisories/GHSA-rprw-h62v-c2w7
