### PR TITLE
unpin urllib and click

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,11 @@ def get_version():
 
 def get_install_requires():
     res = ['elasticsearch==7.1.0' ]
-    res.append('urllib3>=1.24.2,<1.26')
+    res.append('urllib3>=1.24.2')
     res.append('requests>=2.20.0')
     res.append('boto3>=1.9.142')
     res.append('requests_aws4auth>=0.9')
-    res.append('click>=6.7,<7.0')
+    res.append('click>=6.7')
     res.append('pyyaml==3.13')
     res.append('voluptuous>=0.9.3')
     res.append('certifi>=2019.9.11')


### PR DESCRIPTION
Fixes https://github.com/elastic/curator/issues/1589

## Proposed Changes

 The current pinning of deps makes curator unusable alongside the latest version of celery in a project for example. This PR removes that constraint.