### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/test/integration/test_alias.py
+++ b/test/integration/test_alias.py
@@ -35,7 +35,7 @@ class TestActionFileAlias(CuratorTestCase):
                         self.args['actionfile']
                     ],
                     )
-        self.assertEquals(2, len(self.client.indices.get_alias(name=alias)))
+        self.assertEqual(2, len(self.client.indices.get_alias(name=alias)))
     def test_add_only_with_extra_settings(self):
         alias = 'testalias'
         self.write_config(
@@ -51,7 +51,7 @@ class TestActionFileAlias(CuratorTestCase):
                         self.args['actionfile']
                     ],
                     )
-        self.assertEquals(
+        self.assertEqual(
             {
                 'my_index': {
                     'aliases': {
@@ -108,9 +108,9 @@ class TestActionFileAlias(CuratorTestCase):
                     )
         version = curator.get_version(self.client)
         if version > (3,0,0):
-            self.assertEquals(2, len(self.client.indices.get_alias(name=alias)))
+            self.assertEqual(2, len(self.client.indices.get_alias(name=alias)))
         else:
-            self.assertEquals(1, len(self.client.indices.get_alias(name=alias)))
+            self.assertEqual(1, len(self.client.indices.get_alias(name=alias)))
     def test_add_and_remove(self):
         alias = 'testalias'
         self.write_config(

--- a/test/integration/test_allocation.py
+++ b/test/integration/test_allocation.py
@@ -39,10 +39,10 @@ class TestActionFileAllocation(CuratorTestCase):
                         self.args['actionfile']
                     ],
                     )
-        self.assertEquals(value,
+        self.assertEqual(value,
             self.client.indices.get_settings(index='my_index')['my_index']['settings']['index']['routing']['allocation'][at][key])
         if ver >= (7, 10, 0):
-            self.assertEquals(
+            self.assertEqual(
                 EMPTY710ROUTING,
                 self.client.indices.get_settings(index='not_my_index')['not_my_index']['settings']['index']['routing']
             )
@@ -70,10 +70,10 @@ class TestActionFileAllocation(CuratorTestCase):
                         self.args['actionfile']
                     ],
                     )
-        self.assertEquals(value,
+        self.assertEqual(value,
             self.client.indices.get_settings(index='my_index')['my_index']['settings']['index']['routing']['allocation'][at][key])
         if ver >= (7, 10, 0):
-            self.assertEquals(
+            self.assertEqual(
                 EMPTY710ROUTING,
                 self.client.indices.get_settings(index='not_my_index')['not_my_index']['settings']['index']['routing']
             )
@@ -101,10 +101,10 @@ class TestActionFileAllocation(CuratorTestCase):
                         self.args['actionfile']
                     ],
                     )
-        self.assertEquals(value,
+        self.assertEqual(value,
             self.client.indices.get_settings(index='my_index')['my_index']['settings']['index']['routing']['allocation'][at][key])
         if ver >= (7, 10, 0):
-            self.assertEquals(
+            self.assertEqual(
                 EMPTY710ROUTING,
                 self.client.indices.get_settings(index='not_my_index')['not_my_index']['settings']['index']['routing']
             )
@@ -130,7 +130,7 @@ class TestActionFileAllocation(CuratorTestCase):
             body={'index.routing.allocation.{0}.{1}'.format(at, key): 'bar'}
         )
         # Ensure we _have_ it here first.
-        self.assertEquals('bar',
+        self.assertEqual('bar',
             self.client.indices.get_settings(index='my_index')['my_index']['settings']['index']['routing']['allocation'][at][key])
         test = clicktest.CliRunner()
         _ = test.invoke(
@@ -141,11 +141,11 @@ class TestActionFileAllocation(CuratorTestCase):
                     ],
                     )
         if ver >= (7, 10, 0):
-            self.assertEquals(
+            self.assertEqual(
                 EMPTY710ROUTING,
                 self.client.indices.get_settings(index='my_index')['my_index']['settings']['index']['routing']
             )
-            self.assertEquals(
+            self.assertEqual(
                 EMPTY710ROUTING,
                 self.client.indices.get_settings(index='not_my_index')['not_my_index']['settings']['index']['routing']
             )
@@ -213,11 +213,11 @@ class TestActionFileAllocation(CuratorTestCase):
                     ],
                     )
         if ver >= (7, 10, 0):
-            self.assertEquals(
+            self.assertEqual(
                 EMPTY710ROUTING,
                 self.client.indices.get_settings(index='my_index')['my_index']['settings']['index']['routing']
             )
-            self.assertEquals(
+            self.assertEqual(
                 EMPTY710ROUTING,
                 self.client.indices.get_settings(index='not_my_index')['not_my_index']['settings']['index']['routing']
             )
@@ -247,10 +247,10 @@ class TestActionFileAllocation(CuratorTestCase):
                         self.args['actionfile']
                     ],
                     )
-        self.assertEquals(value,
+        self.assertEqual(value,
             self.client.indices.get_settings(index='my_index')['my_index']['settings']['index']['routing']['allocation'][at][key])
         if ver >= (7, 10, 0):
-            self.assertEquals(
+            self.assertEqual(
                 EMPTY710ROUTING,
                 self.client.indices.get_settings(index='not_my_index')['not_my_index']['settings']['index']['routing']
             )
@@ -279,10 +279,10 @@ class TestCLIAllocation(CuratorTestCase):
             '--filter_list', '{"filtertype":"pattern","kind":"prefix","value":"my"}',
         ]
         self.assertEqual(0, self.run_subprocess(args, logname='TestCLIAllocation.test_include'))
-        self.assertEquals(value,
+        self.assertEqual(value,
             self.client.indices.get_settings(index='my_index')['my_index']['settings']['index']['routing']['allocation'][at][key])
         if ver >= (7, 10, 0):
-            self.assertEquals(
+            self.assertEqual(
                 EMPTY710ROUTING,
                 self.client.indices.get_settings(index='not_my_index')['not_my_index']['settings']['index']['routing']
             )

--- a/test/integration/test_cli.py
+++ b/test/integration/test_cli.py
@@ -168,7 +168,7 @@ class TestCLIMethods(CuratorTestCase):
 
                     ],
                     )
-        self.assertEquals(10, len(curator.get_indices(self.client)))
+        self.assertEqual(10, len(curator.get_indices(self.client)))
     def test_action_disabled(self):
         self.create_indices(10)
         self.write_config(
@@ -183,7 +183,7 @@ class TestCLIMethods(CuratorTestCase):
                         self.args['actionfile']
                     ],
                     )
-        self.assertEquals(0, len(curator.get_indices(self.client)))
+        self.assertEqual(0, len(curator.get_indices(self.client)))
         self.assertEqual(0, result.exit_code)
     # I'll have to think up another way to create an exception.
     # The exception that using "alias" created, a missing argument,
@@ -208,7 +208,7 @@ class TestCLIMethods(CuratorTestCase):
                         self.args['actionfile']
                     ],
                     )
-        self.assertEquals(0, len(curator.get_indices(self.client)))
+        self.assertEqual(0, len(curator.get_indices(self.client)))
         self.assertEqual(0, result.exit_code)
     def test_continue_if_exception_False(self):
         name = 'log1'
@@ -229,7 +229,7 @@ class TestCLIMethods(CuratorTestCase):
                         self.args['actionfile']
                     ],
                     )
