### PR TITLE
Adding support for data_hot role on data_node detection

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -2139,7 +2139,7 @@ class Shrink(object):
     def _data_node(self, node_id):
         roles = utils.node_roles(self.client, node_id)
         name = utils.node_id_to_name(self.client, node_id)
-        if not 'data' in roles:
+        if not 'data' in roles and not 'data_hot' in roles:
             self.loggit.info('Skipping node "{0}": non-data node'.format(name))
             return False
         if 'master' in roles and not self.node_filters['permit_masters']:


### PR DESCRIPTION
Fixes #1620 

## Proposed Changes
  - Added data_hot role to _data_node check function
  - I havn't added the data_warm role to the list as these nodes are less wanted/efficient to run shrink operations
