### PR TITLE
Update cx_freeze params

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ base = "Win32GUI" if sys.platform == "win32" else None
 
 setup(
   executables=[
-    Executable("run_curator.py", base=base, targetName="curator"),
-    Executable("run_singleton.py", base=base, targetName="curator_cli"),
-    Executable("run_es_repo_mgr.py", base=base, targetName="es_repo_mgr"),
+    Executable("run_curator.py", base=base, target_name="curator"),
+    Executable("run_singleton.py", base=base, target_name="curator_cli"),
+    Executable("run_es_repo_mgr.py", base=base, target_name="es_repo_mgr"),
   ]
 )


### PR DESCRIPTION
Similar to #1679 

The docker build is currently broken due to a breaking change in the latest cx_freeze, which removes camelCasing from the Executable parameters.
The latest cx_freeze (6.15.0) is automatically pulled in during the pip3 installation on alpine.

https://github.com/marcelotduarte/cx_Freeze/releases/tag/6.15.0
https://github.com/marcelotduarte/cx_Freeze/commit/8a3dc177c53800008f2cbf365750edb25859cdf9