-        self.assertEquals(2, len(curator.get_indices(self.client)))
+        self.assertEqual(2, len(curator.get_indices(self.client)))
         self.assertEqual(1, result.exit_code)
     def test_no_options_in_action(self):
         self.create_indices(10)

--- a/test/integration/test_close.py
+++ b/test/integration/test_close.py
@@ -27,7 +27,7 @@ class TestActionFileClose(CuratorTestCase):
                 self.args['actionfile']
             ],
         )
-        self.assertEquals(
+        self.assertEqual(
             'close',
             self.client.cluster.state(
                 index='my_index',
@@ -58,7 +58,7 @@ class TestActionFileClose(CuratorTestCase):
                 self.args['actionfile']
             ],
         )
-        self.assertEquals(
+        self.assertEqual(
             'close',
             self.client.cluster.state(
                 index='my_index',
@@ -80,7 +80,7 @@ class TestActionFileClose(CuratorTestCase):
         self.create_index('dummy')
         self.create_index('my_other')
         self.client.indices.put_alias(index='my_index,dummy', name=alias)
-        self.assertEquals(
+        self.assertEqual(
             {
                 "dummy":{"aliases":{"testalias":{}}},
                 "my_index":{"aliases":{"testalias":{}}}
@@ -99,14 +99,14 @@ class TestActionFileClose(CuratorTestCase):
                 self.args['actionfile']
             ],
         )
-        self.assertEquals(
+        self.assertEqual(
             'close',
             self.client.cluster.state(
                 index=index,
                 metric='metadata',
             )['metadata']['indices'][index]['state']
         )
-        self.assertEquals(
+        self.assertEqual(
             'close',
             self.client.cluster.state(
                 index='my_other',
@@ -115,7 +115,7 @@ class TestActionFileClose(CuratorTestCase):
         )
         # Now open the indices and verify that the alias is still gone.
         self.client.indices.open(index=index)
-        self.assertEquals(
+        self.assertEqual(
             {"dummy":{"aliases":{"testalias":{}}}},
             self.client.indices.get_alias(name=alias)
         )
@@ -138,7 +138,7 @@ class TestActionFileClose(CuratorTestCase):
             ]
         )
         try:
-            self.assertEquals(
+            self.assertEqual(
                 'close',
                 self.client.cluster.state(
                     index='my_index',
@@ -175,7 +175,7 @@ class TestActionFileClose(CuratorTestCase):
             ]
         )
         try:
-            self.assertEquals(
+            self.assertEqual(
                 'close',
                 self.client.cluster.state(
                     index='my_index',
@@ -212,7 +212,7 @@ class TestActionFileClose(CuratorTestCase):
             ]
         )
         try:
-            self.assertEquals(
+            self.assertEqual(
                 'open',
                 self.client.cluster.state(
                     index='my_index',
@@ -226,7 +226,7 @@ class TestActionFileClose(CuratorTestCase):
                     metric='metadata',
                 )['metadata']['indices']['dummy']['state']
             )
-            self.assertEquals(1, _.exit_code)
+            self.assertEqual(1, _.exit_code)
         finally:
             # re-enable shard allocation for next tests
             enable_allocation = '{"transient":{"cluster.routing.allocation.enable":null}}'
@@ -271,7 +271,7 @@ class TestCLIClose(CuratorTestCase):
         self.create_index('dummy')
         self.create_index('my_other')
         self.client.indices.put_alias(index='my_index,dummy', name=alias)
-        self.assertEquals(
+        self.assertEqual(
             {
                 "dummy":{"aliases":{"testalias":{}}},
                 "my_index":{"aliases":{"testalias":{}}}
@@ -290,19 +290,19 @@ class TestCLIClose(CuratorTestCase):
             0,
             self.run_subprocess(args, logname='TestCLIClose.test_close_delete_aliases')
         )
-        self.assertEquals(
+        self.assertEqual(
             'close',
             self.client.cluster.state(
                 index=index, metric='metadata')['metadata']['indices'][index]['state']
         )
-        self.assertEquals(
+        self.assertEqual(
             'close',
             self.client.cluster.state(
                 index='my_other', metric='metadata')['metadata']['indices']['my_other']['state']
         )
         # Now open the indices and verify that the alias is still gone.
         self.client.indices.open(index=index)
-        self.assertEquals(
+        self.assertEqual(
             {"dummy":{"aliases":{"testalias":{}}}},
             self.client.indices.get_alias(name=alias)
         )
@@ -320,7 +320,7 @@ class TestCLIClose(CuratorTestCase):
             0,
             self.run_subprocess(args, logname='TestCLIClose.test_close_skip_flush')
         )
-        self.assertEquals(
+        self.assertEqual(
             'close',
             self.client.cluster.state(
                 index='my_index', metric='metadata')['metadata']['indices']['my_index']['state']

--- a/test/integration/test_clusterrouting.py
+++ b/test/integration/test_clusterrouting.py
@@ -36,7 +36,7 @@ class TestCLIClusterRouting(CuratorTestCase):
                     ],
                     )
 
-        self.assertEquals(testvars.CRA_all,
+        self.assertEqual(testvars.CRA_all,
             self.client.cluster.get_settings())
     def test_extra_option(self):
         self.write_config(

--- a/test/integration/test_count_pattern.py
+++ b/test/integration/test_count_pattern.py
@@ -63,7 +63,7 @@ class TestCLICountPattern(CuratorTestCase):
             ],
         )
         indices = sorted(list(self.client.indices.get('_all')))
-        self.assertEquals(['a-3', 'b-6', 'c-8', 'not_a_match'], indices)
+        self.assertEqual(['a-3', 'b-6', 'c-8', 'not_a_match'], indices)
     def test_match_proper_indices_by_age(self):
         self.create_index('a-2017.10.01')
         self.create_index('a-2017.10.02')
@@ -89,7 +89,7 @@ class TestCLICountPattern(CuratorTestCase):
             ],
         )
         indices = sorted(list(self.client.indices.get('_all')))
-        self.assertEquals(['a-2017.10.03', 'b-2017.09.03', 'not_a_match'], indices)
+        self.assertEqual(['a-2017.10.03', 'b-2017.09.03', 'not_a_match'], indices)
     def test_count_indices_by_age_same_age(self):
         key = 'tag'
         value = 'value'
@@ -119,9 +119,9 @@ class TestCLICountPattern(CuratorTestCase):
                 self.args['actionfile']
             ],
         )
-        self.assertEquals(value,
+        self.assertEqual(value,
             self.client.indices.get_settings(index='c-2017.10.03')['c-2017.10.03']['settings']['index']['routing']['allocation'][at][key])
-        self.assertEquals(value,
+        self.assertEqual(value,
             self.client.indices.get_settings(index='d-2017.10.03')['d-2017.10.03']['settings']['index']['routing']['allocation'][at][key])
         idxlist = [
             'a-2017.10.01', 'a-2017.10.02', 'a-2017.10.03',
@@ -131,7 +131,7 @@ class TestCLICountPattern(CuratorTestCase):
         ]
         for idx in idxlist:
             if ver >= (7, 10, 0):
-                self.assertEquals(
+                self.assertEqual(
                     EMPTY710ROUTING,
                     self.client.indices.get_settings(index=idx)[idx]['settings']['index']['routing']
                 )

--- a/test/integration/test_delete_indices.py
+++ b/test/integration/test_delete_indices.py
@@ -54,7 +54,7 @@ class TestActionFileDeleteIndices(CuratorTestCase):
             ],
         )
 
-        self.assertEquals(5, len(exclude_ilm_history(curator.get_indices(self.client))))
+        self.assertEqual(5, len(exclude_ilm_history(curator.get_indices(self.client))))
     def test_retention_from_name_days_ignore_failed_match(self):
         # Test extraction of unit_count from index name
         # Create indices for 10 days with retention time of 5 days in index name
@@ -79,7 +79,7 @@ class TestActionFileDeleteIndices(CuratorTestCase):
                 self.args['actionfile']
             ],
         )
-        self.assertEquals(15, len(exclude_ilm_history(curator.get_indices(self.client))))
+        self.assertEqual(15, len(exclude_ilm_history(curator.get_indices(self.client))))
     def test_retention_from_name_days_keep_exclude_false_after_failed_match(self):
         # Test extraction of unit_count from index name and confirm correct
         # behavior after a failed regex match with no fallback time - see gh issue 1206
@@ -115,7 +115,7 @@ class TestActionFileDeleteIndices(CuratorTestCase):
                 self.args['actionfile']
             ],
         )
-        self.assertEquals(25, len(exclude_ilm_history(curator.get_indices(self.client))))
+        self.assertEqual(25, len(exclude_ilm_history(curator.get_indices(self.client))))
     def test_retention_from_name_days_failed_match_with_fallback(self):
         # Test extraction of unit_count from index name
         # Create indices for 10 days with retention time of 5 days in index name
@@ -140,7 +140,7 @@ class TestActionFileDeleteIndices(CuratorTestCase):
                 self.args['actionfile']
             ],
         )
-        self.assertEquals(12, len(exclude_ilm_history(curator.get_indices(self.client))))
+        self.assertEqual(12, len(exclude_ilm_history(curator.get_indices(self.client))))
     def test_retention_from_name_no_capture_group(self):
         # Test extraction of unit_count from index name when pattern contains no capture group
         # Create indices for 10 months with retention time of 2 months in index name
@@ -163,7 +163,7 @@ class TestActionFileDeleteIndices(CuratorTestCase):
                 self.args['actionfile']
             ],
         )
-        self.assertEquals(10, len(exclude_ilm_history(curator.get_indices(self.client))))
+        self.assertEqual(10, len(exclude_ilm_history(curator.get_indices(self.client))))
     def test_retention_from_name_illegal_regex_no_fallback(self):
         # Test extraction of unit_count from index name when pattern contains an illegal regular expression
         # Create indices for 10 months with retention time of 2 months in index name
@@ -186,7 +186,7 @@ class TestActionFileDeleteIndices(CuratorTestCase):
                 self.args['actionfile']
             ],
         )
-        self.assertEquals(10, len(exclude_ilm_history(curator.get_indices(self.client))))
+        self.assertEqual(10, len(exclude_ilm_history(curator.get_indices(self.client))))
     def test_retention_from_name_illegal_regex_with_fallback(self):
         # Test extraction of unit_count from index name when pattern contains an illegal regular expression
         # Create indices for 10 days with retention time of 2 days in index name
@@ -208,7 +208,7 @@ class TestActionFileDeleteIndices(CuratorTestCase):
                 self.args['actionfile']
             ],
         )
