### PR TITLE
Ready to release 8.0.2

### DIFF
--- a/curator/actions/__init__.py
+++ b/curator/actions/__init__.py
@@ -13,3 +13,22 @@ from curator.actions.replicas import Replicas
 from curator.actions.rollover import Rollover
 from curator.actions.shrink import Shrink
 from curator.actions.snapshot import Snapshot, DeleteSnapshots, Restore
+
+CLASS_MAP = {
+    'alias' : Alias,
+    'allocation' : Allocation,
+    'close' : Close,
+    'cluster_routing' : ClusterRouting,
+    'create_index' : CreateIndex,
+    'delete_indices' : DeleteIndices,
+    'delete_snapshots' : DeleteSnapshots,
+    'forcemerge' : ForceMerge,
+    'index_settings' : IndexSettings,
+    'open' : Open,
+    'reindex' : Reindex,
+    'replicas' : Replicas,
+    'restore' : Restore,
+    'rollover' : Rollover,
+    'snapshot' : Snapshot,
+    'shrink' : Shrink,
+}

--- a/curator/classdef.py
+++ b/curator/classdef.py
@@ -1,0 +1,227 @@
+"""Other Classes"""
+import logging
+from es_client.exceptions import ConfigurationError as ESclient_ConfigError
+from es_client.helpers.utils import get_yaml
+from curator import IndexList, SnapshotList
+from curator.actions import CLASS_MAP
+from curator.exceptions import ConfigurationError
+from curator.config_utils import password_filter
+from curator.helpers.testers import validate_actions
+
+# Let me tell you the story of the nearly wasted afternoon and the research that went into this
+# seemingly simple work-around. Actually, no. It's even more wasted time writing that story here.
+# Suffice to say that I couldn't use the CLASS_MAP with class objects to directly map them to class
+# instances. The Wrapper class and the ActionDef.instantiate method do all of the work for me,
+# allowing me to easily and cleanly pass *args and **kwargs to the individual action classes of
+# CLASS_MAP.
+
+class Wrapper:
+    """Wrapper Class"""
+    def __init__(self, cls):
+        """Instantiate with passed Class (not instance or object)
+
+        :param cls: A class (not an instance of the class)
+        """
+        #: The class itself (not an instance of it), passed from ``cls``
+        self.class_object = cls
+        #: An instance of :py:attr:`class_object`
+        self.class_instance = None
+
+    def set_instance(self, *args, **kwargs):
+        """Set up :py:attr:`class_instance` from :py:attr:`class_object`"""
+        self.class_instance = self.class_object(*args, **kwargs)
+
+    def get_instance(self, *args, **kwargs):
+        """Return the instance with ``*args`` and ``**kwargs``
+        """
+        self.set_instance(*args, **kwargs)
+        return self.class_instance
+
+class ActionsFile:
+    """Class to parse and verify entire actions file
+
+    Individual actions are :py:class:`~.curator.classdef.ActionDef` objects
+    """
+    def __init__(self, action_file):
+        self.logger = logging.getLogger(__name__)
+        #: The full, validated configuration from ``action_file``.
+        self.fullconfig = self.get_validated(action_file)
+        self.logger.debug('Action Configuration: %s', password_filter(self.fullconfig))
+        #: A dict of all actions in the provided configuration. Each original key name is preserved
+        #: and the value is now an :py:class:`~.curator.classdef.ActionDef`, rather than a dict.
+        self.actions = None
+        self.set_actions(self.fullconfig['actions'])
+
+    def get_validated(self, action_file):
+        """
+        :param action_file: The path to a valid YAML action configuration file
+        :type action_file: str
+
+        :returns: The result from passing ``action_file`` to
+            :py:func:`~.curator.helpers.testers.validate_actions`
+        """
+        try:
+            return validate_actions(get_yaml(action_file))
+        except (ESclient_ConfigError, UnboundLocalError) as err:
+            self.logger.critical('Configuration Error: %s', err)
+            raise ConfigurationError from err
+
+    def parse_actions(self, all_actions):
+        """Parse the individual actions found in ``all_actions['actions']``
+
+        :param all_actions: All actions, each its own dictionary behind a numeric key. Making the
+            keys numeric guarantees that if they are sorted, they will always be executed in order.
+
+        :type all_actions: dict
+
+        :returns:
+        :rtype: list of :py:class:`~.curator.classdef.ActionDef`
+        """
+        acts = {}
+        for idx in all_actions.keys():
+            acts[idx] = ActionDef(all_actions[idx])
+        return acts
+
+    def set_actions(self, all_actions):
+        """Set the actions via :py:meth:`~.curator.classdef.ActionsFile.parse_actions`
+
+        :param all_actions: All actions, each its own dictionary behind a numeric key. Making the
+            keys numeric guarantees that if they are sorted, they will always be executed in order.
+        :type all_actions: dict
+        :rtype: None
+        """
+        self.actions = self.parse_actions(all_actions)
+
+# In this case, I just don't care that pylint thinks I'm overdoing it with attributes
+# pylint: disable=too-many-instance-attributes
+class ActionDef:
+    """Individual Action Definition Class
+
+    Instances of this class represent an individual action from an action file.
+    """
+    def __init__(self, action_dict):
+        #: The whole action dictionary
+        self.action_dict = action_dict
+        #: The action name
+        self.action = None
+        #: The action's class (Alias, Allocation, etc.)
+        self.action_cls = None
+        #: Only when action is alias will this be a :py:class:`~.curator.IndexList`
+        self.alias_adds = None
+        #: Only when action is alias will this be a :py:class:`~.curator.IndexList`
+        self.alias_removes = None
+        #: The list class, either :py:class:`~.curator.IndexList` or
+        #: :py:class:`~.curator.SnapshotList`. Default is :py:class:`~.curator.IndexList`
+        self.list_obj = Wrapper(IndexList)
+        #: The action ``description``
+        self.description = None
+        #: The action ``options`` :py:class:`dict`
+        self.options = {}
+        #: The action ``filters`` :py:class:`list`
+        self.filters = None
+        #: The action option ``disable_action``
+        self.disabled = None
+        #: The action option ``continue_if_exception``
+        self.cif = None
+        #: The action option ``timeout_override``
+        self.timeout_override = None
+        #: The action option ``ignore_empty_list``
+        self.iel = None
+        #: The action option ``allow_ilm_indices``
+        self.allow_ilm = None
+        self.set_root_attrs()
+        self.set_option_attrs()
+        self.log_the_options()
+        self.get_action_class()
+
+    def instantiate(self, attribute, *args, **kwargs):
+        """
+        Convert ``attribute`` from being a :py:class:`~.curator.classdef.Wrapper` of a Class to an
+        instantiated object of that Class.
+
+        This is madness or genius. You decide. This entire method plus the
+        :py:class:`~.curator.classdef.Wrapper` class came about because I couldn't cleanly
+        instantiate a class variable into a class object. It works, and that's good enough for me.
+
+        :param attribute: The `name` of an attribute that references a Wrapper class instance
+        :type attribute: str
+        """
+        try:
+            wrapper = getattr(self, attribute)
+        except AttributeError as exc:
+            raise AttributeError(f'Bad Attribute: {attribute}. Exception: {exc}') from exc
+        setattr(self, attribute, self.get_obj_instance(wrapper, *args, **kwargs))
+
+    def get_obj_instance(self, wrapper, *args, **kwargs):
+        """Get the class instance wrapper identified by ``wrapper``
+        Pass all other args and kwargs to the :py:meth:`~.curator.classdef.Wrapper.get_instance`
+        method.
+
+        :returns: An instance of the class that :py:class:`~.curator.classdef.Wrapper` is wrapping
+        """
+        if not isinstance(wrapper, Wrapper):
+            raise ConfigurationError(
+                f'{__name__} was passed wrapper which was of type {type(wrapper)}')
+        return wrapper.get_instance(*args, **kwargs)
+
+    def set_alias_extras(self):
+        """Populate the :py:attr:`alias_adds` and :py:attr:`alias_removes` attributes"""
+        self.alias_adds = Wrapper(IndexList)
+        self.alias_removes = Wrapper(IndexList)
+
+    def get_action_class(self):
+        """Get the action class from :py:const:`~.curator.actions.CLASS_MAP`
+
+        Do extra setup when action is ``alias``
+
+        Set :py:attr:`list_obj` to :py:class:`~.curator.SnapshotList` when
+        :py:attr:`~.curator.classdef.ActionDef.action` is ``delete_snapshots`` or ``restore``
+        """
+
+        self.action_cls = Wrapper(CLASS_MAP[self.action])
+        if self.action == 'alias':
+            self.set_alias_extras()
+        if self.action in ['delete_snapshots', 'restore']:
+            self.list_obj = Wrapper(SnapshotList)
+
+    def set_option_attrs(self):
+        """
+        Iteratively get the keys and values from :py:attr:`~.curator.classdef.ActionDef.options`
+        and set the attributes
+        """
+        attmap = {
+            'disable_action': 'disabled',
+            'continue_if_exception': 'cif',
+            'ignore_empty_list': 'iel',
+            'allow_ilm_indices': 'allow_ilm',
+            'timeout_override' : 'timeout_override'
+        }
+        for key in self.action_dict['options']:
+            if key in attmap:
+                setattr(self, attmap[key], self.action_dict['options'][key])
+            else:
+                self.options[key] = self.action_dict['options'][key]
+
+    def set_root_attrs(self):
+        """
+        Iteratively get the keys and values from
+        :py:attr:`~.curator.classdef.ActionDef.action_dict` and set the attributes
+        """
+        for key, value in self.action_dict.items():
+            # Gonna grab options in get_option_attrs()
+            if key == 'options':
+                continue
+            if value is not None:
+                setattr(self, key, value)
+
+    def log_the_options(self):
+        """Log options at initialization time"""
+        logger = logging.getLogger('curator.cli.ActionDef')
+        msg = (
+            f'For action {self.action}: disable_action={self.disabled}'
+            f'continue_if_exception={self.cif}, timeout_override={self.timeout_override}'
+            f'ignore_empty_list={self.iel}, allow_ilm_indices={self.allow_ilm}'
+        )
+        logger.debug(msg)
+        if self.allow_ilm:
+            logger.warning('Permitting operation on indices with an ILM policy')

