### PR TITLE
Add the Python settings to RTD yaml file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,3 +15,7 @@ build:
 sphinx:
    configuration: docs/conf.py
 
+python:
+  install:
+    - method: pip
+      path: .


### PR DESCRIPTION
Trying to get modules installed for ReadTheDocs build to show content.