-        self.assertEquals(3, len(exclude_ilm_history(curator.get_indices(self.client))))
+        self.assertEqual(3, len(exclude_ilm_history(curator.get_indices(self.client))))
     def test_name_older_than_now(self):
         self.create_indices(10)
         self.write_config(
@@ -226,7 +226,7 @@ class TestActionFileDeleteIndices(CuratorTestCase):
                         self.args['actionfile']
                     ],
                     )
-        self.assertEquals(5, len(exclude_ilm_history(curator.get_indices(self.client))))
+        self.assertEqual(5, len(exclude_ilm_history(curator.get_indices(self.client))))
     def test_creation_date_newer_than_epoch(self):
         self.create_indices(10)
         self.write_config(
@@ -245,7 +245,7 @@ class TestActionFileDeleteIndices(CuratorTestCase):
                         self.args['actionfile']
                     ],
                     )
-        self.assertEquals(0, len(exclude_ilm_history(curator.get_indices(self.client))))
+        self.assertEqual(0, len(exclude_ilm_history(curator.get_indices(self.client))))
     def test_delete_in_period(self):
         # filtertype: {0}
         # source: {1}
@@ -276,7 +276,7 @@ class TestActionFileDeleteIndices(CuratorTestCase):
                     ],
                     )
         self.assertEqual(0, result.exit_code)
