### PR TITLE
readme: fix link and footnote

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,11 +76,11 @@ can use the env variable ``TEST_ES_SERVER`` to point to a different instance
 Origins
 -------
 
-Curator was first called ``clearESindices.py`` [1] and was almost immediately
-renamed to ``logstash_index_cleaner.py`` [1].  After a time it was migrated
-under the [logstash](https://github.com/elastic/logstash) repository as
+Curator was first called ``clearESindices.py`` [1]_ and was almost immediately
+renamed to ``logstash_index_cleaner.py`` [1]_.  After a time it was migrated
+under the `logstash <https://github.com/elastic/logstash>`_ repository as
 ``expire_logs``.  Soon thereafter, Jordan Sissel was hired by Elasticsearch, as
 was the original author of this tool.  It became Elasticsearch Curator after
-that and is now hosted at <https://github.com/elastic/curator>
+that and is now hosted at `elastic/curator <https://github.com/elastic/curator>`_.
 
-[1] <https://logstash.jira.com/browse/LOGSTASH-211>
+.. [1] `LOGSTASH-211 <https://logstash.jira.com/browse/LOGSTASH-211>`_.


### PR DESCRIPTION
Fixes --

## Proposed Changes

 Converts the Markdown leftover in the readme into reStructured Text.
