### PR TITLE
Release prep for 8.8.2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYVER=3.11.1
+ARG PYVER=3.11.4
 ARG ALPTAG=3.17
 FROM python:${PYVER}-alpine${ALPTAG} as builder
 

--- a/curator/_version.py
+++ b/curator/_version.py
@@ -1,2 +1,2 @@
 """Curator Version"""
-__version__ = '8.0.4'
+__version__ = '8.0.5'

--- a/curator/helpers/waiters.py
+++ b/curator/helpers/waiters.py
@@ -11,9 +11,9 @@ from curator.helpers.utils import chunk_index_list
 
 def health_check(client, **kwargs):
     """
-    This function calls `client.cluster.` :py:meth:`~.elasticsearch.client.ClusterClient.health` and, based on the
-    params provided, will return ``True`` or ``False`` depending on whether that particular keyword
-    appears in the output, and has the expected value.
+    This function calls `client.cluster.` :py:meth:`~.elasticsearch.client.ClusterClient.health`
+    and, based on the params provided, will return ``True`` or ``False`` depending on whether that
+    particular keyword appears in the output, and has the expected value.
 
     If multiple keys are provided, all must match for a ``True`` response.
 
@@ -120,11 +120,11 @@ def restore_check(client, index_list):
 
 def snapshot_check(client, snapshot=None, repository=None):
     """
-    This function calls `client.snapshot.` :py:meth:`~.elasticsearch.client.SnapshotClient.get` and tests to see
-    whether the snapshot is complete, and if so, with what status.  It will log errors according
-    to the result. If the snapshot is still ``IN_PROGRESS``, it will return ``False``.  ``SUCCESS``
-    will be an ``INFO`` level message, ``PARTIAL`` nets a ``WARNING`` message, ``FAILED`` is an
-    ``ERROR``, message, and all others will be a ``WARNING`` level message.
+    This function calls `client.snapshot.` :py:meth:`~.elasticsearch.client.SnapshotClient.get` and
+    tests to see whether the snapshot is complete, and if so, with what status.  It will log errors
+    according to the result. If the snapshot is still ``IN_PROGRESS``, it will return ``False``.
+    ``SUCCESS`` will be an ``INFO`` level message, ``PARTIAL`` nets a ``WARNING`` message,
+    ``FAILED`` is an ``ERROR``, message, and all others will be a ``WARNING`` level message.
 
     :param client: A client connection object
     :param snapshot: The snapshot name
@@ -200,7 +200,7 @@ def task_check(client, task_id=None):
     descr = task['description']
 
     if completed:
-        completion_time = ((running_time * 1000) + task['start_time_in_millis'])
+        completion_time = (running_time * 1000) + task['start_time_in_millis']
         time_string = strftime('%Y-%m-%dT%H:%M:%SZ', localtime(completion_time/1000))
         logger.info('Task "%s" completed at %s.', descr, time_string)
         retval = True

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,30 @@
 Changelog
 =========
 
+8.0.5 (13 July 2023)
+--------------------
+
+**Announcements**
+
+Release for Elasticsearch 8.8.2
+
+**Changes**
+
+  * Small PEP formatting changes that were found editing code.
+  * Bump Python version in Dockerfile to 3.11.4
+  * Bump Python dependency versions.
+  * Change ``targetName`` to ``target_name`` in ``setup.py`` for newest version
+    of cx_Freeze. Hat tip to ``@rene-dekker`` in #1681 who made these changes
+    to 5.x and 7.x.
+  * Fix command-line behavior to not fail if the default config file is not
+    present. The newer CLI-based configuration should allow for no config file
+    at all, and now that's fixed.
+  * Initial work done to prevent a race condition where an index is present at IndexList
+    initialization, but is missing by the time index stats collection begins. The resultant
+    404s were causing Curator to shut down and not complete steps.
+  * When running in a Docker container, make Curator log to ``/proc/1/fd/1`` by
+    default, if no value is provided for ``logfile`` (otherwise, use that).
+
 8.0.4 (28 April 2023)
 ---------------------
 

--- a/docs/asciidoc/index.asciidoc
+++ b/docs/asciidoc/index.asciidoc
@@ -1,10 +1,10 @@
-:curator_version: 8.0.4
+:curator_version: 8.0.5
 :curator_major: 8
 :curator_doc_tree: 8.0