-        self.assertEquals(5, len(exclude_ilm_history(curator.get_indices(self.client))))
+        self.assertEqual(5, len(exclude_ilm_history(curator.get_indices(self.client))))
     def test_delete_in_period_absolute_date(self):
         delete_period_abs = ('---\n'
         'actions:\n'
@@ -360,7 +360,7 @@ class TestActionFileDeleteIndices(CuratorTestCase):
         )
         self.assertEqual(0, result.exit_code)
         indices = exclude_ilm_history(curator.get_indices(self.client))
-        self.assertEquals(1, len(indices))
+        self.assertEqual(1, len(indices))
         self.assertEqual('notintersecting', indices[0])
     def test_empty_list(self):
         self.create_indices(10)
@@ -380,7 +380,7 @@ class TestActionFileDeleteIndices(CuratorTestCase):
                         self.args['actionfile']
                     ],
                     )
-        self.assertEquals(10, len(exclude_ilm_history(curator.get_indices(self.client))))
+        self.assertEqual(10, len(exclude_ilm_history(curator.get_indices(self.client))))
         self.assertEqual(1, result.exit_code)
     def test_ignore_empty_list(self):
         self.create_indices(10)
@@ -400,7 +400,7 @@ class TestActionFileDeleteIndices(CuratorTestCase):
                         self.args['actionfile']
                     ],
                     )
