### PR TITLE
Version bump urllib3 to 1.26.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 voluptuous>=0.12.1
 elasticsearch>=7.12.0,<8.0.0
-urllib3==1.26.4
+urllib3==1.26.5
 requests>=2.25.1
 boto3>=1.17.57
 requests_aws4auth>=1.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
 install_requires = 
     voluptuous>=0.12.1
     elasticsearch>=7.12.0,<8.0.0
-    urllib3==1.26.4
+    urllib3==1.26.5
     requests>=2.25.1
     boto3>=boto3-1.17.57
     requests_aws4auth>=1.0.1
@@ -35,7 +35,7 @@ install_requires =
 setup_requires =
     voluptuous>=0.12.1
     elasticsearch>=7.12.0,<8.0.0
-    urllib3==1.26.4
+    urllib3==1.26.5
     requests>=2.25.1
     boto3>=boto3-1.17.57
     requests_aws4auth>=1.0.1

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def get_version():
 
 def get_install_requires():
     res = ['elasticsearch>=7.12.0,<8.0.0' ]
-    res.append('urllib3==1.26.4')
+    res.append('urllib3==1.26.5')
     res.append('requests>=2.25.1')
     res.append('boto3>=1.17.57')
     res.append('requests_aws4auth>=1.0.1')


### PR DESCRIPTION
Updates version of urllib3 dependency to 1.26.5 to avoid https://github.com/advisories/GHSA-q2q7-5pp4-w6pg.

Fixes #1609
