### PR TITLE
fix segfault

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,10 @@ RUN python3 setup.py build_exe
 
 FROM alpine:3.13
 RUN apk --no-cache upgrade && apk --no-cache add openssl-dev expat
-COPY --from=builder build/exe.linux-x86_64-3.9 /curator/
+COPY --from=builder build/exe.linux-x86_64-3.9 /build/exe.linux-x86_64-3.9/
 RUN mkdir /.curator
 
 USER nobody:nobody
 ENV LD_LIBRARY_PATH /curator/lib:$LD_LIBRARY_PATH
-ENTRYPOINT ["/curator/curator"]
-
+ENV PATH /build/exe.linux-x86_64-3.9:$PATH
+ENTRYPOINT ["curator"]


### PR DESCRIPTION
On build latest version I found strange bug - if copy build-folder to any folder with other name - curator shows error "segmentation fault". I guess it's because build-script defines hard-coded path in compiled binary and as curator's folder moved to /curator/, its binary can't import compiled libraries from old path.
In this PR we add curator's binary to PATH, but leaved it in build-folder, so curator will run without "Segmentation fault" error.