### PR TITLE
Update targetName to match the latest cx_freeze release (6.15.0)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,17 +55,17 @@ try:
     curator_exe = Executable(
         "run_curator.py",
         base=base,
-        targetName = "curator",
+        target_name = "curator",
     )
     curator_cli_exe = Executable(
         "run_singleton.py",
         base=base,
-        targetName = "curator_cli",
+        target_name = "curator_cli",
     )
     repomgr_exe = Executable(
         "run_es_repo_mgr.py",
         base=base,
-        targetName = "es_repo_mgr",
+        target_name = "es_repo_mgr",
     )
     buildOptions = dict(
         packages = [],
@@ -77,19 +77,19 @@ try:
         curator_exe = Executable(
             "run_curator.py",
             base=base,
-            targetName = "curator.exe",
+            target_name = "curator.exe",
             icon = icon
         )
         curator_cli_exe = Executable(
             "run_singleton.py",
             base=base,
-            targetName = "curator_cli.exe",
+            target_name = "curator_cli.exe",
             icon = icon
         )
         repomgr_exe = Executable(
             "run_es_repo_mgr.py",
             base=base,
-            targetName = "es_repo_mgr.exe",
+            target_name = "es_repo_mgr.exe",
             icon = icon
         )
 


### PR DESCRIPTION
Fixes #
The docker build is currently broken due to a breaking change in the latest cx_freeze, which removes camelCasing from the Executable parameters.
The latest cx_freeze (6.15.0) is automatically pulled in during the pip3 installation on alpine.

https://github.com/marcelotduarte/cx_Freeze/releases/tag/6.15.0
https://github.com/marcelotduarte/cx_Freeze/commit/8a3dc177c53800008f2cbf365750edb25859cdf9

