### PR TITLE
Use Python's build in unittest.mock

### DIFF
--- a/curator/utils.py
+++ b/curator/utils.py
@@ -134,7 +134,7 @@ def verify_client_object(test):
     :rtype: None
     """
     # Ignore mock type for testing
-    if str(type(test)) == "<class 'mock.Mock'>" or \
+    if str(type(test)) == "<class 'unittest.mock.Mock'>" or \
         str(type(test)) == "<class 'mock.mock.Mock'>":
         pass
     elif not isinstance(test, elasticsearch.Elasticsearch):

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,6 @@ setup_requires =
 packages = curator
 include_package_data = True
 tests_require =
-    mock
     nose
     coverage
     nosexcover

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ try:
             "Programming Language :: Python :: 3.9",
         ],
         test_suite = "test.run_tests.run_all",
-        tests_require = ["mock", "nose", "coverage", "nosexcover"],
+        tests_require = ["nose", "coverage", "nosexcover"],
         options = build_dict,
         executables = [curator_exe, curator_cli_exe, repomgr_exe]
     )

--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -14,7 +14,7 @@ from curator import get_version
 
 from . import testvars as testvars
 from unittest import SkipTest, TestCase
-from mock import Mock
+from unittest.mock import Mock
 
 client = None
 

--- a/test/integration/test_alias.py
+++ b/test/integration/test_alias.py
@@ -5,7 +5,7 @@ import json
 import string, random, tempfile
 import click
 from click import testing as clicktest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 from datetime import datetime, timedelta
 
 from . import CuratorTestCase

--- a/test/integration/test_allocation.py
+++ b/test/integration/test_allocation.py
@@ -5,7 +5,7 @@ import json
 import string, random, tempfile
 import click
 from click import testing as clicktest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from . import CuratorTestCase
 from . import testvars as testvars

--- a/test/integration/test_cli.py
+++ b/test/integration/test_cli.py
@@ -5,7 +5,7 @@ import json
 import string, random, tempfile
 import click
 from click import testing as clicktest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from . import CuratorTestCase
 from . import testvars as testvars

--- a/test/integration/test_clusterrouting.py
+++ b/test/integration/test_clusterrouting.py
@@ -5,7 +5,7 @@ import json
 import string, random, tempfile
 import click
 from click import testing as clicktest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from . import CuratorTestCase
 from . import testvars as testvars

--- a/test/integration/test_count_pattern.py
+++ b/test/integration/test_count_pattern.py
@@ -5,7 +5,7 @@ import json
 import string, random, tempfile
 import time
 from click import testing as clicktest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 import unittest
 from . import CuratorTestCase
 from . import testvars as testvars

--- a/test/integration/test_create_index.py
+++ b/test/integration/test_create_index.py
@@ -5,7 +5,7 @@ import json
 import string, random, tempfile
 import click
 from click import testing as clicktest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from . import CuratorTestCase
 from . import testvars as testvars

--- a/test/integration/test_datemath.py
+++ b/test/integration/test_datemath.py
@@ -5,7 +5,7 @@ import json
 import string, random, tempfile
 import click
 from click import testing as clicktest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 from datetime import timedelta, datetime, date
 
 from . import CuratorTestCase

--- a/test/integration/test_delete_snapshots.py
+++ b/test/integration/test_delete_snapshots.py
@@ -5,7 +5,7 @@ import json
 import string, random, tempfile
 import time
 from click import testing as clicktest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from . import CuratorTestCase
 from . import testvars as testvars

--- a/test/integration/test_envvars.py
+++ b/test/integration/test_envvars.py
@@ -5,7 +5,7 @@ import json
 import string, random, tempfile
 import click
 from click import testing as clicktest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from . import CuratorTestCase
 from . import testvars as testvars

--- a/test/integration/test_es_repo_mgr.py
+++ b/test/integration/test_es_repo_mgr.py
@@ -5,7 +5,7 @@ import json
 import click
 import string, random, tempfile
 from click import testing as clicktest
-from mock import patch, Mock, MagicMock
+from unittest.mock import patch, Mock, MagicMock
 
 from . import CuratorTestCase
 from . import testvars as testvars

--- a/test/integration/test_forcemerge.py
+++ b/test/integration/test_forcemerge.py
@@ -8,7 +8,7 @@ import tempfile
 from time import sleep
 import click
 from click import testing as clicktest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from . import CuratorTestCase
 from . import testvars as testvars

--- a/test/integration/test_integrations.py
+++ b/test/integration/test_integrations.py
@@ -6,7 +6,7 @@ import string, random, tempfile
 from time import sleep
 import click
 from click import testing as clicktest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from . import CuratorTestCase
 from . import testvars as testvars

--- a/test/integration/test_open.py
+++ b/test/integration/test_open.py
@@ -5,7 +5,7 @@ import json
 import string, random, tempfile
 import click
 from click import testing as clicktest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from . import CuratorTestCase
 from . import testvars as testvars

--- a/test/integration/test_replicas.py
+++ b/test/integration/test_replicas.py
@@ -5,7 +5,7 @@ import json
 import string, random, tempfile
 import click
 from click import testing as clicktest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from . import CuratorTestCase
 from . import testvars as testvars

--- a/test/integration/test_restore.py
+++ b/test/integration/test_restore.py
@@ -5,7 +5,7 @@ import time
 import json
 import string, random, tempfile
 from click import testing as clicktest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from . import CuratorTestCase
 from . import testvars as testvars

--- a/test/integration/test_shrink.py
+++ b/test/integration/test_shrink.py
@@ -5,7 +5,7 @@ import json
 import subprocess
 import string, random, tempfile
 from click import testing as clicktest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from . import CuratorTestCase
 from . import testvars as testvars

--- a/test/integration/test_snapshot.py
+++ b/test/integration/test_snapshot.py
@@ -4,7 +4,7 @@ import os
 import json
 import string, random, tempfile
 from click import testing as clicktest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 from datetime import datetime, timedelta
 
 from . import CuratorTestCase

--- a/test/integration/test_unfreeze.py
+++ b/test/integration/test_unfreeze.py
@@ -5,7 +5,7 @@ import json
 import string, random, tempfile
 import click
 from click import testing as clicktest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from . import CuratorTestCase
 from . import testvars as testvars

--- a/test/unit/__init__.py
+++ b/test/unit/__init__.py
@@ -4,7 +4,7 @@ import tempfile
 import random
 import string
 from unittest import SkipTest, TestCase
-from mock import Mock
+from unittest.mock import Mock
 from .testvars import *
 
 class CLITestCase(TestCase):

--- a/test/unit/test_action_alias.py
+++ b/test/unit/test_action_alias.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import elasticsearch
 import curator
 # Get test variables and constants from a single source

--- a/test/unit/test_action_allocation.py
+++ b/test/unit/test_action_allocation.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import elasticsearch
 import curator
 # Get test variables and constants from a single source

--- a/test/unit/test_action_close.py
+++ b/test/unit/test_action_close.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import elasticsearch
 import curator
 # Get test variables and constants from a single source

--- a/test/unit/test_action_clusterrouting.py
+++ b/test/unit/test_action_clusterrouting.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import elasticsearch
 import curator
 # Get test variables and constants from a single source

--- a/test/unit/test_action_create_index.py
+++ b/test/unit/test_action_create_index.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import elasticsearch
 import curator
 # Get test variables and constants from a single source

--- a/test/unit/test_action_delete_indices.py
+++ b/test/unit/test_action_delete_indices.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import elasticsearch
 import curator
 # Get test variables and constants from a single source

--- a/test/unit/test_action_delete_snapshots.py
+++ b/test/unit/test_action_delete_snapshots.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import elasticsearch
 import curator
 # Get test variables and constants from a single source

--- a/test/unit/test_action_forcemerge.py
+++ b/test/unit/test_action_forcemerge.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import elasticsearch
 import curator
 # Get test variables and constants from a single source

--- a/test/unit/test_action_indexsettings.py
+++ b/test/unit/test_action_indexsettings.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import elasticsearch
 import curator
 # Get test variables and constants from a single source

--- a/test/unit/test_action_open.py
+++ b/test/unit/test_action_open.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import elasticsearch
 import curator
 # Get test variables and constants from a single source

--- a/test/unit/test_action_reindex.py
+++ b/test/unit/test_action_reindex.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import elasticsearch
 import curator
 # Get test variables and constants from a single source

--- a/test/unit/test_action_replicas.py
+++ b/test/unit/test_action_replicas.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import elasticsearch
 import curator
 # Get test variables and constants from a single source

--- a/test/unit/test_action_restore.py
+++ b/test/unit/test_action_restore.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import elasticsearch
 import curator
 # Get test variables and constants from a single source

--- a/test/unit/test_action_rollover.py
+++ b/test/unit/test_action_rollover.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import elasticsearch
 import curator
 # Get test variables and constants from a single source

--- a/test/unit/test_action_shrink.py
+++ b/test/unit/test_action_shrink.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import elasticsearch
 import curator
 # Get test variables and constants from a single source

--- a/test/unit/test_action_snapshot.py
+++ b/test/unit/test_action_snapshot.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import elasticsearch
 import curator
 # Get test variables and constants from a single source

--- a/test/unit/test_class_index_list.py
+++ b/test/unit/test_class_index_list.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from copy import deepcopy
 import elasticsearch
 import yaml

--- a/test/unit/test_class_snapshot_list.py
+++ b/test/unit/test_class_snapshot_list.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import elasticsearch
 import yaml
 import curator

--- a/test/unit/test_cli_methods.py
+++ b/test/unit/test_cli_methods.py
@@ -1,7 +1,7 @@
 import sys
 import logging
 from unittest import TestCase
-from mock import Mock, patch, mock_open
+from unittest.mock import Mock, patch, mock_open
 import elasticsearch
 import curator
 from curator import _version as __version__

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,7 +1,7 @@
 import base64
 from datetime import datetime, timedelta
 from unittest import TestCase
-from mock import MagicMock, Mock, PropertyMock, patch
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
 import elasticsearch
 import yaml
 from . import testvars as testvars

--- a/test/unit/test_validators.py
+++ b/test/unit/test_validators.py
@@ -1,7 +1,7 @@
 import sys
 import logging
 from unittest import TestCase
-from mock import Mock, patch, mock_open
+from unittest.mock import Mock, patch, mock_open
 from voluptuous import *
 import curator
 


### PR DESCRIPTION
Since Python 3.3 the unittest module supports mock and replaces python-mock which is now deprecated.

Fixes #

## Proposed Changes

  - Stop using the deprecated mock module and use the Python unittest.mock module

