### PR TITLE
Version bump to pyyaml 5.4.1

### DIFF
--- a/curator/utils.py
+++ b/curator/utils.py
@@ -56,7 +56,7 @@ def get_yaml(path):
     yaml.add_constructor('!single', single_constructor)
 
     try:
-        return yaml.load(read_file(path))
+        return yaml.load(read_file(path), Loader=yaml.FullLoader)
     except yaml.scanner.ScannerError as err:
         print('Unable to read/parse YAML file: {0}'.format(path))
         print(err)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ requests>=2.20.0
 boto3>=1.9.142
 requests_aws4auth>=0.9
 click>=6.7,<7.0
-pyyaml==3.13
+pyyaml==5.4.1
 certifi>=2019.9.11
 six>=1.11.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     boto3>=1.9.142
     requests_aws4auth>=0.9
     click>=6.7,<7.0
-    pyyaml==3.13
+    pyyaml==5.4.1
     certifi>=2019.9.11
     six>=1.11.0
 
@@ -41,7 +41,7 @@ setup_requires =
     boto3>=1.9.142
     requests_aws4auth>=0.9
     click>=6.7,<7.0
-    pyyaml==3.13
+    pyyaml==5.4.1
     certifi>=2019.9.11
     six>=1.11.0
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def get_install_requires():
     res.append('boto3>=1.9.142')
     res.append('requests_aws4auth>=0.9')
     res.append('click>=6.7,<7.0')
-    res.append('pyyaml==3.13')
+    res.append('pyyaml==5.4.1')
     res.append('voluptuous>=0.9.3')
     res.append('certifi>=2019.9.11')
     res.append('six>=1.11.0')

--- a/test/unit/test_class_index_list.py
+++ b/test/unit/test_class_index_list.py
@@ -800,7 +800,7 @@ class TestIterateFiltersIndex(TestCase):
         client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
         ilo = curator.IndexList(client)
-        config = yaml.load(testvars.pattern_ft)['actions'][1]
+        config = yaml.load(testvars.pattern_ft, Loader=yaml.FullLoader)['actions'][1]
         ilo.iterate_filters(config)
         self.assertEqual(['a-2016.03.03'], ilo.indices)
     def test_age_filtertype(self):
@@ -810,7 +810,7 @@ class TestIterateFiltersIndex(TestCase):
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
         ilo = curator.IndexList(client)
-        config = yaml.load(testvars.age_ft)['actions'][1]
+        config = yaml.load(testvars.age_ft, Loader=yaml.FullLoader)['actions'][1]
         ilo.iterate_filters(config)
         self.assertEqual(['index-2016.03.03'], ilo.indices)
     def test_space_filtertype(self):
@@ -821,7 +821,7 @@ class TestIterateFiltersIndex(TestCase):
         client.indices.stats.return_value = testvars.stats_four
         client.field_stats.return_value = testvars.fieldstats_four
         ilo = curator.IndexList(client)
-        config = yaml.load(testvars.space_ft)['actions'][1]
+        config = yaml.load(testvars.space_ft, Loader=yaml.FullLoader)['actions'][1]
         ilo.iterate_filters(config)
         self.assertEqual(['a-2016.03.03'], ilo.indices)
     def test_forcemerge_filtertype(self):
@@ -832,7 +832,7 @@ class TestIterateFiltersIndex(TestCase):
         client.indices.stats.return_value = testvars.stats_one
         client.indices.segments.return_value = testvars.shards
         ilo = curator.IndexList(client)
-        config = yaml.load(testvars.forcemerge_ft)['actions'][1]
+        config = yaml.load(testvars.forcemerge_ft, Loader=yaml.FullLoader)['actions'][1]
         ilo.iterate_filters(config)
         self.assertEqual([testvars.named_index], ilo.indices)
     def test_allocated_filtertype(self):
@@ -842,7 +842,7 @@ class TestIterateFiltersIndex(TestCase):
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
         ilo = curator.IndexList(client)
-        config = yaml.load(testvars.allocated_ft)['actions'][1]
+        config = yaml.load(testvars.allocated_ft, Loader=yaml.FullLoader)['actions'][1]
         ilo.iterate_filters(config)
         self.assertEqual(['index-2016.03.04'], ilo.indices)
     def test_kibana_filtertype(self):
@@ -857,7 +857,7 @@ class TestIterateFiltersIndex(TestCase):
         ilo.indices = [
             '.kibana', '.kibana-5', '.kibana-6', 'dummy'
         ]
-        config = yaml.load(testvars.kibana_ft)['actions'][1]
+        config = yaml.load(testvars.kibana_ft, Loader=yaml.FullLoader)['actions'][1]
         ilo.iterate_filters(config)
         self.assertEqual(['dummy'], ilo.indices)
     def test_opened_filtertype(self):
@@ -868,7 +868,7 @@ class TestIterateFiltersIndex(TestCase):
         client.indices.stats.return_value = testvars.stats_four
         client.field_stats.return_value = testvars.fieldstats_four
         ilo = curator.IndexList(client)