--- a/curator/repomgrcli.py
+++ b/curator/repomgrcli.py
@@ -317,7 +317,7 @@ def source(
 @click.option('--ssl_version', help='Minimum acceptable TLS/SSL version', type=str)
 @click.option('--master-only', help='Only run if the single host provided is the elected master', is_flag=True, default=None)
 @click.option('--skip_version_test', help='Do not check the host version', is_flag=True, default=None)
-@click.option('--dry-run', is_flag=True, help='Do not perform any changes.')
+@click.option('--dry-run', is_flag=True, help='Do not perform any changes. NON-FUNCTIONAL PLACEHOLDER! DO NOT USE!')
 @click.option('--loglevel', help='Log level', type=click.Choice(['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']))
 @click.option('--logfile', help='log file')
 @click.option('--logformat', help='Log output format', type=click.Choice(['default', 'logstash', 'json', 'ecs']))

--- a/docker_test/scripts/create.sh
+++ b/docker_test/scripts/create.sh
@@ -128,6 +128,12 @@ echo
 
 for IP in $IPLIST; do
   echo "REMOTE_ES_SERVER=\"http://$IP:${REMOTE_PORT}\""
+  if [ "$AUTO_EXPORT" == "y" ]; then
+    # This puts our curatortestenv file where it can be purged easily by destroy.sh
+    cd $SCRIPTPATH
+    cd ..
+    echo "export REMOTE_ES_SERVER=http://$IP:$REMOTE_PORT" > curatortestenv
+  fi
 done
 
 echo

--- a/docker_test/scripts/destroy.sh
+++ b/docker_test/scripts/destroy.sh
@@ -26,6 +26,7 @@ UPONE=$(pwd | awk -F\/ '{print $NF}')
 
 if [[ "$UPONE" = "docker_test" ]]; then
   rm -rf $(pwd)/repo/*
+  rm -rf $(pwd)/curatortestenv
 else
   echo "WARNING: Unable to automatically empty bind mounted repo path."
   echo "Please manually empty the contents of the repo directory!"

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,8 +3,8 @@
 Changelog
 =========
 
-8.0.2 (? ? ?)
--------------
+8.0.2 (15 February 2023)
+------------------------
 
 **Changes**
 
@@ -12,6 +12,12 @@ Changelog
     regards to passing configuration settings as command-line options, particularly for Docker.
   * Re-created the ``get_client`` function. It now resides in ``curator.helpers.getters`` and will
     eventually see use in the Reindex class for remote connections.
+  * Created a new set of classes to import, validate the schema, and split individual actions into
+    their own sub-object instances. This is primarily to make ``curator/cli.py`` read much more
+    cleanly. No new functionality here, but fewer conditional branches, and hopefully more readable
+    code.
+  * Updated the documentation to show these changes, both the API and the Elastic.co usage docs.
+
 
 8.0.1 (10 February 2023)
 ------------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,6 +9,7 @@ API and Code Reference
    actions
    indexlist
    snapshotlist
+   classdef
    helpers
    validators
    defaults

--- a/docs/asciidoc/command-line.asciidoc
+++ b/docs/asciidoc/command-line.asciidoc
@@ -11,7 +11,13 @@
 [[command-line]]
 == Command Line Interface
 
-The command-line arguments are as follows:
+Most common client configuration settings are now available at the command-line.
+
+IMPORTANT: While both the configuration file and the command-line arguments can be used together,
+  it is important to note that command-line options will override file-based configuration of the
+  same setting.
+
+The most basic command-line arguments are as follows:
 
 [source,sh]
 -------
@@ -33,7 +39,7 @@ specified.
 
 `ACTION_FILE.YML` is a YAML <<actionfile, actionfile>>.
 
-Command-line help is never far away:
+For other client configuration options, command-line help is never far away:
 
 [source,sh]
 -------
@@ -52,10 +58,35 @@ Usage: curator [OPTIONS] ACTION_FILE
   See http://elastic.co/guide/en/elasticsearch/client/curator/current
 
 Options:
-  --config PATH  Path to configuration file. Default: ~/.curator/curator.yml
-  --dry-run      Do not perform any changes.
-  --version      Show the version and exit.
-  --help         Show this message and exit.
+  --config PATH                   Path to configuration file.
+  --hosts TEXT                    Elasticsearch URL to connect to
+  --cloud_id TEXT                 Shorthand to connect to Elastic Cloud instance
+  --id TEXT                       API Key "id" value
+  --api_key TEXT                  API Key "api_key" value
+  --username TEXT                 Username used to create "basic_auth" tuple
+  --password TEXT                 Password used to create "basic_auth" tuple
+  --bearer_auth TEXT
+  --opaque_id TEXT
+  --request_timeout FLOAT         Request timeout in seconds
+  --http_compress                 Enable HTTP compression
+  --verify_certs                  Verify SSL/TLS certificate(s)
+  --ca_certs TEXT                 Path to CA certificate file or directory
+  --client_cert TEXT              Path to client certificate file
+  --client_key TEXT               Path to client certificate key
+  --ssl_assert_hostname TEXT      Hostname or IP address to verify on the node's certificate.
+  --ssl_assert_fingerprint TEXT   SHA-256 fingerprint of the node's certificate. If this value is given then root-of-trust
+                                  verification isn't done and only the node's certificate fingerprint is verified.
+  --ssl_version TEXT              Minimum acceptable TLS/SSL version
+  --master-only                   Only run if the single host provided is the elected master
+  --skip_version_test             Do not check the host version
+  --dry-run                       Do not perform any changes.
+  --loglevel [DEBUG|INFO|WARNING|ERROR|CRITICAL]
+                                  Log level
+  --logfile TEXT                  log file
+  --logformat [default|logstash|json|ecs]
+                                  Log output format
+  --version                       Show the version and exit.
+  --help                          Show this message and exit.
 -------
 
 You can use <<envvars,environment variables>> in your configuration files.
@@ -96,43 +127,61 @@ file, though it does support using the client configuration file if you want.
 As an important bonus, the command-line options allow you to override the
 settings in the `curator.yml` file!
 
+IMPORTANT: While both the configuration file and the command-line arguments can be used together,
+  it is important to note that command-line options will override file-based configuration of the
+  same setting.
+
 [source,sh]
 ---------
 $ curator_cli --help
 Usage: curator_cli [OPTIONS] COMMAND [ARGS]...
 
 Options:
-  --config PATH       Path to configuration file. Default:
-                      ~/.curator/curator.yml
-  --host TEXT         Elasticsearch host.
-  --url_prefix TEXT   Elasticsearch http url prefix.
-  --port TEXT         Elasticsearch port.
-  --use_ssl           Connect to Elasticsearch through SSL.
-  --certificate TEXT  Path to certificate to use for SSL validation.
-  --client-cert TEXT  Path to file containing SSL certificate for client auth.
-  --client-key TEXT   Path to file containing SSL key for client auth.
-  --ssl-no-validate   Do not validate SSL certificate
-  --http_auth TEXT    Use Basic Authentication ex: user:pass
-  --timeout INTEGER   Connection timeout in seconds.
-  --master-only       Only operate on elected master node.
-  --dry-run           Do not perform any changes.
-  --loglevel TEXT     Log level
-  --logfile TEXT      log file
-  --logformat TEXT    Log output format [default|logstash|json|ecs].
-  --version           Show the version and exit.
-  --help              Show this message and exit.
+  --config PATH                   Path to configuration file.
+  --hosts TEXT                    Elasticsearch URL to connect to
+  --cloud_id TEXT                 Shorthand to connect to Elastic Cloud instance
+  --id TEXT                       API Key "id" value
+  --api_key TEXT                  API Key "api_key" value
+  --username TEXT                 Username used to create "basic_auth" tuple
+  --password TEXT                 Password used to create "basic_auth" tuple
+  --bearer_auth TEXT
+  --opaque_id TEXT
+  --request_timeout FLOAT         Request timeout in seconds
+  --http_compress                 Enable HTTP compression
+  --verify_certs                  Verify SSL/TLS certificate(s)
+  --ca_certs TEXT                 Path to CA certificate file or directory
+  --client_cert TEXT              Path to client certificate file
+  --client_key TEXT               Path to client certificate key
+  --ssl_assert_hostname TEXT      Hostname or IP address to verify on the node's certificate.
+  --ssl_assert_fingerprint TEXT   SHA-256 fingerprint of the node's certificate. If this value is given then root-of-trust
+                                  verification isn't done and only the node's certificate fingerprint is verified.
+  --ssl_version TEXT              Minimum acceptable TLS/SSL version
+  --master-only                   Only run if the single host provided is the elected master
+  --skip_version_test             Do not check the host version
+  --dry-run                       Do not perform any changes.
+  --loglevel [DEBUG|INFO|WARNING|ERROR|CRITICAL]
+                                  Log level
+  --logfile TEXT                  log file
+  --logformat [default|logstash|json|ecs]
+                                  Log output format
+  --version                       Show the version and exit.
+  --help                          Show this message and exit.
 
 Commands:
+  alias             Add/Remove Indices to/from Alias
   allocation        Shard Routing Allocation
-  close             Close indices
-  delete-indices    Delete indices
-  delete-snapshots  Delete snapshots
-  forcemerge        forceMerge index/shard segments
-  open              Open indices
-  replicas          Change replica count
-  show-indices      Show indices
-  show-snapshots    Show snapshots
-  snapshot          Snapshot indices
+  close             Close Indices
+  delete-indices    Delete Indices
+  delete-snapshots  Delete Snapshots
+  forcemerge        forceMerge Indices (reduce segment count)
+  open              Open Indices
+  replicas          Change Replica Count
+  restore           Restore Indices
+  rollover          Rollover Index associated with Alias
+  show-indices      Show Indices
+  show-snapshots    Show Snapshots
+  shrink            Shrink Indices to --number_of_shards
+  snapshot          Snapshot Indices
 ---------
 
 The option flags for the given commands match those used for the same

--- a/docs/classdef.rst
+++ b/docs/classdef.rst
@@ -1,0 +1,34 @@
+.. _classdef:
+
+Other Class Definitions
+#######################
+
+.. _wrapper:
+
+Wrapper
+=======
+
+.. autoclass:: curator.classdef.Wrapper
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. _actionfile:
+
+ActionsFile
+===========
+
+.. autoclass:: curator.classdef.ActionsFile
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+.. _actiondef:
+
+ActionDef
+=========
+
+.. autoclass:: curator.classdef.ActionDef
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,6 +72,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 
 intersphinx_mapping = {
 	'python': ('https://docs.python.org/3.11', None),
+    'es_client': ('https://es_client.readthedocs.io/en/v8.6.1.post1', None),
 	'elasticsearch8': ('https://elasticsearch-py.readthedocs.io/en/v8.6.1', None),
     'voluptuous': ('http://alecthomas.github.io/voluptuous/docs/_build/html', None),
     'click': ('https://click.palletsprojects.com/en/8.1.x', None),

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -50,6 +50,8 @@ Getters
 
 .. autofunction:: byte_size
 
+.. autofunction:: get_client
+
 .. autofunction:: get_indices
 
 .. autofunction:: get_repository
@@ -77,6 +79,8 @@ Testers
 
 .. py:module:: curator.helpers.testers
 
+.. autofunction:: ilm_policy_check
+
 .. autofunction:: repository_exists
 
 .. autofunction:: rollable_alias
@@ -92,6 +96,7 @@ Testers
 .. autofunction:: verify_repository
 
 .. autofunction:: verify_snapshot_list
+
 .. _helpers_utils:
 
 Utils

--- a/docs/other_modules.rst
+++ b/docs/other_modules.rst
@@ -10,19 +10,75 @@ Other Modules
 
 .. autofunction:: process_action
 
+.. autofunction:: override_logging
+
+.. autofunction:: cli_hostslist
+
+.. autofunction:: ilm_action_skip
+
+.. autofunction:: exception_handler
+
 .. autofunction:: run
 
-.. py:function:: cli(config, dry_run, action_file)
+.. py:function:: cli(ctx, config, hosts, cloud_id, id, api_key, username, password, bearer_auth, opaque_id, request_timeout, http_compress, verify_certs, ca_certs, client_cert, client_key, ssl_assert_hostname, ssl_assert_fingerprint, ssl_version, master_only, skip_version_test, dry_run, loglevel, logfile, logformat, action_file)
 
     This is the :py:class:`click.Command` that initiates everything and connects the command-line to
     the rest of Curator.
 
-    :param config: Path to configuration file. Default: ~/.curator/curator.yml
+    :param ctx: The Click Context
+    :param config: Path to configuration file.
+    :param hosts: Elasticsearch URL to connect to
+    :param cloud_id: Shorthand to connect to Elastic Cloud instance
+    :param id: API Key "id" value
+    :param api_key: API Key "api_key" value
+    :param username: Username used to create "basic_auth" tuple
+    :param password: Password used to create "basic_auth" tuple
+    :param bearer_auth: Bearer Auth Token
+    :param opaque_id: Opaque ID string
+    :param request_timeout: Request timeout in seconds
+    :param http_compress: Enable HTTP compression
+    :param verify_certs: Verify SSL/TLS certificate(s)
+    :param ca_certs: Path to CA certificate file or directory
+    :param client_cert: Path to client certificate file
+    :param client_key: Path to client certificate key
+    :param ssl_assert_hostname: Hostname or IP address to verify on the node's certificate.
+    :param ssl_assert_fingerprint: SHA-256 fingerprint of the node's certificate. If this value is
+        given then root-of-trust verification isn't done and only the node's certificate
+        fingerprint is verified.
+    :param ssl_version: Minimum acceptable TLS/SSL version
+    :param master_only: Only run if the single host provided is the elected master
+    :param skip_version_test: Do not check the host version
     :param dry_run: Do not perform any changes.
+    :param loglevel: Log level
+    :param logfile: Path to log file
+    :param logformat: Log output format
     :param action_file: Path to action file
 
+    :type ctx: :py:class:`~.click.Context`
     :type config: str
+    :type hosts: list
+    :type cloud_id: str
+    :type id: str
+    :type api_key: str
+    :type username: str
+    :type password: str
+    :type bearer_auth: str
+    :type opaque_id: str
+    :type request_timeout: int
+    :type http_compress: bool
+    :type verify_certs: bool
+    :type ca_certs: str
+    :type client_cert: str
+    :type client_key: str
+    :type ssl_assert_hostname: str
+    :type ssl_assert_fingerprint: str
+    :type ssl_version: str
+    :type master_only: bool
+    :type skip_version_test: bool
     :type dry_run: bool
+    :type loglevel: str
+    :type logfile: str
+    :type logformat: str
     :type action_file: str
 
 ``curator.config_utils``
@@ -267,7 +323,7 @@ This inherits from :py:class:`logging.Formatter`, so some of what you see docume
     :param ssl_version: Minimum acceptable TLS/SSL version
     :param master_only: Only run if the single host provided is the elected master
     :param skip_version_test: Do not check the host version
-    :param dry_run: Do not perform any changes.
+    :param dry_run: Do not perform any changes. NON-FUNCTIONAL PLACEHOLDER! DO NOT USE!
     :param loglevel: Log level
     :param logfile: Path to log file
     :param logformat: Log output format

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -21,7 +21,7 @@ Command-Line Usage
 ==================
 
 The documentation for this is on
-`Elastic's Website </https://www.elastic.co/guide/en/elasticsearch/client/curator/current/index.html>`_.
+`Elastic's Website <https://www.elastic.co/guide/en/elasticsearch/client/curator/current/index.html>`_.
 
 Example API Usage
 =================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,29 @@ exclude = [
     "tests",
 ]
 
+[tool.hatch.envs.test]
+dependencies = [
+    "coverage[toml]",
+    "mock",
+    "requests",
+    "pytest >=7.2.1",
+    "pytest-cov",
+]
+
+[tool.hatch.envs.test.scripts]
+step0 = "$(docker_test/scripts/destroy.sh 2&>1 /dev/null)"
+step1 = "step0 ; echo 'Starting test environment in Docker...' ; $(AUTO_EXPORT=y docker_test/scripts/create.sh 8.6.1 2&>1 /dev/null)"
+step2 = "step1 ; source docker_test/curatortestenv; echo 'Running tests:'"
+step3 = "step2 ; pytest ; EXITCODE=$?"
+step4 = "step3 ; echo 'Tests complete! Destroying Docker test environment...' "
+full = "step4 ; $(docker_test/scripts/destroy.sh 2&>1 /dev/null ) ;  exit $EXITCODE"
+run-coverage = "pytest --cov-config=pyproject.toml --cov=curator --cov=tests"
+run = "run-coverage --no-cov"
+
+[[tool.hatch.envs.test.matrix]]
+python = ["3.9", "3.10", "3.11"]
+version = ["8.0.2"]
+
 [tool.pytest.ini_options]
 pythonpath = [".", "curator"]
 minversion = "7.2"

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -220,3 +220,13 @@ class CuratorTestCase(TestCase):
             )
             return
         self.result = self.runner.invoke(cli, self.runner_args)
+
+    def invoke_runner_alt(self, **kwargs):
+        myargs = []
+        if kwargs:
+            for key, value in kwargs.items():
+                myargs.append(f'--{key}')
+                myargs.append(value)
+            myargs.append(self.args['actionfile'])
+            self.result = self.runner.invoke(cli, myargs)
+

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -15,6 +15,17 @@ class TestCLIMethods(CuratorTestCase):
         self.write_config(self.args['actionfile'], testvars.disabled_proto.format('close', 'delete_indices'))
         self.invoke_runner()
         assert 1 == self.result.exit_code
+    def test_cli_client_config(self):
+        self.create_indices(10)
+        self.write_config(self.args['configfile'], testvars.bad_client_config.format(HOST))
+        self.write_config(self.args['actionfile'], testvars.disabled_proto.format('close', 'delete_indices'))
+        self.invoke_runner_alt(hosts='http://127.0.0.1:9200', loglevel='DEBUG', logformat='ecs', logfile=self.args['configfile'])
+        assert 0 == self.result.exit_code
+    def test_cli_unreachable_cloud_id(self):
+        self.create_indices(10)
+        self.write_config(self.args['actionfile'], testvars.disabled_proto.format('close', 'delete_indices'))
+        self.invoke_runner_alt(hosts='http://127.0.0.2:9200', cloud_id='abc:def', username='user', password='pass')
+        assert 1 == self.result.exit_code
     def test_no_config(self):
         # This test checks whether localhost:9200 is provided if no hosts or
         # port are in the configuration. But in testing, sometimes


### PR DESCRIPTION

**Changes**

  * Added the same CLI flags that the singletons offers. This gives much more flexibility with
    regards to passing configuration settings as command-line options, particularly for Docker.
  * Re-created the ``get_client`` function. It now resides in ``curator.helpers.getters`` and will
    eventually see use in the Reindex class for remote connections.
  * Created a new set of classes to import, validate the schema, and split individual actions into
    their own sub-object instances. This is primarily to make ``curator/cli.py`` read much more
    cleanly. No new functionality here, but fewer conditional branches, and hopefully more readable
    code.
  * Updated the documentation to show these changes, both the API and the Elastic.co usage docs.