-        self.assertEquals(10, len(exclude_ilm_history(curator.get_indices(self.client))))
+        self.assertEqual(10, len(exclude_ilm_history(curator.get_indices(self.client))))
         self.assertEqual(0, result.exit_code)
     def test_extra_options(self):
         self.write_config(
@@ -447,7 +447,7 @@ class TestActionFileDeleteIndices(CuratorTestCase):
                         self.args['actionfile']
                     ],
                     )
-        self.assertEquals(0, len(exclude_ilm_history(curator.get_indices(self.client))))
+        self.assertEqual(0, len(exclude_ilm_history(curator.get_indices(self.client))))
     def test_name_negative_epoch(self):
         self.create_index('index-1969.12.31')
         self.write_config(
@@ -465,7 +465,7 @@ class TestActionFileDeleteIndices(CuratorTestCase):
                         self.args['actionfile']
                     ],
                     )
-        self.assertEquals(0, len(exclude_ilm_history(curator.get_indices(self.client))))
+        self.assertEqual(0, len(exclude_ilm_history(curator.get_indices(self.client))))
     def test_allow_ilm_indices_true(self):
         # ILM will not be added until 6.6
         if curator.get_version(self.client) < (6,6,0):
@@ -504,7 +504,7 @@ class TestActionFileDeleteIndices(CuratorTestCase):
                 curator.cli,
                 [ '--config', self.args['configfile'], self.args['actionfile'] ],
             )