-        config = yaml.load(testvars.opened_ft)['actions'][1]
+        config = yaml.load(testvars.opened_ft, Loader=yaml.FullLoader)['actions'][1]
         ilo.iterate_filters(config)
         self.assertEqual(['c-2016.03.05'], ilo.indices)
     def test_closed_filtertype(self):
@@ -879,7 +879,7 @@ class TestIterateFiltersIndex(TestCase):
         client.indices.stats.return_value = testvars.stats_four
         client.field_stats.return_value = testvars.fieldstats_four
         ilo = curator.IndexList(client)
-        config = yaml.load(testvars.closed_ft)['actions'][1]
+        config = yaml.load(testvars.closed_ft, Loader=yaml.FullLoader)['actions'][1]
         ilo.iterate_filters(config)
         self.assertEqual(
             ['a-2016.03.03','b-2016.03.04','d-2016.03.06'], sorted(ilo.indices))
@@ -890,7 +890,7 @@ class TestIterateFiltersIndex(TestCase):
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
         ilo = curator.IndexList(client)
-        config = yaml.load(testvars.none_ft)['actions'][1]
+        config = yaml.load(testvars.none_ft, Loader=yaml.FullLoader)['actions'][1]
         ilo.iterate_filters(config)
         self.assertEqual(
             ['index-2016.03.03', 'index-2016.03.04'], sorted(ilo.indices))
@@ -901,7 +901,7 @@ class TestIterateFiltersIndex(TestCase):
         client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
         ilo = curator.IndexList(client)
-        config = yaml.load(testvars.invalid_ft)['actions'][1]
+        config = yaml.load(testvars.invalid_ft, Loader=yaml.FullLoader)['actions'][1]
         self.assertRaises(
             curator.ConfigurationError,
             ilo.iterate_filters, config

--- a/test/unit/test_class_snapshot_list.py
+++ b/test/unit/test_class_snapshot_list.py
@@ -320,7 +320,7 @@ class TestIterateFiltersSnaps(TestCase):
         client.snapshot.get.return_value = testvars.snapshots
         client.snapshot.get_repository.return_value = testvars.test_repo
         slo = curator.SnapshotList(client, repository=testvars.repo_name)
-        config = yaml.load(testvars.invalid_ft)['actions'][1]
+        config = yaml.load(testvars.invalid_ft, Loader=yaml.FullLoader)['actions'][1]
         self.assertRaises(
             curator.ConfigurationError,
             slo.iterate_filters, config
@@ -330,7 +330,7 @@ class TestIterateFiltersSnaps(TestCase):
         client.snapshot.get.return_value = testvars.snapshots
         client.snapshot.get_repository.return_value = testvars.test_repo
         slo = curator.SnapshotList(client, repository=testvars.repo_name)
-        config = yaml.load(testvars.snap_age_ft)['actions'][1]
+        config = yaml.load(testvars.snap_age_ft, Loader=yaml.FullLoader)['actions'][1]
         slo.iterate_filters(config)
         self.assertEqual(
             ['snap_name', 'snapshot-2015.03.01'], sorted(slo.snapshots))
@@ -339,7 +339,7 @@ class TestIterateFiltersSnaps(TestCase):
         client.snapshot.get.return_value = testvars.snapshots
         client.snapshot.get_repository.return_value = testvars.test_repo
         slo = curator.SnapshotList(client, repository=testvars.repo_name)
-        config = yaml.load(testvars.snap_pattern_ft)['actions'][1]
+        config = yaml.load(testvars.snap_pattern_ft, Loader=yaml.FullLoader)['actions'][1]
         slo.iterate_filters(config)
         self.assertEqual(
             ['snap_name', 'snapshot-2015.03.01'], sorted(slo.snapshots))
@@ -348,7 +348,7 @@ class TestIterateFiltersSnaps(TestCase):
         client.snapshot.get.return_value = testvars.snapshots
         client.snapshot.get_repository.return_value = testvars.test_repo
         slo = curator.SnapshotList(client, repository=testvars.repo_name)
-        config = yaml.load(testvars.snap_none_ft)['actions'][1]
+        config = yaml.load(testvars.snap_none_ft, Loader=yaml.FullLoader)['actions'][1]
         slo.iterate_filters(config)
         self.assertEqual(
             ['snap_name', 'snapshot-2015.03.01'], sorted(slo.snapshots))


### PR DESCRIPTION
This is yet another trial at bumping PyYAML to latest version.  Various efforts have failed due to compatibility issues but I wanted to make one more try, since it looked to me like it might work now.

Motivation: Many CVEs have been reported for PyYAML which are now found by vulnerability scanners when scanning the system with the old PyYAML version:

* https://nvd.nist.gov/vuln/detail/CVE-2020-14343
* https://nvd.nist.gov/vuln/detail/CVE-2020-1747
* https://nvd.nist.gov/vuln/detail/CVE-2019-20477
* https://nvd.nist.gov/vuln/detail/CVE-2017-18342