-:es_py_version: 8.7.0
-:es_doc_tree: 8.7
-:stack_doc_tree: 8.7
-:pybuild_ver: 3.11.3
+:es_py_version: 8.8.2
+:es_doc_tree: 8.8
+:stack_doc_tree: 8.8
+:pybuild_ver: 3.11.4
 :copyright_years: 2011-2023
 :ref:  http://www.elastic.co/guide/en/elasticsearch/reference/{es_doc_tree}
 :esref: http://www.elastic.co/guide/en/elasticsearch/reference/{stack_doc_tree}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,8 +72,8 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 
 intersphinx_mapping = {
 	'python': ('https://docs.python.org/3.11', None),
-    'es_client': ('https://es-client.readthedocs.io/en/v8.7.0', None),
-	'elasticsearch8': ('https://elasticsearch-py.readthedocs.io/en/v8.7.0', None),
+    'es_client': ('https://es-client.readthedocs.io/en/v8.8.2', None),
+	'elasticsearch8': ('https://elasticsearch-py.readthedocs.io/en/v8.8.2', None),
     'voluptuous': ('http://alecthomas.github.io/voluptuous/docs/_build/html', None),
     'click': ('https://click.palletsprojects.com/en/8.1.x', None),
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,13 +28,13 @@ keywords = [
     'index-expiry'
 ]
 dependencies = [
-    "elasticsearch8==8.7.0",
-    "es_client==8.7.0",
-    "ecs-logging==2.0.0",
-    "click==8.1.3",
+    "elasticsearch8==8.8.2",
+    "es_client==8.8.2",
+    "ecs-logging==2.0.2",
+    "click==8.1.4",
     "pyyaml==6.0.0",
     "voluptuous>=0.13.1",
-    "certifi>=2022.12.7",
+    "certifi>=2023.5.7",
     "six>=1.16.0",
 ]
 
@@ -103,7 +103,7 @@ run = "run-coverage --no-cov"
 
 [[tool.hatch.envs.test.matrix]]
 python = ["3.9", "3.10", "3.11"]
-version = ["8.0.4"]
+version = ["8.0.5"]
 
 [tool.pytest.ini_options]
 pythonpath = [".", "curator"]

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ base = "Win32GUI" if sys.platform == "win32" else None
 
 setup(
   executables=[
-    Executable("run_curator.py", base=base, targetName="curator"),
-    Executable("run_singleton.py", base=base, targetName="curator_cli"),
-    Executable("run_es_repo_mgr.py", base=base, targetName="es_repo_mgr"),
+    Executable("run_curator.py", base=base, target_name="curator"),
+    Executable("run_singleton.py", base=base, target_name="curator_cli"),
+    Executable("run_es_repo_mgr.py", base=base, target_name="es_repo_mgr"),
   ]
 )

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -19,7 +19,7 @@ class TestCLIMethods(CuratorTestCase):
         self.create_indices(10)
         self.write_config(self.args['configfile'], testvars.bad_client_config.format(HOST))
         self.write_config(self.args['actionfile'], testvars.disabled_proto.format('close', 'delete_indices'))
-        self.invoke_runner_alt(hosts='http://127.0.0.1:9200', loglevel='DEBUG', logformat='ecs', logfile=self.args['configfile'])
+        self.invoke_runner_alt(hosts='http://127.0.0.1:9200', loglevel='DEBUG', logformat='ecs')
         assert 0 == self.result.exit_code
     def test_cli_unreachable_cloud_id(self):
         self.create_indices(10)


### PR DESCRIPTION
**Changes**

  * Small PEP formatting changes that were found editing code.
  * Bump Python version in Dockerfile to 3.11.4
  * Bump Python dependency versions.
  * Change ``targetName`` to ``target_name`` in ``setup.py`` for newest version
    of cx_Freeze. Hat tip to ``@rene-dekker`` in #1681 who made these changes
    to 5.x and 7.x.
  * Fix command-line behavior to not fail if the default config file is not
    present. The newer CLI-based configuration should allow for no config file
    at all, and now that's fixed.
  * Initial work done to prevent a race condition where an index is present at IndexList
    initialization, but is missing by the time index stats collection begins. The resultant
    404s were causing Curator to shut down and not complete steps.
  * When running in a Docker container, make Curator log to ``/proc/1/fd/1`` by
    default, if no value is provided for ``logfile`` (otherwise, use that).