-            self.assertEquals(5, len(exclude_ilm_history(curator.get_indices(self.client))))
+            self.assertEqual(5, len(exclude_ilm_history(curator.get_indices(self.client))))
     def test_allow_ilm_indices_false(self):
         # ILM will not be added until 6.6
         if curator.get_version(self.client) < (6,6,0):
@@ -544,7 +544,7 @@ class TestActionFileDeleteIndices(CuratorTestCase):
                 curator.cli,
                 [ '--config', self.args['configfile'], self.args['actionfile'] ],
             )
-            self.assertEquals(10, len(exclude_ilm_history(curator.get_indices(self.client))))
+            self.assertEqual(10, len(exclude_ilm_history(curator.get_indices(self.client))))
 
 class TestCLIDeleteIndices(CuratorTestCase):
     def test_name_older_than_now_cli(self):
@@ -556,4 +556,4 @@ class TestCLIDeleteIndices(CuratorTestCase):
             '--filter_list', '{"filtertype":"age","source":"name","direction":"older","timestring":"%Y.%m.%d","unit":"days","unit_count":5}',
         ]
         self.assertEqual(0, self.run_subprocess(args, logname='TestCLIDeleteIndices.test_name_older_than_now_cli'))
-        self.assertEquals(5, len(exclude_ilm_history(curator.get_indices(self.client))))
+        self.assertEqual(5, len(exclude_ilm_history(curator.get_indices(self.client))))

--- a/test/integration/test_envvars.py
+++ b/test/integration/test_envvars.py
@@ -87,5 +87,5 @@ class TestEnvVars(CuratorTestCase):
                         self.args['actionfile']
                     ],
                     )
-        self.assertEquals(5, len(curator.get_indices(self.client)))
+        self.assertEqual(5, len(curator.get_indices(self.client)))
         del os.environ[evar]

--- a/test/integration/test_integrations.py
+++ b/test/integration/test_integrations.py
@@ -35,7 +35,7 @@ class TestFilters(CuratorTestCase):
                         self.args['actionfile']
                     ],
                     )
-        self.assertEquals(1, len(curator.get_indices(self.client)))
+        self.assertEqual(1, len(curator.get_indices(self.client)))
     def test_filter_by_array_of_aliases(self):
         alias = 'testalias'
         self.write_config(
@@ -55,9 +55,9 @@ class TestFilters(CuratorTestCase):
                     )
         ver = curator.get_version(self.client)
         if ver >= (5,5,0):
-            self.assertEquals(2, len(curator.get_indices(self.client)))
+            self.assertEqual(2, len(curator.get_indices(self.client)))
         else:
-            self.assertEquals(1, len(curator.get_indices(self.client)))
+            self.assertEqual(1, len(curator.get_indices(self.client)))
     def test_filter_by_alias_bad_aliases(self):
         alias = 'testalias'
         self.write_config(
@@ -75,9 +75,9 @@ class TestFilters(CuratorTestCase):
                         self.args['actionfile']
                     ],
                     )
-        self.assertEquals(
+        self.assertEqual(
             type(curator.ConfigurationError()), type(result.exception))
-        self.assertEquals(2, len(curator.get_indices(self.client)))
+        self.assertEqual(2, len(curator.get_indices(self.client)))
     def test_field_stats_skips_empty_index(self):
         delete_field_stats = ('---\n'
             'actions:\n'

--- a/test/integration/test_snapshot.py
+++ b/test/integration/test_snapshot.py
@@ -80,7 +80,7 @@ class TestActionFileSnapshot(CuratorTestCase):
                     self.client, self.args['repository'], '_all'
                    )
         self.assertEqual(0, len(snapshot['snapshots']))
-        self.assertEquals(0, len(curator.get_indices(self.client)))
+        self.assertEqual(0, len(curator.get_indices(self.client)))
     def test_snapshot_do_not_ignore_empty_list(self):
         self.create_indices(5)
         self.create_repository()
@@ -101,7 +101,7 @@ class TestActionFileSnapshot(CuratorTestCase):
                     self.client, self.args['repository'], '_all'
                    )
         self.assertEqual(0, len(snapshot['snapshots']))
-        self.assertEquals(5, len(curator.get_indices(self.client)))
+        self.assertEqual(5, len(curator.get_indices(self.client)))
     def test_no_repository(self):
         self.create_indices(5)
         self.write_config(


### PR DESCRIPTION
## Proposed Changes

  Use assertEqual instead of assertEquals for Python 3.11 compatibility. Deprecated unittest aliases were removed in Python 3.11 . This will cause error when tests are executed in Python 3.11 .

Ref : python/cpython#28268
