### PR TITLE
add .dockerignore to increase build speed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile


### PR DESCRIPTION
On development when you change Dockerfile and run building Docker image, it starts from scratch, because with command "COPY . ." Dockerfile is copied too which forces Docker Builder to ignore building cache. We can prevent that by adding .dockerignore file with added line "Dockerfile". In future more files could be added to .dockerignore to increase build speed.