### PR TITLE
Release prep for 8.0.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ elasticsearch_curator.egg-info
 elasticsearch_curator_dev.egg-info
 html_docs/
 index.html
+pytest.ini
 samples
 scratch
 test/.DS_Store

--- a/curator/_version.py
+++ b/curator/_version.py
@@ -1,2 +1,2 @@
 """Curator Version"""
-__version__ = '8.0.6.post1'
+__version__ = '8.0.7'

--- a/curator/actions/index_settings.py
+++ b/curator/actions/index_settings.py
@@ -77,6 +77,10 @@ class IndexSettings:
         # Detect if even one index is open.  Save all found to open_index_list.
         open_index_list = []
         open_indices = False
+        # This action requires index settings and state to be present
+        # Calling these here should not cause undue problems, even if it's a repeat call
+        self.index_list.get_index_state()
+        self.index_list.get_index_settings()
         for idx in self.index_list.indices:
             if self.index_list.index_info[idx]['state'] == 'open':
                 open_index_list.append(idx)

--- a/curator/indexlist.py
+++ b/curator/indexlist.py
@@ -72,9 +72,8 @@ class IndexList:
         if self.indices:
             for index in self.indices:
                 self.__build_index_info(index)
-            self.loggit.debug('FRESH UNPOPULATED: self.index_info = %s', self.index_info)
-            self.get_metadata()
-            self.get_index_stats()
+            # self.get_index_settings()
+            # self.get_index_stats()
 
     def __build_index_info(self, index):
         """
@@ -83,15 +82,7 @@ class IndexList:
         """
         self.loggit.debug('Building preliminary index metadata for %s', index)
         if index not in self.index_info:
-            self.index_info[index] = {
-                "age" : {},
-                "number_of_replicas" : 0,
-                "number_of_shards" : 0,
-                "segments" : 0,
-                "size_in_bytes" : 0,
-                "docs" : 0,
-                "state" : "",
-            }
+            self.index_info[index] = self.__zero_values()
 
     def __map_method(self, ftype):
         methods = {
@@ -120,65 +111,36 @@ class IndexList:
         """
         missing = err.info['error']['index']
         self.loggit.warning('Index was initiallly present, but now is not: %s', missing)
-        self.loggit.debug('Removing %s from active IndexList')
+        self.loggit.debug('Removing %s from active IndexList', missing)
         self.indices.remove(missing)
         return missing
 
-    def get_index_stats(self):
-        """
-        Populate ``index_info`` with index ``size_in_bytes``, ``primary_size_in_bytes`` and doc
-        count information for each index.
-        """
-        self.loggit.debug('Getting index stats')
-        self.empty_list_check()
-        # Subroutine to do the dirty work
-        def iterate_over_stats(stats):
-            for index in stats['indices']:
-                size = stats['indices'][index]['total']['store']['size_in_bytes']
-                docs = stats['indices'][index]['total']['docs']['count']
-                primary_size = stats['indices'][index]['primaries']['store']['size_in_bytes']
-                msg = (
-                    f'Index: {index}  Size: {byte_size(size)}  Docs: {docs} '
-                    f'PrimarySize: {byte_size(primary_size)}'
-                )
-                self.loggit.debug(msg)
-                self.index_info[index]['size_in_bytes'] = size
-                self.index_info[index]['docs'] = docs
-                self.index_info[index]['primary_size_in_bytes'] = primary_size
+    def __zero_values(self):
+        """The default values for index metadata"""
+        return {
+            'age' : {'creation_date': 0, 'name': 0},
+            'docs' : 0,
+            'number_of_replicas' : 0,
+            'number_of_shards' : 0,
+            'primary_size_in_bytes': 0,
+            'routing': {},
+            'segments' : 0,
+            'size_in_bytes' : 0,
+            'state' : '',
+        }
 
-        working_list = self.working_list()
-        for index in self.working_list():
-            if self.index_info[index]['state'] == 'close':
-                working_list.remove(index)
-        if working_list:
-            index_lists = chunk_index_list(working_list)
-            for lst in index_lists:
-                stats_result = {}
-                checking = True
-                while checking:
-                    try:
-                        stats_result.update(self._get_indices_stats(lst))
-                    except NotFoundError as err:
-                        lst.remove(self.__remove_missing(err))
-                        continue
-                    except TransportError as err:
-                        if '413' in err.errors:
-                            msg = (
-                                'Huge Payload 413 Err - '
-                                'Trying to get information via multiple requests'
-                            )
-                            self.loggit.debug(msg)
-                            stats_result = {}
-                            try:
-                                stats_result.update(self._bulk_queries(lst, self._get_indices_stats))
-                            except NotFoundError as err2:
-                                lst.remove(self.__remove_missing(err2))
-                                continue
-                    iterate_over_stats(stats_result)
-                    checking = False
+    # def _get_cluster_state(self, data):
+    #     return self.client.cluster.state(
+    #         index=to_csv(data), metric='metadata')['metadata']['indices']
+
+    def _get_indices_segments(self, data):
+        return self.client.indices.segments(index=to_csv(data))['indices'].copy()
+
+    def _get_indices_settings(self, data):
+        return self.client.indices.get_settings(index=to_csv(data))
 
     def _get_indices_stats(self, data):
-        return self.client.indices.stats(index=to_csv(data), metric='store,docs')
+        return self.client.indices.stats(index=to_csv(data), metric='store,docs')['indices']
 
     def _bulk_queries(self, data, exec_func):
         slice_number = 10
@@ -193,9 +155,6 @@ class IndexList:
             query_result.update(exec_func(data_sliced))
         return query_result
 
-    def _get_cluster_state(self, data):
-        return self.client.cluster.state(index=to_csv(data), metric='metadata')['metadata']['indices']
-
     def mitigate_alias(self, index):
         """
         Mitigate when an alias is detected instead of an index name
@@ -207,6 +166,7 @@ class IndexList:
         :returns: No return value:
         :rtype: None
         """
+        self.loggit.debug('BEGIN mitigate_alias')
         self.loggit.debug('Correcting an instance where an alias name points to index "%s"', index)
         data = self.client.indices.get(index=index)
         aliases = list(data[index]['aliases'])
@@ -222,55 +182,222 @@ class IndexList:
         self.indices.append(index)
         self.loggit.debug('Adding preliminary metadata for "%s" to IndexList.index_info', index)
         self.__build_index_info(index)
+        self.loggit.debug('END mitigate_alias')
 
-    def get_metadata(self):
+    def alias_index_check(self, data):
         """
-        Populate ``index_info`` with index ``size_in_bytes`` and doc count information for each
-        index.
+        Check each index in data to see if it's an alias.
         """
-        self.empty_list_check()
-        for lst in chunk_index_list(self.indices):
-            working_list = {}
-            # The API called by _get_cluster_state doesn't suffer from the same problems that
-            # _get_indices_stats does. This won't result in an error if an index is suddenly
-            # missing.
+        # self.loggit.debug('BEGIN alias_index_check')
+        working_list = data[:]
+        for entry in working_list:
+            if self.client.indices.exists_alias(name=entry):
+                index = list(self.client.indices.get_alias(name=entry).keys())[0]
+                self.loggit.warning('"%s" is actually an alias for index "%s"', entry, index)
+                self.mitigate_alias(index)
+                # The mitigate_alias step ensures that the class ivars are handled properly
+                # The following ensure that we pass back a modified list
+                data.remove(entry)
+                data.append(index)
+        # self.loggit.debug('END alias_index_check')
+        return data
+
+    def indices_exist(self, data, exec_func):
+        """Check if indices exist. If one doesn't, remove it. Loop until all exist"""
+        self.loggit.debug('BEGIN indices_exist')
+        checking = True
+        working_list = {}
+        verified_data = self.alias_index_check(data)
+        while checking:
             try:
-                working_list.update(self._get_cluster_state(lst))
+                working_list.update(exec_func(verified_data))
+            except NotFoundError as err:
+                data.remove(self.__remove_missing(err))
+                continue
             except TransportError as err:
                 if '413' in err.errors:
                     msg = 'Huge Payload 413 Err - Trying to get information via multiple requests'
                     self.loggit.debug(msg)
-                    working_list = {}
-                    working_list.update(self._bulk_queries(lst, self._get_cluster_state))
+                    working_list.update(self._bulk_queries(verified_data, exec_func))
+            checking = False
+        # self.loggit.debug('END indices_exist')
+        return working_list
+
+    def data_getter(self, data, exec_func):
+        """
+        Function that prevents unnecessary code repetition for different data getter methods
+        """
+        self.loggit.debug('BEGIN data_getter')
+        checking = True
+        while checking:
+            working_list = self.indices_exist(data, exec_func)
             if working_list:
-                self.loggit.debug('working_list.keys() = %s', working_list.keys())
                 for index in list(working_list.keys()):
-                    self.loggit.debug('index = %s', index)
                     try:
                         sii = self.index_info[index]
                     except KeyError:
-                        # What I believe has happened with this race condition is that during
-                        # __build_index_info initially, an index has a name, but is in process
-                        # of being remounted as a searchable snapshot index, and suddenly the
-                        # original index name is an alias, and the _get_cluster_state call returns
-                        # the new, actual index name instead of the alias it had. This is how a
-                        # KeyError can actually happen in this case. The relevant logs showing
-                        # this behavior are in issue #1682
                         self.loggit.warning(
                             'Index %s was not present at IndexList initialization, and may be '
                             'behind an alias', index
                         )
                         self.mitigate_alias(index)
                         sii = self.index_info[index]
-                    wli = working_list[index]
-                    sii['age']['creation_date'] = (
-                        fix_epoch(wli['settings']['index']['creation_date'])
+                        working_list = {}
+                        try:
+                            working_list.update(self._bulk_queries(data, exec_func))
+                        except NotFoundError as err:
+                            data.remove(self.__remove_missing(err))
+                            continue
+                    yield sii, working_list[index], index
+            checking = False
+        # self.loggit.debug('END data_getter')
+
+    def population_check(self, index, key):
+        """Verify that key is in self.index_info[index], and that it is populated"""
+        retval = True
+        # self.loggit.debug('BEGIN population_check')
+        # self.loggit.debug('population_check: %s, %s', index, key)
+        if not index in self.index_info:
+            # This is just in case the index was somehow not populated
+            self.__build_index_info(index)
+        if not key in self.index_info[index]:
+            self.index_info[index][key] = self.__zero_values()[key]
+        if self.index_info[index][key] == self.__zero_values()[key]:
+            retval = False
+        # self.loggit.debug('END population_check')
+        return retval
+
+    def needs_data(self, indices, fields):
+        """Check for data population in self.index_info"""
+        self.loggit.debug('Indices: %s, Fields: %s', indices, fields)
+        needful = []
+        working_list = self.indices_exist(indices, self._get_indices_settings)
+        for idx in working_list:
+            count = 0
+            for field in fields:
+                # If the return value is True for this field, it means it's populated
+                if self.population_check(idx, field):
+                    count += 1
+            if count == 0:
+                # All values are the default/zero
+                needful.append(idx)
+        if fields == ['state']:
+            self.loggit.debug('Always check open/close for all passed indices')
+            needful = list(working_list.keys())
+        self.loggit.debug('These indices need data in index_info: %s', needful)
+        return needful
+
+    def get_index_settings(self):
+        """
+        For each index in self.indices, populate ``index_info`` with:
+            creation_date
+            number_of_replicas
+            number_of_shards
+            routing information (if present)
+        """
+        self.loggit.debug('Getting index settings -- BEGIN')
+        self.empty_list_check()
+        fields = ['age', 'number_of_replicas', 'number_of_shards', 'routing']
+        for lst in chunk_index_list(self.indices):
+            # This portion here is to ensure that we're not polling for data unless we must
+            needful = self.needs_data(lst, fields)
+            if not needful:
+                # All indices are populated with some data, so we can skip data collection
+                continue
+            # Now we only need to run on the 'needful'
+            for sii, wli, _ in self.data_getter(needful, self._get_indices_settings):
+                sii['age']['creation_date'] = (
+                    fix_epoch(wli['settings']['index']['creation_date'])
+                )
+                sii['number_of_replicas'] = wli['settings']['index']['number_of_replicas']
+                sii['number_of_shards'] = wli['settings']['index']['number_of_shards']
+                if 'routing' in wli['settings']['index']:
+                    sii['routing'] = wli['settings']['index']['routing']
+        self.loggit.debug('Getting index settings -- END')
+
+    def get_index_state(self):
+        """
+        For each index in self.indices, populate ``index_info`` with:
+            state (open or closed)
+        from the cat API
+        """
+        self.loggit.debug('Getting index state -- BEGIN')
+        self.empty_list_check()
+        fields = ['state']
+        for lst in chunk_index_list(self.indices):
+            # This portion here is to ensure that we're not polling for data unless we must
+            needful = self.needs_data(lst, fields)
+            # Checking state is _always_ needful.
+            resp = self.client.cat.indices(index=to_csv(needful), format='json', h='index,status')
+            for entry in resp:
+                try:
+                    self.index_info[entry['index']]['state'] = entry['status']
+                except KeyError:
+                    self.loggit.warning(
+                        'Index %s was not present at IndexList initialization, and may be '
+                        'behind an alias', entry['index']
                     )
-                    sii['number_of_replicas'] = wli['settings']['index']['number_of_replicas']
-                    sii['number_of_shards'] = wli['settings']['index']['number_of_shards']
-                    sii['state'] = wli['state']
-                    if 'routing' in wli['settings']['index']:
-                        sii['routing'] = wli['settings']['index']['routing']
+                    self.mitigate_alias(entry['index'])
+                    self.index_info[entry['index']]['state'] = entry['status']
+        # self.loggit.debug('Getting index state -- END')
+
+    def get_index_stats(self):
+        """
+        Populate ``index_info`` with index ``size_in_bytes``, ``primary_size_in_bytes`` and doc
+        count information for each index.
+        """
+        self.loggit.debug('Getting index stats -- BEGIN')
+        self.empty_list_check()
+        fields = ['size_in_bytes', 'docs', 'primary_size_in_bytes']
+        # This ensures that the index state is populated
+        self.get_index_state()
+        # Don't populate working_list until after the get_index state as it
+        # can and will remove missing indices
+        working_list = self.working_list()
+        for index in self.working_list():
+            if self.index_info[index]['state'] == 'close':
+                working_list.remove(index)
+        if working_list:
+            index_lists = chunk_index_list(working_list)
+            for lst in index_lists:
+                # This portion here is to ensure that we're not polling for data unless we must
+                needful = self.needs_data(lst, fields)
+                if not needful:
+                    # All indices are populated with some data, so we can skip data collection
+                    continue
+                # Now we only need to run on the 'needful'
+                for sii, wli, index in self.data_getter(needful, self._get_indices_stats):
+                    try:
+                        size = wli['total']['store']['size_in_bytes']
+                        docs = wli['total']['docs']['count']
+                        primary_size = wli['primaries']['store']['size_in_bytes']
+                        msg = (
+                            f'Index: {index}  Size: {byte_size(size)}  Docs: {docs} '
+                            f'PrimarySize: {byte_size(primary_size)}'
+                        )
+                        self.loggit.debug(msg)
+                        sii['size_in_bytes'] = size
+                        sii['docs'] = docs
+                        sii['primary_size_in_bytes'] = primary_size
+                    except KeyError:
+                        msg = f'Index stats missing for "{index}" -- might be closed'
+                        self.loggit.warning(msg)
+        # self.loggit.debug('Getting index stats -- END')
+
+    def get_segment_counts(self):
+        """
+        Populate ``index_info`` with segment information for each index.
+        """
+        self.loggit.debug('Getting index segment counts')
+        self.empty_list_check()
+        for lst in chunk_index_list(self.indices):
+            for sii, wli, _ in self.data_getter(lst, self._get_indices_segments):
+                shards = wli['shards']
+                segmentcount = 0
+                for shardnum in shards:
+                    for shard in range(0, len(shards[shardnum])):
+                        segmentcount += shards[shardnum][shard]['num_search_segments']
+                sii['segments'] = segmentcount
 
     def empty_list_check(self):
         """Raise :py:exc:`~.curator.exceptions.NoIndices` if ``indices`` is empty"""
@@ -288,33 +415,6 @@ class IndexList:
         self.loggit.debug('Generating working list of indices')
         return self.indices[:]
 
-    def _get_indices_segments(self, data):
-        return self.client.indices.segments(index=to_csv(data))['indices'].copy()
-
-    def _get_segment_counts(self):
-        """
-        Populate ``index_info`` with segment information for each index.
-        """
-        self.loggit.debug('Getting index segment counts')
-        self.empty_list_check()
-        for lst in chunk_index_list(self.indices):
-            working_list = {}
-            try:
-                working_list.update(self._get_indices_segments(lst))
-            except TransportError as err:
-                if '413' in err.errors:
-                    self.loggit.debug('Huge Payload 413 Error - Trying to get information with multiple requests')
-                    working_list = {}
-                    working_list.update(self._bulk_queries(lst, self._get_indices_segments))
-            if working_list:
-                for index in list(working_list.keys()):
-                    shards = working_list[index]['shards']
-                    segmentcount = 0
-                    for shardnum in shards:
-                        for shard in range(0,len(shards[shardnum])):
-                            segmentcount += (shards[shardnum][shard]['num_search_segments'])
-                    self.index_info[index]['segments'] = segmentcount
-
     def _get_name_based_ages(self, timestring):
         """
         Add indices to ``index_info`` based on the age as indicated by the index
@@ -330,6 +430,7 @@ class IndexList:
             epoch = tstr.get_epoch(index)
             if isinstance(epoch, int):
                 self.index_info[index]['age']['name'] = epoch
+
 
     def _get_field_stats_dates(self, field='@timestamp'):
         """
@@ -386,7 +487,7 @@ class IndexList:
                 raise MissingArgument('source "name" requires the "timestring" keyword argument')
             self._get_name_based_ages(timestring)
         elif source == 'creation_date':
-            # Nothing to do here as this comes from `get_metadata` in __init__
+            # Nothing to do here as this comes from `get_settings` in __init__
             pass
         elif source == 'field_stats':
             if not field:
@@ -411,18 +512,25 @@ class IndexList:
         # Build an temporary dictionary with just index and age as the key and value, respectively
         temp = {}
         for index in index_list:
-            if self.age_keyfield in self.index_info[index]['age']:
-                temp[index] = self.index_info[index]['age'][self.age_keyfield]
-            else:
-                msg = (f'{index} does not have key "{self.age_keyfield}" in IndexList metadata')
+            try:
+                if self.index_info[index]['age'][self.age_keyfield]:
+                    temp[index] = self.index_info[index]['age'][self.age_keyfield]
+                else:
+                    msg = (
+                        f'No date for "{index}" in IndexList metadata. '
+                        f'Possible timestring mismatch. Excluding index "{index}".'
+                    )
+                    self.__excludify(True, True, index, msg)
+            except KeyError:
+                msg = f'{index} does not have key "{self.age_keyfield}" in IndexList metadata'
                 self.__excludify(True, True, index, msg)
         # Sort alphabetically prior to age sort to keep sorting consistent
-        temp_tuple = (sorted(temp.items(), key=lambda k: k[0], reverse=reverse))
+        temp_tuple = sorted(temp.items(), key=lambda k: k[0], reverse=reverse)
         # If reverse is True, this will sort so the youngest indices are first.
         # However, if you want oldest first, set reverse to False.
         # Effectively, this should set us up to act on everything older than
         # meets the other set criteria. It starts as a tuple, but then becomes a list.
-        sorted_tuple = (sorted(temp_tuple, key=lambda k: k[1], reverse=reverse))
+        sorted_tuple = sorted(temp_tuple, key=lambda k: k[1], reverse=reverse)
         return [x[0] for x in sorted_tuple]
 
     def filter_by_regex(self, kind=None, value=None, exclude=False):
@@ -489,12 +597,14 @@ class IndexList:
             ``indices``. Default is ``False``
         """
         self.loggit.debug('Filtering indices by age')
-        # Get timestamp point of reference, PoR
-        PoR = get_point_of_reference(unit, unit_count, epoch)
+        # Get timestamp point of reference, por
+        por = get_point_of_reference(unit, unit_count, epoch)
         if not direction:
             raise MissingArgument('Must provide a value for "direction"')
         if direction not in ['older', 'younger']:
             raise ValueError(f'Invalid value for "direction": {direction}')
+        # This filter requires index settings.
+        self.get_index_settings()
         self._calculate_ages(
             source=source, timestring=timestring, field=field, stats_result=stats_result)
         if unit_count_pattern:
@@ -508,11 +618,11 @@ class IndexList:
                 unit_count_matcher = None
         for index in self.working_list():
             try:
-                removeThisIndex = False
+                remove_this_index = False
                 age = int(self.index_info[index]['age'][self.age_keyfield])
                 msg = (
                     f'Index "{index}" age ({age}), direction: "{direction}", point of '
-                    f'reference, ({PoR})'
+                    f'reference, ({por})'
                 )
                 # Because time adds to epoch, smaller numbers are actually older
                 # timestamps.
@@ -521,9 +631,9 @@ class IndexList:
                     unit_count_from_index = get_unit_count_from_name(index, unit_count_matcher)
                     if unit_count_from_index:
                         self.loggit.debug('Pattern matched, applying unit_count of  "%s"', unit_count_from_index)
-                        adjustedPoR = get_point_of_reference(unit, unit_count_from_index, epoch)
+                        adjustedpor = get_point_of_reference(unit, unit_count_from_index, epoch)
                         msg = (
-                            f'Adjusting point of reference from {PoR} to {adjustedPoR} '
+                            f'Adjusting point of reference from {por} to {adjustedpor} '
                             f'based on unit_count of {unit_count_from_index} from index name'
                         )
                         self.loggit.debug(msg)
@@ -535,20 +645,20 @@ class IndexList:
                             f'Removing index "{index}" from actionable list'
                         )
                         self.loggit.debug(msg)
-                        removeThisIndex = True
-                        adjustedPoR = PoR # necessary to avoid exception if the first index is excluded
+                        remove_this_index = True
+                        adjustedpor = por # necessary to avoid exception if the first index is excluded
                     else:
                         # Unable to match the pattern and unit_count is set, so fall back to using unit_count
                         # for determining whether to keep this index in the list
                         self.loggit.debug('Unable to match pattern using fallback value of "%s"', unit_count)
-                        adjustedPoR = PoR
+                        adjustedpor = por
                 else:
-                    adjustedPoR = PoR
+                    adjustedpor = por
                 if direction == 'older':
-                    agetest = age < adjustedPoR
+                    agetest = age < adjustedpor
                 else:
-                    agetest = age > adjustedPoR
-                self.__excludify(agetest and not removeThisIndex, exclude, index, msg)
+                    agetest = age > adjustedpor
+                self.__excludify(agetest and not remove_this_index, exclude, index, msg)
             except KeyError:
                 msg = (
                     f'Index "{index}" does not meet provided criteria. '
@@ -605,6 +715,9 @@ class IndexList:
             raise MissingArgument('No value for "disk_space" provided')
         if threshold_behavior not in ['greater_than', 'less_than']:
             raise ValueError(f'Invalid value for "threshold_behavior": {threshold_behavior}')
+        # This filter requires both index stats and index settings
+        self.get_index_stats()
+        self.get_index_settings()
         disk_space = float(disk_space)
         disk_usage = 0.0
         disk_limit = disk_space * 2**30
@@ -617,6 +730,7 @@ class IndexList:
             self._calculate_ages(
                 source=source, timestring=timestring, field=field, stats_result=stats_result)
             # Using default value of reverse=True in self._sort_by_age()
+            self.loggit.debug('SORTING BY AGE')
             sorted_indices = self._sort_by_age(working_list)
         else:
             # Default to sorting by index name
@@ -664,8 +778,11 @@ class IndexList:
             raise MissingArgument('Missing value for "max_num_segments"')
         self.loggit.debug(
             'Cannot get segment count of closed indices. Omitting any closed indices.')
+        # This filter requires the index state (open/close), and index settings.
+        self.get_index_state()
+        self.get_index_settings()
         self.filter_closed()
-        self._get_segment_counts()
+        self.get_segment_counts()
         for index in self.working_list():
             # Do this to reduce long lines and make it more readable...
             shards = int(self.index_info[index]['number_of_shards'])
@@ -687,6 +804,8 @@ class IndexList:
             ``indices``. Default is ``True``
         """
         self.loggit.debug('Filtering closed indices')
+        # This filter requires index state (open/close)
+        self.get_index_state()
         self.empty_list_check()
         for index in self.working_list():
             condition = self.index_info[index]['state'] == 'close'
@@ -703,6 +822,9 @@ class IndexList:
             ``indices``. Default is ``True``
         """
         self.loggit.debug('Filtering empty indices')
+        # This index requires index state (open/close) and index stats
+        self.get_index_state()
+        self.get_index_stats()
         self.filter_closed()
         self.empty_list_check()
         for index in self.working_list():
@@ -719,6 +841,8 @@ class IndexList:
             ``indices``. Default is ``True``
         """
         self.loggit.debug('Filtering open indices')
+        # This filter requires index state (open/close)
+        self.get_index_state()
         self.empty_list_check()
         for index in self.working_list():
             condition = self.index_info[index]['state'] == 'open'
@@ -743,9 +867,12 @@ class IndexList:
             raise MissingArgument('No value for "value" provided')
         if allocation_type not in ['include', 'exclude', 'require']:
             raise ValueError(f'Invalid "allocation_type": {allocation_type}')
+        # This filter requires index settings
+        self.get_index_settings()
+        self.get_index_state()
         self.empty_list_check()
         for lst in chunk_index_list(self.indices):
-            working_list = self.client.indices.get_settings(index=to_csv(lst))
+            working_list = self._get_indices_settings(lst)
             if working_list:
                 for index in list(working_list.keys()):
                     try:
@@ -848,6 +975,9 @@ class IndexList:
         self.loggit.debug('Filtering indices by count')
         if not count:
             raise MissingArgument('No value for "count" provided')
+        # This filter requires index state (open/close) and index settings
+        self.get_index_state()
+        self.get_index_settings()
         # Create a copy-by-value working list
         working_list = self.working_list()
         if pattern:
@@ -931,6 +1061,8 @@ class IndexList:
                 f'Unacceptable value: {number_of_shards} -- "number_of_shards" cannot be less '
                 f'than 1. A valid index will have at least one shard.'
             )
+        # This filter requires index_settings to count shards
+        self.get_index_settings()
         self.empty_list_check()
         for index in self.working_list():
             self.loggit.debug('Filter by number of shards: Index: %s', index)
@@ -1005,6 +1137,8 @@ class IndexList:
                         'Must provide "date_from", "date_to", "date_from_format", and '
                         '"date_to_format" with absolute period_type'
                     )
+        # This filter requires index settings 
+        self.get_index_settings()
         try:
             start, end = func(*args, **kwgs)
         # pylint: disable=broad-except
@@ -1054,7 +1188,7 @@ class IndexList:
             self.loggit.debug('Empty working list. No ILM indices to filter.')
             return
         for lst in index_lists:
-            working_list = self.client.indices.get_settings(index=to_csv(lst))
+            working_list = self._get_indices_settings(lst)
             if working_list:
                 for index in list(working_list.keys()):
                     try:
@@ -1143,6 +1277,9 @@ class IndexList:
         index_size_limit = float(size_threshold) * 2**30
         self.loggit.debug(
             'Cannot get disk usage info from closed indices. Omitting any closed indices.')
+        # This filter requires index state (open/close) and index stats
+        self.get_index_state()
+        self.get_index_stats()
         self.filter_closed()
         # Create a copy-by-value working list
         working_list = self.working_list()

--- a/docs/asciidoc/index.asciidoc
+++ b/docs/asciidoc/index.asciidoc
@@ -1,4 +1,4 @@
-:curator_version: 8.0.6
+:curator_version: 8.0.7
 :curator_major: 8
 :curator_doc_tree: 8.0
 :es_py_version: 8.8.2

--- a/tests/integration/test_create_index.py
+++ b/tests/integration/test_create_index.py
@@ -30,6 +30,7 @@ class TestCLICreateIndex(CuratorTestCase):
         assert not get_indices(self.client)
         self.invoke_runner()
         ilo = IndexList(self.client)
+        ilo.get_index_settings()
         aliases = self.client.indices.get_alias(name=alias)
         mapping = self.client.indices.get_mapping(index=idx)
         assert [idx] == ilo.indices

--- a/tests/integration/test_forcemerge.py
+++ b/tests/integration/test_forcemerge.py
@@ -15,7 +15,7 @@ class TestActionFileforceMerge(CuratorTestCase):
         self.create_index(idx)
         self.add_docs(idx)
         ilo1 = IndexList(self.client)
-        ilo1._get_segment_counts()
+        ilo1.get_segment_counts()
         assert 3 == ilo1.index_info[idx]['segments']
         self.write_config(self.args['configfile'], testvars.client_config.format(HOST))
         self.write_config(self.args['actionfile'], testvars.forcemerge_test.format(count, 0.9))
@@ -26,7 +26,7 @@ class TestActionFileforceMerge(CuratorTestCase):
         # 3 checks before giving up and reporting the result.
         for _ in range(0, 3):
             self.client.indices.refresh(index=idx)
-            ilo2._get_segment_counts()
+            ilo2.get_segment_counts()
             if ilo2.index_info[idx]['segments'] == count:
                 break
             sleep(1)
@@ -43,7 +43,7 @@ class TestCLIforceMerge(CuratorTestCase):
         self.create_index(idx)
         self.add_docs(idx)
         ilo1 = IndexList(self.client)
-        ilo1._get_segment_counts()
+        ilo1.get_segment_counts()
         assert 3 == ilo1.index_info[idx]['segments']
         args = self.get_runner_args()
         args += [
@@ -60,7 +60,7 @@ class TestCLIforceMerge(CuratorTestCase):
         # This is forcing 3 checks before giving up and reporting the result.
         for _ in range(0, 3):
             self.client.indices.refresh(index=idx)
-            ilo2._get_segment_counts()
+            ilo2.get_segment_counts()
             if ilo2.index_info[idx]['segments'] == count:
                 break
             sleep(1)

--- a/tests/unit/test_action_alias.py
+++ b/tests/unit/test_action_alias.py
@@ -1,5 +1,5 @@
 """Alias unit tests"""
-# pylint: disable=missing-function-docstring, missing-class-docstring, invalid-name, line-too-long
+# pylint: disable=missing-function-docstring, missing-class-docstring, invalid-name, line-too-long, attribute-defined-outside-init
 from unittest import TestCase
 from mock import Mock
 from curator import IndexList
@@ -8,135 +8,92 @@ from curator.actions.alias import Alias
 from . import testvars
 
 class TestActionAlias(TestCase):
+    VERSION = {'version': {'number': '8.0.0'} }
+    def builder(self):
+        self.client = Mock()
+        self.client.info.return_value = self.VERSION
+        self.client.cat.indices.return_value = testvars.state_one
+        self.client.indices.get_settings.return_value = testvars.settings_one
+        self.client.indices.stats.return_value = testvars.stats_one
+        self.client.indices.exists_alias.return_value = False
+        self.ilo = IndexList(self.client)
+    def builder2(self):
+        self.client = Mock()
+        self.client.info.return_value = self.VERSION
+        self.client.cat.indices.return_value = testvars.state_two
+        self.client.indices.get_settings.return_value = testvars.settings_two
+        self.client.indices.stats.return_value = testvars.stats_two
+        self.client.indices.exists_alias.return_value = False
+        self.ilo = IndexList(self.client)
     def test_init_raise(self):
         self.assertRaises(MissingArgument, Alias)
     def test_add_raises_on_missing_parameter(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        _ = IndexList(client)
+        self.builder()
         ao = Alias(name='alias')
         self.assertRaises(TypeError, ao.add)
     def test_add_raises_on_invalid_parameter(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        _ = IndexList(client)
+        self.builder()
         ao = Alias(name='alias')
         self.assertRaises(TypeError, ao.add, [])
     def test_add_single(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        _ = IndexList(client)
+        self.builder()
         ao = Alias(name='alias')
-        ao.add(_)
+        ao.add(self.ilo)
         self.assertEqual(testvars.alias_one_add, ao.actions)
     def test_add_single_with_extra_settings(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        _ = IndexList(client)
+        self.builder()
         esd = {
             'filter' : { 'term' : { 'user' : 'kimchy' } }
         }
         ao = Alias(name='alias', extra_settings=esd)
-        ao.add(_)
+        ao.add(self.ilo)
         self.assertEqual(testvars.alias_one_add_with_extras, ao.actions)
     def test_remove_single(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.get_alias.return_value = testvars.settings_1_get_aliases
-        _ = IndexList(client)
+        self.builder()
+        self.client.indices.get_alias.return_value = testvars.settings_1_get_aliases
         ao = Alias(name='my_alias')
-        ao.remove(_)
+        ao.remove(self.ilo)
         self.assertEqual(testvars.alias_one_rm, ao.actions)
     def test_add_multiple(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        _ = IndexList(client)
+        self.builder2()
         ao = Alias(name='alias')
-        ao.add(_)
+        ao.add(self.ilo)
         cmp = sorted(ao.actions, key=lambda k: k['add']['index'])
         self.assertEqual(testvars.alias_two_add, cmp)
     def test_remove_multiple(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.indices.get_alias.return_value = testvars.settings_2_get_aliases
-        _ = IndexList(client)
+        self.builder2()
+        self.client.indices.get_alias.return_value = testvars.settings_2_get_aliases
         ao = Alias(name='my_alias')
-        ao.remove(_)
+        ao.remove(self.ilo)
         cmp = sorted(ao.actions, key=lambda k: k['remove']['index'])
         self.assertEqual(testvars.alias_two_rm, cmp)
     def test_raise_action_error_on_empty_body(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        _ = IndexList(client)
+        self.builder()
         ao = Alias(name='alias')
         self.assertRaises(ActionError, ao.check_actions)
     def test_raise_no_indices_on_empty_body_when_warn_if_no_indices(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        _ = IndexList(client)
+        self.builder()
         # empty it, so there can be no body
-        _.indices = []
+        self.ilo.indices = []
         ao = Alias(name='alias')
-        ao.add(_, warn_if_no_indices=True)
+        ao.add(self.ilo, warn_if_no_indices=True)
         self.assertRaises(NoIndices, ao.check_actions)
     def test_do_dry_run(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.update_aliases.return_value = testvars.alias_success
-        _ = IndexList(client)
+        self.builder()
+        self.client.indices.update_aliases.return_value = testvars.alias_success
         ao = Alias(name='alias')
-        ao.add(_)
+        ao.add(self.ilo)
         self.assertIsNone(ao.do_dry_run())
     def test_do_action(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.update_aliases.return_value = testvars.alias_success
-        _ = IndexList(client)
+        self.builder()
+        self.client.indices.update_aliases.return_value = testvars.alias_success
         ao = Alias(name='alias')
-        ao.add(_)
+        ao.add(self.ilo)
         self.assertIsNone(ao.do_action())
     def test_do_action_raises_exception(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.update_aliases.return_value = testvars.alias_success
-        client.indices.update_aliases.side_effect = testvars.four_oh_one
-        _ = IndexList(client)
+        self.builder()
+        self.client.indices.update_aliases.return_value = testvars.alias_success
+        self.client.indices.update_aliases.side_effect = testvars.four_oh_one
         ao = Alias(name='alias')
-        ao.add(_)
+        ao.add(self.ilo)
         self.assertRaises(FailedExecution, ao.do_action)

--- a/tests/unit/test_action_allocation.py
+++ b/tests/unit/test_action_allocation.py
@@ -1,5 +1,5 @@
 """Alias unit tests"""
-# pylint: disable=missing-function-docstring, missing-class-docstring, invalid-name, line-too-long
+# pylint: disable=missing-function-docstring, missing-class-docstring, invalid-name, line-too-long, attribute-defined-outside-init
 from unittest import TestCase
 from mock import Mock
 from curator import IndexList
@@ -8,99 +8,60 @@ from curator.actions.allocation import Allocation
 from . import testvars
 
 class TestActionAllocation(TestCase):
+    VERSION = {'version': {'number': '5.0.0'} }
+    def builder(self):
+        self.client = Mock()
+        self.client.info.return_value = self.VERSION
+        self.client.cat.indices.return_value = testvars.state_one
+        self.client.indices.get_settings.return_value = testvars.settings_one
+        self.client.indices.stats.return_value = testvars.stats_one
+        self.client.indices.exists_alias.return_value = False
+        self.client.indices.put_settings.return_value = None
+        self.ilo = IndexList(self.client)
     def test_init_raise(self):
         self.assertRaises(TypeError, Allocation, 'invalid')
     def test_init(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        ilo = IndexList(client)
-        ao = Allocation(ilo, key='key', value='value')
-        self.assertEqual(ilo, ao.index_list)
-        self.assertEqual(client, ao.client)
+        self.builder()
+        ao = Allocation(self.ilo, key='key', value='value')
+        self.assertEqual(self.ilo, ao.index_list)
+        self.assertEqual(self.client, ao.client)
     def test_create_body_no_key(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        ilo = IndexList(client)
-        self.assertRaises(MissingArgument, Allocation, ilo)
+        self.builder()
+        self.assertRaises(MissingArgument, Allocation, self.ilo)
     def test_create_body_invalid_allocation_type(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        ilo = IndexList(client)
+        self.builder()
         self.assertRaises(
             ValueError,
-            Allocation, ilo,
+            Allocation, self.ilo,
             key='key', value='value', allocation_type='invalid'
         )
     def test_create_body_valid(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        ilo = IndexList(client)
-        ao = Allocation(ilo, key='key', value='value')
+        self.builder()
+        ao = Allocation(self.ilo, key='key', value='value')
         self.assertEqual({'index.routing.allocation.require.key': 'value'}, ao.settings)
     def test_do_action_raise_on_put_settings(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.put_settings.return_value = None
-        client.indices.put_settings.side_effect = testvars.fake_fail
-        ilo = IndexList(client)
-        ao = Allocation(ilo, key='key', value='value')
+        self.builder()
+        self.client.indices.put_settings.side_effect = testvars.fake_fail
+        ao = Allocation(self.ilo, key='key', value='value')
         self.assertRaises(Exception, ao.do_action)
     def test_do_dry_run(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.put_settings.return_value = None
-        ilo = IndexList(client)
-        ao = Allocation(ilo, key='key', value='value')
-        self.assertIsNone(ao.do_dry_run())
+        self.builder()
+        alo = Allocation(self.ilo, key='key', value='value')
+        self.assertIsNone(alo.do_dry_run())
     def test_do_action(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.put_settings.return_value = None
-        ilo = IndexList(client)
-        ao = Allocation(ilo, key='key', value='value')
-        self.assertIsNone(ao.do_action())
+        self.builder()
+        alo = Allocation(self.ilo, key='key', value='value')
+        self.assertIsNone(alo.do_action())
     def test_do_action_wait_v50(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.put_settings.return_value = None
-        client.cluster.health.return_value = {'relocating_shards':0}
-        ilo = IndexList(client)
-        ao = Allocation(
-            ilo, key='key', value='value', wait_for_completion=True)
-        self.assertIsNone(ao.do_action())
+        self.builder()
+        self.client.cluster.health.return_value = {'relocating_shards':0}
+        alo = Allocation(
+            self.ilo, key='key', value='value', wait_for_completion=True)
+        self.assertIsNone(alo.do_action())
     def test_do_action_wait_v51(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.1.1'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.put_settings.return_value = None
-        client.cluster.health.return_value = {'relocating_shards':0}
-        ilo = IndexList(client)
-        ao = Allocation(
-            ilo, key='key', value='value', wait_for_completion=True)
-        self.assertIsNone(ao.do_action())
+        self.builder()
+        self.client.info.return_value = {'version': {'number': '5.1.1'} }
+        self.client.cluster.health.return_value = {'relocating_shards':0}
+        alo = Allocation(
+            self.ilo, key='key', value='value', wait_for_completion=True)
+        self.assertIsNone(alo.do_action())

--- a/tests/unit/test_action_close.py
+++ b/tests/unit/test_action_close.py
@@ -1,5 +1,5 @@
 """Alias unit tests"""
-# pylint: disable=missing-function-docstring, missing-class-docstring, invalid-name, line-too-long
+# pylint: disable=missing-function-docstring, missing-class-docstring, invalid-name, line-too-long, attribute-defined-outside-init
 from unittest import TestCase
 from mock import Mock
 from curator import IndexList
@@ -8,83 +8,55 @@ from curator.actions.close import Close
 from . import testvars
 
 class TestActionClose(TestCase):
+    VERSION = {'version': {'number': '5.0.0'} }
+    def builder(self):
+        self.client = Mock()
+        self.client.info.return_value = self.VERSION
+        self.client.cat.indices.return_value = testvars.state_one
+        self.client.indices.get_settings.return_value = testvars.settings_one
+        self.client.indices.stats.return_value = testvars.stats_one
+        self.client.indices.flush_synced.return_value = testvars.synced_pass
+        self.client.indices.exists_alias.return_value = False
+        self.client.indices.close.return_value = None
+        self.ilo = IndexList(self.client)
     def test_init_raise(self):
         self.assertRaises(TypeError, Close, 'invalid')
     def test_init(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        ilo = IndexList(client)
-        co = Close(ilo)
-        self.assertEqual(ilo, co.index_list)
-        self.assertEqual(client, co.client)
+        self.builder()
+        self.client.indices.flush_synced.return_value = None
+        self.client.indices.close.return_value = None
+        clo = Close(self.ilo)
+        self.assertEqual(self.ilo, clo.index_list)
+        self.assertEqual(self.client, clo.client)
     def test_do_dry_run(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.flush_synced.return_value = testvars.synced_pass
-        client.indices.close.return_value = None
-        ilo = IndexList(client)
-        co = Close(ilo)
-        self.assertIsNone(co.do_dry_run())
+        self.builder()
+        self.ilo = IndexList(self.client)
+        clo = Close(self.ilo)
+        self.assertIsNone(clo.do_dry_run())
     def test_do_action(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.flush_synced.return_value = testvars.synced_pass
-        client.indices.close.return_value = None
-        ilo = IndexList(client)
-        co = Close(ilo)
-        self.assertIsNone(co.do_action())
+        self.builder()
+        self.ilo = IndexList(self.client)
+        clo = Close(self.ilo)
+        self.assertIsNone(clo.do_action())
     def test_do_action_with_delete_aliases(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.flush_synced.return_value = testvars.synced_pass
-        client.indices.close.return_value = None
-        ilo = IndexList(client)
-        co = Close(ilo, delete_aliases=True)
-        self.assertIsNone(co.do_action())
+        self.builder()
+        self.ilo = IndexList(self.client)
+        clo = Close(self.ilo, delete_aliases=True)
+        self.assertIsNone(clo.do_action())
     def test_do_action_with_skip_flush(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.flush_synced.return_value = testvars.synced_pass
-        client.indices.close.return_value = None
-        ilo = IndexList(client)
-        co = Close(ilo, skip_flush=True)
-        self.assertIsNone(co.do_action())
+        self.builder()
+        self.ilo = IndexList(self.client)
+        clo = Close(self.ilo, skip_flush=True)
+        self.assertIsNone(clo.do_action())
     def test_do_action_raises_exception(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.flush_synced.return_value = testvars.synced_pass
-        client.indices.close.return_value = None
-        client.indices.close.side_effect = testvars.fake_fail
-        ilo = IndexList(client)
-        co = Close(ilo)
-        self.assertRaises(FailedExecution, co.do_action)
+        self.builder()
+        self.client.indices.close.side_effect = testvars.fake_fail
+        self.ilo = IndexList(self.client)
+        clo = Close(self.ilo)
+        self.assertRaises(FailedExecution, clo.do_action)
     def test_do_action_delete_aliases_with_exception(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.flush_synced.return_value = testvars.synced_pass
-        client.indices.close.return_value = None
-        ilo = IndexList(client)
-        client.indices.delete_alias.side_effect = testvars.fake_fail
-        co = Close(ilo, delete_aliases=True)
-        self.assertIsNone(co.do_action())
+        self.builder()
+        self.ilo = IndexList(self.client)
+        self.client.indices.delete_alias.side_effect = testvars.fake_fail
+        clo = Close(self.ilo, delete_aliases=True)
+        self.assertIsNone(clo.do_action())

--- a/tests/unit/test_action_delete_indices.py
+++ b/tests/unit/test_action_delete_indices.py
@@ -1,4 +1,5 @@
 """test_action_delete_indices"""
+# pylint: disable=missing-function-docstring, missing-class-docstring, protected-access, attribute-defined-outside-init
 from unittest import TestCase
 from mock import Mock
 from curator.actions import DeleteIndices
@@ -8,74 +9,52 @@ from curator import IndexList
 from . import testvars
 
 class TestActionDeleteIndices(TestCase):
+    VERSION = {'version': {'number': '8.0.0'} }
+    def builder(self):
+        self.client = Mock()
+        self.client.info.return_value = self.VERSION
+        self.client.cat.indices.return_value = testvars.state_one
+        self.client.indices.get_settings.return_value = testvars.settings_one
+        self.client.indices.stats.return_value = testvars.stats_one
+        self.client.indices.exists_alias.return_value = False
+        self.ilo = IndexList(self.client)
+    def builder4(self):
+        self.client = Mock()
+        self.client.info.return_value = self.VERSION
+        self.client.cat.indices.return_value = testvars.state_four
+        self.client.indices.get_settings.return_value = testvars.settings_four
+        self.client.indices.stats.return_value = testvars.stats_four
+        self.client.indices.exists_alias.return_value = False
+        self.client.indices.delete.return_value = None
+        self.ilo = IndexList(self.client)
     def test_init_raise(self):
         self.assertRaises(TypeError, DeleteIndices, 'invalid')
     def test_init_raise_bad_master_timeout(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        ilo = IndexList(client)
-        self.assertRaises(TypeError, DeleteIndices, ilo, 'invalid')
+        self.builder()
+        self.assertRaises(TypeError, DeleteIndices, self.ilo, 'invalid')
     def test_init(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        ilo = IndexList(client)
-        do = DeleteIndices(ilo)
-        self.assertEqual(ilo, do.index_list)
-        self.assertEqual(client, do.client)
+        self.builder()
+        dio = DeleteIndices(self.ilo)
+        self.assertEqual(self.ilo, dio.index_list)
+        self.assertEqual(self.client, dio.client)
     def test_do_dry_run(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
-        client.indices.stats.return_value = testvars.stats_four
-        client.indices.delete.return_value = None
-        ilo = IndexList(client)
-        do = DeleteIndices(ilo)
-        self.assertIsNone(do.do_dry_run())
+        self.builder4()
+        dio = DeleteIndices(self.ilo)
+        self.assertIsNone(dio.do_dry_run())
     def test_do_action(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
-        client.indices.stats.return_value = testvars.stats_four
-        client.indices.delete.return_value = None
-        ilo = IndexList(client)
-        do = DeleteIndices(ilo)
-        self.assertIsNone(do.do_action())
+        self.builder4()
+        dio = DeleteIndices(self.ilo)
+        self.assertIsNone(dio.do_action())
     def test_do_action_not_successful(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
-        client.indices.stats.return_value = testvars.stats_four
-        client.indices.delete.return_value = None
-        ilo = IndexList(client)
-        do = DeleteIndices(ilo)
-        self.assertIsNone(do.do_action())
+        self.builder4()
+        dio = DeleteIndices(self.ilo)
+        self.assertIsNone(dio.do_action())
     def test_do_action_raises_exception(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
-        client.indices.stats.return_value = testvars.stats_four
-        client.indices.delete.return_value = None
-        client.indices.delete.side_effect = testvars.fake_fail
-        ilo = IndexList(client)
-        do = DeleteIndices(ilo)
-        self.assertRaises(FailedExecution, do.do_action)
+        self.builder4()
+        self.client.indices.delete.side_effect = testvars.fake_fail
+        dio = DeleteIndices(self.ilo)
+        self.assertRaises(FailedExecution, dio.do_action)
     def test_verify_result_positive(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
-        client.indices.stats.return_value = testvars.stats_four
-        client.indices.delete.return_value = None
-        ilo = IndexList(client)
-        do = DeleteIndices(ilo)
-        self.assertTrue(do._verify_result([],2))
+        self.builder4()
+        dio = DeleteIndices(self.ilo)
+        self.assertTrue(dio._verify_result([],2))

--- a/tests/unit/test_action_forcemerge.py
+++ b/tests/unit/test_action_forcemerge.py
@@ -1,4 +1,5 @@
 """test_action_forcemerge"""
+# pylint: disable=missing-function-docstring, missing-class-docstring, protected-access, attribute-defined-outside-init
 from unittest import TestCase
 from mock import Mock
 from curator.actions import ForceMerge
@@ -8,88 +9,48 @@ from curator import IndexList
 from . import testvars
 
 class TestActionForceMerge(TestCase):
+    VERSION = {'version': {'number': '8.0.0'} }
+    def builder(self):
+        self.client = Mock()
+        self.client.info.return_value = self.VERSION
+        self.client.cat.indices.return_value = testvars.state_one
+        self.client.indices.get_settings.return_value = testvars.settings_one
+        self.client.indices.stats.return_value = testvars.stats_one
+        self.client.indices.exists_alias.return_value = False
+        self.client.indices.segments.return_value = testvars.shards
+        self.ilo = IndexList(self.client)
     def test_init_raise_bad_client(self):
         self.assertRaises(
             TypeError, ForceMerge, 'invalid', max_num_segments=2)
     def test_init_raise_no_segment_count(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.segments.return_value = testvars.shards
-        ilo = IndexList(client)
-        self.assertRaises(MissingArgument, ForceMerge, ilo)
+        self.builder()
+        self.assertRaises(MissingArgument, ForceMerge, self.ilo)
     def test_init(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.segments.return_value = testvars.shards
-        ilo = IndexList(client)
-        fmo = ForceMerge(ilo, max_num_segments=2)
-        self.assertEqual(ilo, fmo.index_list)
-        self.assertEqual(client, fmo.client)
+        self.builder()
+        fmo = ForceMerge(self.ilo, max_num_segments=2)
+        self.assertEqual(self.ilo, fmo.index_list)
+        self.assertEqual(self.client, fmo.client)
     def test_do_dry_run(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.segments.return_value = testvars.shards
-        client.indices.forcemerge.return_value = None
-        client.indices.optimize.return_value = None
-        ilo = IndexList(client)
-        fmo = ForceMerge(ilo, max_num_segments=2)
+        self.builder()
+        self.client.indices.forcemerge.return_value = None
+        self.client.indices.optimize.return_value = None
+        fmo = ForceMerge(self.ilo, max_num_segments=2)
         self.assertIsNone(fmo.do_dry_run())
-    def test_do_action_pre5(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.segments.return_value = testvars.shards
-        client.info.return_value = {'version': {'number': '2.3.2'} }
-        client.indices.optimize.return_value = None
-        ilo = IndexList(client)
-        fmo = ForceMerge(ilo, max_num_segments=2)
-        self.assertIsNone(fmo.do_action())
     def test_do_action(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.segments.return_value = testvars.shards
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.forcemerge.return_value = None
-        ilo = IndexList(client)
-        fmo = ForceMerge(ilo, max_num_segments=2)
+        self.builder()
+        self.client.indices.forcemerge.return_value = None
+        fmo = ForceMerge(self.ilo, max_num_segments=2)
         self.assertIsNone(fmo.do_action())
     def test_do_action_with_delay(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.segments.return_value = testvars.shards
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.forcemerge.return_value = None
-        ilo = IndexList(client)
-        fmo = ForceMerge(ilo, max_num_segments=2, delay=0.050)
+        self.builder()
+        self.client.indices.forcemerge.return_value = None
+        fmo = ForceMerge(self.ilo, max_num_segments=2, delay=0.050)
         self.assertIsNone(fmo.do_action())
     def test_do_action_raises_exception(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.segments.return_value = testvars.shards
-        client.indices.forcemerge.return_value = None
-        client.indices.optimize.return_value = None
-        client.indices.forcemerge.side_effect = testvars.fake_fail
-        client.indices.optimize.side_effect = testvars.fake_fail
-        ilo = IndexList(client)
-        fmo = ForceMerge(ilo, max_num_segments=2)
+        self.builder()
+        self.client.indices.forcemerge.return_value = None
+        self.client.indices.optimize.return_value = None
+        self.client.indices.forcemerge.side_effect = testvars.fake_fail
+        self.client.indices.optimize.side_effect = testvars.fake_fail
+        fmo = ForceMerge(self.ilo, max_num_segments=2)
         self.assertRaises(FailedExecution, fmo.do_action)

--- a/tests/unit/test_action_indexsettings.py
+++ b/tests/unit/test_action_indexsettings.py
@@ -1,4 +1,5 @@
 """test_action_indexsettings"""
+# pylint: disable=missing-function-docstring, missing-class-docstring, protected-access, attribute-defined-outside-init
 from unittest import TestCase
 from mock import Mock
 from curator.actions import IndexSettings
@@ -8,36 +9,30 @@ from curator import IndexList
 from . import testvars
 
 class TestActionIndexSettings(TestCase):
+    VERSION = {'version': {'number': '8.0.0'} }
+    def builder(self):
+        self.client = Mock()
+        self.client.info.return_value = self.VERSION
+        self.client.cat.indices.return_value = testvars.state_one
+        self.client.indices.get_settings.return_value = testvars.settings_one
+        self.client.indices.stats.return_value = testvars.stats_one
+        self.client.indices.exists_alias.return_value = False
+        self.ilo = IndexList(self.client)
     def test_init_raise_bad_index_list(self):
         self.assertRaises(TypeError, IndexSettings, 'invalid')
     def test_init_no_index_settings(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        ilo = IndexList(client)
-        _ = IndexSettings(ilo, {'index':{'refresh_interval':'1s'}})
-        self.assertRaises(MissingArgument, IndexSettings, ilo, {})
+        self.builder()
+        _ = IndexSettings(self.ilo, {'index':{'refresh_interval':'1s'}})
+        self.assertRaises(MissingArgument, IndexSettings, self.ilo, {})
     def test_init_bad_index_settings(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        ilo = IndexList(client)
-        _ = IndexSettings(ilo, {'index':{'refresh_interval':'1s'}})
-        self.assertRaises(ConfigurationError, IndexSettings, ilo, {'a':'b'})
+        self.builder()
+        _ = IndexSettings(self.ilo, {'index':{'refresh_interval':'1s'}})
+        self.assertRaises(ConfigurationError, IndexSettings, self.ilo, {'a':'b'})
     def test_init(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        ilo = IndexList(client)
-        iso = IndexSettings(ilo, {'index':{'refresh_interval':'1s'}})
-        self.assertEqual(ilo, iso.index_list)
-        self.assertEqual(client, iso.client)
+        self.builder()
+        iso = IndexSettings(self.ilo, {'index':{'refresh_interval':'1s'}})
+        self.assertEqual(self.ilo, iso.index_list)
+        self.assertEqual(self.client, iso.client)
     def test_static_settings(self):
         static = [
             'number_of_shards',
@@ -45,15 +40,11 @@ class TestActionIndexSettings(TestCase):
             'codec',
             'routing_partition_size',
         ]
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        ilo = IndexList(client)
-        iso = IndexSettings(ilo, {'index':{'refresh_interval':'1s'}})
+        self.builder()
+        iso = IndexSettings(self.ilo, {'index':{'refresh_interval':'1s'}})
         self.assertEqual(static, iso._static_settings())
     def test_dynamic_settings(self):
+        self.builder()
         dynamic = [
             'number_of_replicas',
             'auto_expand_replicas',
@@ -66,78 +57,39 @@ class TestActionIndexSettings(TestCase):
             'merge',
             'translog',
         ]
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        ilo = IndexList(client)
-        iso = IndexSettings(ilo, {'index':{'refresh_interval':'1s'}})
+        iso = IndexSettings(self.ilo, {'index':{'refresh_interval':'1s'}})
         self.assertEqual(dynamic, iso._dynamic_settings())
     def test_settings_check_raises_with_opened(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        ilo = IndexList(client)
-        iso = IndexSettings(ilo, {'index':{'codec':'best_compression'}})
+        self.builder()
+        self.ilo.get_index_state()
+        self.ilo.get_index_settings()
+        iso = IndexSettings(self.ilo, {'index':{'codec':'best_compression'}})
         self.assertRaises(ActionError, iso._settings_check)
     def test_settings_check_no_raise_with_ignore_unavailable(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        ilo = IndexList(client)
+        self.builder()
         iso = IndexSettings(
-            ilo, {'index':{'codec':'best_compression'}}, ignore_unavailable=True
+            self.ilo, {'index':{'codec':'best_compression'}}, ignore_unavailable=True
         )
         self.assertIsNone(iso._settings_check())
     def test_settings_check_no_raise_with_dynamic_settings(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        ilo = IndexList(client)
-        iso = IndexSettings(ilo, {'index':{'refresh_interval':'1s'}})
+        self.builder()
+        iso = IndexSettings(self.ilo, {'index':{'refresh_interval':'1s'}})
         self.assertIsNone(iso._settings_check())
     def test_settings_check_no_raise_with_unknown(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        ilo = IndexList(client)
-        iso = IndexSettings(ilo, {'index':{'foobar':'1s'}})
+        self.builder()
+        iso = IndexSettings(self.ilo, {'index':{'foobar':'1s'}})
         self.assertIsNone(iso._settings_check())
     def test_settings_dry_run(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        ilo = IndexList(client)
-        iso = IndexSettings(ilo, {'index':{'refresh_interval':'1s'}})
+        self.builder()
+        iso = IndexSettings(self.ilo, {'index':{'refresh_interval':'1s'}})
         self.assertIsNone(iso.do_dry_run())
     def test_settings_do_action(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.put_settings.return_value = {"acknowledged":True}
-        ilo = IndexList(client)
-        iso = IndexSettings(ilo, {'index':{'refresh_interval':'1s'}})
+        self.builder()
+        self.client.indices.put_settings.return_value = {"acknowledged":True}
+        iso = IndexSettings(self.ilo, {'index':{'refresh_interval':'1s'}})
         self.assertIsNone(iso.do_action())
     def test_settings_do_action_raises(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.put_settings.side_effect = testvars.fake_fail
-        ilo = IndexList(client)
-        iso = IndexSettings(ilo, {'index':{'refresh_interval':'1s'}})
+        self.builder()
+        self.client.indices.put_settings.side_effect = testvars.fake_fail
+        iso = IndexSettings(self.ilo, {'index':{'refresh_interval':'1s'}})
         self.assertRaises(Exception, iso.do_action)

--- a/tests/unit/test_action_restore.py
+++ b/tests/unit/test_action_restore.py
@@ -1,4 +1,5 @@
 """test_action_restore"""
+# pylint: disable=missing-function-docstring, missing-class-docstring, protected-access, attribute-defined-outside-init
 from unittest import TestCase
 from mock import Mock
 from curator.actions import Restore

--- a/tests/unit/test_action_shrink.py
+++ b/tests/unit/test_action_shrink.py
@@ -1,4 +1,5 @@
 """test_action_shrink"""
+# pylint: disable=missing-function-docstring, missing-class-docstring, line-too-long, protected-access, attribute-defined-outside-init
 from unittest import TestCase
 from mock import Mock
 from curator.actions import Shrink
@@ -15,13 +16,15 @@ class TestActionShrink_extra_settings(TestCase):
     def builder(self):
         self.client = Mock()
         self.client.info.return_value = {'version': {'number': '8.0.0'} }
+        self.client.cat.indices.return_value = testvars.state_one
         self.client.indices.get_settings.return_value = testvars.settings_one
-        self.client.cluster.state.return_value = testvars.clu_state_one
         self.client.indices.stats.return_value = testvars.stats_one
+        self.client.indices.exists_alias.return_value = False
         self.ilo = IndexList(self.client)
     def test_extra_settings_1(self):
         self.builder()
-        self.assertRaises(ConfigurationError, Shrink, self.ilo, extra_settings={'settings':{'foobar'}})
+        self.assertRaises(
+            ConfigurationError, Shrink, self.ilo, extra_settings={'settings':{'foobar'}})
     def test_extra_settings_2(self):
         self.builder()
         self.assertRaises(ConfigurationError, Shrink, self.ilo, extra_settings={'foobar'})
@@ -30,9 +33,10 @@ class TestActionShrink_data_node(TestCase):
     def builder(self):
         self.client = Mock()
         self.client.info.return_value = {'version': {'number': '8.0.0'} }
+        self.client.cat.indices.return_value = testvars.state_one
         self.client.indices.get_settings.return_value = testvars.settings_one
-        self.client.cluster.state.return_value = testvars.clu_state_one
         self.client.indices.stats.return_value = testvars.stats_one
+        self.client.indices.exists_alias.return_value = False
         self.node_name = 'node_name'
         self.node_id = 'my_node'
         self.client.nodes.stats.return_value = {'nodes':{self.node_id:{'name':self.node_name}}}
@@ -51,9 +55,10 @@ class TestActionShrink_exclude_node(TestCase):
     def builder(self):
         self.client = Mock()
         self.client.info.return_value = {'version': {'number': '8.0.0'} }
+        self.client.cat.indices.return_value = testvars.state_one
         self.client.indices.get_settings.return_value = testvars.settings_one
-        self.client.cluster.state.return_value = testvars.clu_state_one
         self.client.indices.stats.return_value = testvars.stats_one
+        self.client.indices.exists_alias.return_value = False
         self.node_name = 'node_name'
         self.ilo = IndexList(self.client)
     def test_positive(self):
@@ -72,9 +77,10 @@ class TestActionShrink_qualify_single_node(TestCase):
     def builder(self):
         self.client = Mock()
         self.client.info.return_value = {'version': {'number': '8.0.0'} }
+        self.client.cat.indices.return_value = testvars.state_one
         self.client.indices.get_settings.return_value = testvars.settings_one
-        self.client.cluster.state.return_value = testvars.clu_state_one
         self.client.indices.stats.return_value = testvars.stats_one
+        self.client.indices.exists_alias.return_value = False
         self.node_name = 'node_name'
         self.node_id = 'my_node'
         self.client.nodes.stats.return_value = {'nodes':{self.node_id:{'name':self.node_name}}}
@@ -106,9 +112,10 @@ class TestActionShrink_most_available_node(TestCase):
     def builder(self):
         self.client = Mock()
         self.client.info.return_value = {'version': {'number': '8.0.0'} }
+        self.client.cat.indices.return_value = testvars.state_one
         self.client.indices.get_settings.return_value = testvars.settings_one
-        self.client.cluster.state.return_value = testvars.clu_state_one
         self.client.indices.stats.return_value = testvars.stats_one
+        self.client.indices.exists_alias.return_value = False
         self.node_name = 'node_name'
         self.node_id = 'my_node'
         self.byte_count = 123456
@@ -127,9 +134,10 @@ class TestActionShrink_route_index(TestCase):
     def builder(self):
         self.client = Mock()
         self.client.info.return_value = {'version': {'number': '8.0.0'} }
+        self.client.cat.indices.return_value = testvars.state_one
         self.client.indices.get_settings.return_value = testvars.settings_one
-        self.client.cluster.state.return_value = testvars.clu_state_one
         self.client.indices.stats.return_value = testvars.stats_one
+        self.client.indices.exists_alias.return_value = False
         self.ilo = IndexList(self.client)
         self.shrink = Shrink(self.ilo)
     def test_raises(self):
@@ -142,9 +150,10 @@ class TestActionShrink_dry_run(TestCase):
     def builder(self):
         self.client = Mock()
         self.client.info.return_value = {'version': {'number': '8.0.0'} }
+        self.client.cat.indices.return_value = testvars.state_one
         self.client.indices.get_settings.return_value = testvars.settings_one
-        self.client.cluster.state.return_value = testvars.clu_state_one
         self.client.indices.stats.return_value = testvars.stats_one
+        self.client.indices.exists_alias.return_value = False
         self.node_name = 'node_name'
         self.node_id = 'my_node'
         self.byte_count = 123456
@@ -154,14 +163,12 @@ class TestActionShrink_dry_run(TestCase):
         self.builder()
         self.client.nodes.info.return_value = {'nodes':{self.node_id:{'roles':['data']}}}
         self.client.indices.get.return_value = {testvars.named_index:{'settings':{'index':{'number_of_shards': 2}}}}
-        self.client.indices.exists.return_value = False
         shrink = Shrink(self.ilo, shrink_node=self.node_name, post_allocation={'allocation_type':'require', 'key':'_name', 'value':self.node_name})
         self.assertIsNone(shrink.do_dry_run())
     def test_dry_run_raises(self):
         self.builder()
         self.client.nodes.info.return_value = {'nodes':{self.node_id:{'roles':['data']}}}
         self.client.indices.get.side_effect = testvars.fake_fail
-        self.client.indices.exists.return_value = False
         shrink = Shrink(self.ilo, shrink_node=self.node_name)
         self.assertRaises(Exception, shrink.do_dry_run)
 
@@ -170,9 +177,10 @@ class TestActionShrink_various(TestCase):
     def builder(self):
         self.client = Mock()
         self.client.info.return_value = {'version': {'number': '8.0.0'} }
+        self.client.cat.indices.return_value = testvars.state_one
         self.client.indices.get_settings.return_value = testvars.settings_one
-        self.client.cluster.state.return_value = testvars.clu_state_one
         self.client.indices.stats.return_value = testvars.stats_one
+        self.client.indices.exists_alias.return_value = False
         self.node_name = 'node_name'
         self.node_id = 'my_node'
         self.byte_count = 1239132959

--- a/tests/unit/test_action_snapshot.py
+++ b/tests/unit/test_action_snapshot.py
@@ -1,4 +1,5 @@
 """test_action_snapshot"""
+# pylint: disable=missing-function-docstring, missing-class-docstring, line-too-long, protected-access, attribute-defined-outside-init
 from unittest import TestCase
 from mock import Mock
 from curator.actions import Snapshot
@@ -8,181 +9,90 @@ from curator import IndexList
 from . import testvars
 
 class TestActionSnapshot(TestCase):
+    VERSION = {'version': {'number': '8.0.0'} }
+    def builder(self):
+        self.client = Mock()
+        self.client.info.return_value = self.VERSION
+        self.client.cat.indices.return_value = testvars.state_one
+        self.client.indices.get_settings.return_value = testvars.settings_one
+        self.client.indices.stats.return_value = testvars.stats_one
+        self.client.indices.exists_alias.return_value = False
+        self.client.snapshot.get_repository.return_value = testvars.test_repo
+        self.client.snapshot.get.return_value = testvars.snapshots
+        self.client.tasks.get.return_value = testvars.no_snap_tasks
+        self.ilo = IndexList(self.client)
     def test_init_raise_bad_index_list(self):
         self.assertRaises(TypeError, Snapshot, 'invalid')
     def test_init_no_repo_arg_exception(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '8.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        ilo = IndexList(client)
-        self.assertRaises(MissingArgument, Snapshot, ilo)
+        self.builder()
+        self.assertRaises(MissingArgument, Snapshot, self.ilo)
     def test_init_no_repo_exception(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '8.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.snapshot.get_repository.return_value = {'repo':{'foo':'bar'}}
-        ilo = IndexList(client)
-        self.assertRaises(
-            ActionError, Snapshot, ilo, repository='notfound')
+        self.builder()
+        self.client.snapshot.get_repository.return_value = {'repo':{'foo':'bar'}}
+        self.assertRaises(ActionError, Snapshot, self.ilo, repository='notfound')
     def test_init_no_name_exception(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '8.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.snapshot.get_repository.return_value = testvars.test_repo
-        ilo = IndexList(client)
-        self.assertRaises(MissingArgument, Snapshot, ilo,
-            repository=testvars.repo_name)
+        self.builder()
+        self.assertRaises(MissingArgument, Snapshot, self.ilo, repository=testvars.repo_name)
     def test_init_success(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '8.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.snapshot.get_repository.return_value = testvars.test_repo
-        ilo = IndexList(client)
-        so = Snapshot(ilo, repository=testvars.repo_name,
-            name=testvars.snap_name)
-        self.assertEqual(testvars.repo_name, so.repository)
-        self.assertIsNone(so.state)
+        self.builder()
+        sso = Snapshot(self.ilo, repository=testvars.repo_name, name=testvars.snap_name)
+        self.assertEqual(testvars.repo_name, sso.repository)
+        self.assertIsNone(sso.state)
     def test_get_state_success(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '8.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.snapshot.get_repository.return_value = testvars.test_repo
-        client.snapshot.get.return_value = testvars.snapshots
-        client.tasks.get.return_value = testvars.no_snap_tasks
-        ilo = IndexList(client)
-        so = Snapshot(ilo, repository=testvars.repo_name,
-            name=testvars.snap_name)
-        so.get_state()
-        self.assertEqual('SUCCESS', so.state)
+        self.builder()
+        sso = Snapshot(self.ilo, repository=testvars.repo_name, name=testvars.snap_name)
+        sso.get_state()
+        self.assertEqual('SUCCESS', sso.state)
     def test_get_state_fail(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '8.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.snapshot.get_repository.return_value = testvars.test_repo
-        client.snapshot.get.return_value = {'snapshots':[]}
-        client.tasks.get.return_value = testvars.no_snap_tasks
-        ilo = IndexList(client)
-        so = Snapshot(ilo, repository=testvars.repo_name,
-            name=testvars.snap_name)
-        self.assertRaises(CuratorException, so.get_state)
+        self.builder()
+        self.client.snapshot.get.return_value = {'snapshots':[]}
+        sso = Snapshot(self.ilo, repository=testvars.repo_name, name=testvars.snap_name)
+        self.assertRaises(CuratorException, sso.get_state)
     def test_report_state_success(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '8.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.snapshot.get_repository.return_value = testvars.test_repo
-        client.snapshot.get.return_value = testvars.snapshots
-        client.tasks.get.return_value = testvars.no_snap_tasks
-        ilo = IndexList(client)
-        so = Snapshot(ilo, repository=testvars.repo_name,
-            name=testvars.snap_name)
-        so.report_state()
-        self.assertEqual('SUCCESS', so.state)
+        self.builder()
+        sso = Snapshot(self.ilo, repository=testvars.repo_name, name=testvars.snap_name)
+        sso.report_state()
+        self.assertEqual('SUCCESS', sso.state)
     def test_report_state_other(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '8.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.snapshot.get_repository.return_value = testvars.test_repo
-        client.snapshot.get.return_value = testvars.highly_unlikely
-        client.tasks.get.return_value = testvars.no_snap_tasks
-        ilo = IndexList(client)
-        so = Snapshot(ilo, repository=testvars.repo_name,
-            name=testvars.snap_name)
-        self.assertRaises(FailedSnapshot, so.report_state)
+        self.builder()
+        self.client.snapshot.get.return_value = testvars.highly_unlikely
+        sso = Snapshot(self.ilo, repository=testvars.repo_name, name=testvars.snap_name)
+        self.assertRaises(FailedSnapshot, sso.report_state)
     def test_do_dry_run(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '8.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.snapshot.get_repository.return_value = testvars.test_repo
-        client.snapshot.get.return_value = testvars.snapshots
-        client.tasks.get.return_value = testvars.no_snap_tasks
-        client.snapshot.create.return_value = None
-        client.snapshot.status.return_value = testvars.nosnap_running
-        client.snapshot.verify_repository.return_value = testvars.verified_nodes
-        ilo = IndexList(client)
-        so = Snapshot(ilo, repository=testvars.repo_name,
-            name=testvars.snap_name)
-        self.assertIsNone(so.do_dry_run())
+        self.builder()
+        self.client.snapshot.create.return_value = None
+        self.client.snapshot.status.return_value = testvars.nosnap_running
+        self.client.snapshot.verify_repository.return_value = testvars.verified_nodes
+        sso = Snapshot(self.ilo, repository=testvars.repo_name, name=testvars.snap_name)
+        self.assertIsNone(sso.do_dry_run())
     def test_do_action_success(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '8.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.snapshot.get_repository.return_value = testvars.test_repo
-        client.snapshot.get.return_value = testvars.snapshots
-        client.tasks.get.return_value = testvars.no_snap_tasks
-        client.snapshot.create.return_value = testvars.generic_task
-        client.tasks.get.return_value = testvars.completed_task
-        client.snapshot.status.return_value = testvars.nosnap_running
-        client.snapshot.verify_repository.return_value = testvars.verified_nodes
-        ilo = IndexList(client)
-        so = Snapshot(ilo, repository=testvars.repo_name,
-            name=testvars.snap_name)
-        self.assertIsNone(so.do_action())
+        self.builder()
+        self.client.snapshot.create.return_value = testvars.generic_task
+        self.client.tasks.get.return_value = testvars.completed_task
+        self.client.snapshot.status.return_value = testvars.nosnap_running
+        self.client.snapshot.verify_repository.return_value = testvars.verified_nodes
+        sso = Snapshot(self.ilo, repository=testvars.repo_name, name=testvars.snap_name)
+        self.assertIsNone(sso.do_action())
     def test_do_action_raise_snap_in_progress(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '8.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.snapshot.get_repository.return_value = testvars.test_repo
-        client.snapshot.get.return_value = testvars.snapshots
-        client.tasks.get.return_value = testvars.no_snap_tasks
-        client.snapshot.create.return_value = None
-        client.snapshot.status.return_value = testvars.snap_running
-        client.snapshot.verify_repository.return_value = testvars.verified_nodes
-        ilo = IndexList(client)
-        so = Snapshot(ilo, repository=testvars.repo_name,
-            name=testvars.snap_name)
-        self.assertRaises(SnapshotInProgress, so.do_action)
+        self.builder()
+        self.client.snapshot.create.return_value = None
+        self.client.snapshot.status.return_value = testvars.snap_running
+        self.client.snapshot.verify_repository.return_value = testvars.verified_nodes
+        sso = Snapshot(self.ilo, repository=testvars.repo_name, name=testvars.snap_name)
+        self.assertRaises(SnapshotInProgress, sso.do_action)
     def test_do_action_no_wait_for_completion(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '8.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.snapshot.get_repository.return_value = testvars.test_repo
-        client.snapshot.get.return_value = testvars.snapshots
-        client.tasks.get.return_value = testvars.no_snap_tasks
-        client.snapshot.create.return_value = testvars.generic_task
-        client.snapshot.status.return_value = testvars.nosnap_running
-        client.snapshot.verify_repository.return_value = testvars.verified_nodes
-        ilo = IndexList(client)
-        so = Snapshot(ilo, repository=testvars.repo_name,
+        self.builder()
+        self.client.snapshot.create.return_value = testvars.generic_task
+        self.client.snapshot.status.return_value = testvars.nosnap_running
+        self.client.snapshot.verify_repository.return_value = testvars.verified_nodes
+        sso = Snapshot(self.ilo, repository=testvars.repo_name,
             name=testvars.snap_name, wait_for_completion=False)
-        self.assertIsNone(so.do_action())
+        self.assertIsNone(sso.do_action())
     def test_do_action_raise_on_failure(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '8.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.snapshot.get_repository.return_value = testvars.test_repo
-        client.snapshot.get.return_value = testvars.snapshots
-        client.tasks.get.return_value = testvars.no_snap_tasks
-        client.snapshot.create.return_value = None
-        client.snapshot.create.side_effect = testvars.fake_fail
-        client.snapshot.status.return_value = testvars.nosnap_running
-        client.snapshot.verify_repository.return_value = testvars.verified_nodes
-        ilo = IndexList(client)
-        so = Snapshot(ilo, repository=testvars.repo_name,
-            name=testvars.snap_name)
-        self.assertRaises(FailedExecution, so.do_action)
+        self.builder()
+        self.client.snapshot.create.return_value = None
+        self.client.snapshot.create.side_effect = testvars.fake_fail
+        self.client.snapshot.status.return_value = testvars.nosnap_running
+        self.client.snapshot.verify_repository.return_value = testvars.verified_nodes
+        sso = Snapshot(self.ilo, repository=testvars.repo_name, name=testvars.snap_name)
+        self.assertRaises(FailedExecution, sso.do_action)

--- a/tests/unit/test_class_index_list.py
+++ b/tests/unit/test_class_index_list.py
@@ -1,7 +1,8 @@
 """Test index_list class"""
+# pylint: disable=missing-function-docstring, missing-class-docstring, line-too-long, attribute-defined-outside-init, protected-access
 from unittest import TestCase
-from mock import Mock
 from copy import deepcopy
+from mock import Mock
 import yaml
 from curator.exceptions import ActionError, ConfigurationError, FailedExecution, MissingArgument, NoIndices
 from curator.helpers.date_ops import fix_epoch
@@ -9,1258 +10,866 @@ from curator import IndexList
 # Get test variables and constants from a single source
 from . import testvars
 
+def get_es_ver():
+    return {'version': {'number': '8.0.0'} }
+
+def get_testvals(number, key):
+    """Return the appropriate value per the provided key number"""
+    data = {
+        "1": {
+            "settings": testvars.settings_one,
+            "state": testvars.state_one,
+            "stats": testvars.stats_one,
+            "fieldstats": testvars.fieldstats_one,
+        },
+        "2": {
+            "settings": testvars.settings_two,
+            "state": testvars.state_two,
+            "stats": testvars.stats_two,
+            "fieldstats": testvars.fieldstats_two,
+        },
+        "4": {
+            "settings": testvars.settings_four,
+            "state": testvars.state_four,
+            "stats": testvars.stats_four,
+            "fieldstats": testvars.fieldstats_four,
+        },
+    }
+    return data[number][key]
+
 class TestIndexListClientAndInit(TestCase):
+    def builder(self, key='2'):
+        self.client = Mock()
+        self.client.info.return_value = get_es_ver()
+        self.client.cat.indices.return_value = get_testvals(key, 'state')
+        self.client.indices.get_settings.return_value = get_testvals(key, 'settings')
+        self.client.indices.stats.return_value = get_testvals(key, 'stats')
+        self.client.indices.exists_alias.return_value = False
+        self.ilo = IndexList(self.client)
     def test_init_bad_client(self):
         client = 'not a real client'
         self.assertRaises(TypeError, IndexList, client)
     def test_init_get_indices_exception(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.indices.get_settings.side_effect = testvars.fake_fail
-        self.assertRaises(FailedExecution, IndexList, client)
+        self.builder()
+        self.client.indices.get_settings.side_effect = testvars.fake_fail
+        self.assertRaises(FailedExecution, IndexList, self.client)
     def test_init(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
+        self.builder()
+        self.ilo.get_index_stats()
+        self.ilo.get_index_settings()
         self.assertEqual(
             testvars.stats_two['indices']['index-2016.03.03']['total']['store']['size_in_bytes'],
-            il.index_info['index-2016.03.03']['size_in_bytes']
+            self.ilo.index_info['index-2016.03.03']['size_in_bytes']
         )
         self.assertEqual(
-            testvars.clu_state_two['metadata']['indices']['index-2016.03.04']['state'],
-            il.index_info['index-2016.03.04']['state']
+            testvars.state_two[1]['status'],
+            self.ilo.index_info['index-2016.03.04']['state']
         )
-        self.assertEqual(['index-2016.03.03','index-2016.03.04'], sorted(il.indices))
+        self.assertEqual(['index-2016.03.03','index-2016.03.04'], sorted(self.ilo.indices))
     def test_for_closed_index(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_2_closed
-        client.cluster.state.return_value = testvars.cs_two_closed
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        self.assertEqual('close', il.index_info['index-2016.03.03']['state'])
+        self.builder()
+        self.client.cat.indices.return_value = testvars.state_2_closed
+        self.client.indices.get_settings.return_value = testvars.settings_2_closed
+        ilo2 = IndexList(self.client)
+        ilo2.get_index_state()
+        self.assertEqual('close', ilo2.index_info['index-2016.03.03']['state'])
+
 class TestIndexListOtherMethods(TestCase):
+    def builder(self, key='2'):
+        self.client = Mock()
+        self.client.info.return_value = get_es_ver()
+        self.client.cat.indices.return_value = get_testvals(key, 'state')
+        self.client.indices.get_settings.return_value = get_testvals(key, 'settings')
+        self.client.indices.stats.return_value = get_testvals(key, 'stats')
+        self.client.indices.exists_alias.return_value = False
+        self.ilo = IndexList(self.client)
     def test_empty_list(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        self.assertEqual(2, len(il.indices))
-        il.indices = []
-        self.assertRaises(NoIndices, il.empty_list_check)
+        self.builder()
+        self.client.indices.exists_alias.return_value = False
+        self.assertEqual(2, len(self.ilo.indices))
+        self.ilo.indices = []
+        self.assertRaises(NoIndices, self.ilo.empty_list_check)
     def test_get_segmentcount(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.segments.return_value = testvars.shards
-        il = IndexList(client)
-        il._get_segment_counts()
-        self.assertEqual(71, il.index_info[testvars.named_index]['segments'])
+        self.builder(key='1')
+        self.client.indices.segments.return_value = testvars.shards
+        self.ilo.get_segment_counts()
+        self.assertEqual(71, self.ilo.index_info[testvars.named_index]['segments'])
 
 class TestIndexListAgeFilterName(TestCase):
+    def builder(self, key='2'):
+        self.client = Mock()
+        self.client.info.return_value = get_es_ver()
+        self.client.cat.indices.return_value = get_testvals(key, 'state')
+        self.client.indices.get_settings.return_value = get_testvals(key, 'settings')
+        self.client.indices.stats.return_value = get_testvals(key, 'stats')
+        self.client.indices.exists_alias.return_value = False
+        self.ilo = IndexList(self.client)
     def test_get_name_based_ages_match(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        il._get_name_based_ages('%Y.%m.%d')
-        self.assertEqual(1456963200,il.index_info['index-2016.03.03']['age']['name'])
+        self.builder()
+        self.ilo._get_name_based_ages('%Y.%m.%d')
+        self.assertEqual(1456963200, self.ilo.index_info['index-2016.03.03']['age']['name'])
     def test_get_name_based_ages_no_match(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        nomatch = IndexList(client)
-        nomatch._get_name_based_ages('%Y-%m-%d')
+        self.builder()
+        self.ilo.get_index_settings()
+        self.ilo._get_name_based_ages('%Y-%m-%d')
         self.assertEqual(
             fix_epoch(
                 testvars.settings_two['index-2016.03.03']['settings']['index']['creation_date']
             ),
-            nomatch.index_info['index-2016.03.03']['age']['creation_date']
+            self.ilo.index_info['index-2016.03.03']['age']['creation_date']
         )
 
 class TestIndexListAgeFilterStatsAPI(TestCase):
+    def builder(self, key='2'):
+        self.client = Mock()
+        self.client.info.return_value = get_es_ver()
+        self.client.cat.indices.return_value = get_testvals(key, 'state')
+        self.client.indices.get_settings.return_value = get_testvals(key, 'settings')
+        self.client.indices.stats.return_value = get_testvals(key, 'stats')
+        self.client.indices.exists_alias.return_value = False
+        self.ilo = IndexList(self.client)
     def test_get_field_stats_dates_negative(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.search.return_value = testvars.fieldstats_query
-        il = IndexList(client)
-        client.field_stats.return_value = testvars.fieldstats_two
-        il._get_field_stats_dates(field='timestamp')
-        self.assertNotIn('not_an_index_name', list(il.index_info.keys()))
+        self.builder()
+        self.client.search.return_value = testvars.fieldstats_query
+        self.client.field_stats.return_value = testvars.fieldstats_two
+        self.ilo._get_field_stats_dates(field='timestamp')
+        self.assertNotIn('not_an_index_name', list(self.ilo.index_info.keys()))
     def test_get_field_stats_dates_field_not_found(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.search.return_value = {'aggregations': {'foo':'bar'}}
-        il = IndexList(client)
+        self.builder()
+        self.client.search.return_value = {'aggregations': {'foo':'bar'}}
         self.assertRaises(
-            ActionError, il._get_field_stats_dates, field='not_in_index')
+            ActionError, self.ilo._get_field_stats_dates, field='not_in_index')
 
 class TestIndexListRegexFilters(TestCase):
+    def builder(self, key='2'):
+        self.client = Mock()
+        self.client.info.return_value = get_es_ver()
+        self.client.cat.indices.return_value = get_testvals(key, 'state')
+        self.client.indices.get_settings.return_value = get_testvals(key, 'settings')
+        self.client.indices.stats.return_value = get_testvals(key, 'stats')
+        self.client.indices.exists_alias.return_value = False
+        self.ilo = IndexList(self.client)
     def test_filter_by_regex_prefix(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        self.assertEqual(
-            ['index-2016.03.03', 'index-2016.03.04'],
-            sorted(il.indices)
-        )
-        il.filter_by_regex(kind='prefix', value='ind')
-        self.assertEqual(
-            ['index-2016.03.03', 'index-2016.03.04'],
-            sorted(il.indices)
-        )
-        il.filter_by_regex(kind='prefix', value='ind', exclude=True)
-        self.assertEqual([], il.indices)
+        self.builder()
+        self.assertEqual(['index-2016.03.03', 'index-2016.03.04'], sorted(self.ilo.indices))
+        self.ilo.filter_by_regex(kind='prefix', value='ind')
+        self.assertEqual(['index-2016.03.03', 'index-2016.03.04'], sorted(self.ilo.indices))
+        self.ilo.filter_by_regex(kind='prefix', value='ind', exclude=True)
+        self.assertEqual([], self.ilo.indices)
     def test_filter_by_regex_middle(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        self.assertEqual(
-            ['index-2016.03.03', 'index-2016.03.04'],
-            sorted(il.indices)
-        )
-        il.filter_by_regex(kind='regex', value='dex')
-        self.assertEqual(
-            ['index-2016.03.03', 'index-2016.03.04'],
-            sorted(il.indices)
-        )
-        il.filter_by_regex(kind='regex', value='dex', exclude=True)
-        self.assertEqual([], il.indices)
+        self.builder()
+        self.assertEqual(['index-2016.03.03', 'index-2016.03.04'], sorted(self.ilo.indices))
+        self.ilo.filter_by_regex(kind='regex', value='dex')
+        self.assertEqual(['index-2016.03.03', 'index-2016.03.04'], sorted(self.ilo.indices))
+        self.ilo.filter_by_regex(kind='regex', value='dex', exclude=True)
+        self.assertEqual([], self.ilo.indices)
     def test_filter_by_regex_timestring(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        self.assertEqual(
-            ['index-2016.03.03', 'index-2016.03.04'],
-            sorted(il.indices)
-        )
-        il.filter_by_regex(kind='timestring', value='%Y.%m.%d')
-        self.assertEqual(
-            ['index-2016.03.03', 'index-2016.03.04'],
-            sorted(il.indices)
-        )
-        il.filter_by_regex(kind='timestring', value='%Y.%m.%d', exclude=True)
-        self.assertEqual([], il.indices)
+        self.builder()
+        self.assertEqual(['index-2016.03.03', 'index-2016.03.04'], sorted(self.ilo.indices))
+        self.ilo.filter_by_regex(kind='timestring', value='%Y.%m.%d')
+        self.assertEqual(['index-2016.03.03', 'index-2016.03.04'], sorted(self.ilo.indices))
+        self.ilo.filter_by_regex(kind='timestring', value='%Y.%m.%d', exclude=True)
+        self.assertEqual([], self.ilo.indices)
     def test_filter_by_regex_no_match_exclude(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        self.assertEqual(
-            ['index-2016.03.03', 'index-2016.03.04'],
-            sorted(il.indices)
-        )
-        il.filter_by_regex(kind='prefix', value='invalid', exclude=True)
-        # self.assertEqual([], il.indices)
-        self.assertEqual(
-            ['index-2016.03.03', 'index-2016.03.04'],
-            sorted(il.indices)
-        )
+        self.builder()
+        self.assertEqual(['index-2016.03.03', 'index-2016.03.04'], sorted(self.ilo.indices))
+        self.ilo.filter_by_regex(kind='prefix', value='invalid', exclude=True)
+        self.assertEqual(['index-2016.03.03', 'index-2016.03.04'], sorted(self.ilo.indices))
     def test_filter_by_regex_no_value(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        self.assertEqual(
-            ['index-2016.03.03', 'index-2016.03.04'],
-            sorted(il.indices)
-        )
-        self.assertRaises(ValueError, il.filter_by_regex, kind='prefix', value=None)
-        self.assertEqual(
-            ['index-2016.03.03', 'index-2016.03.04'],
-            sorted(il.indices)
-        )
-        il.filter_by_regex(kind='prefix', value=0)
-        self.assertEqual([], il.indices)
+        self.builder()
+        self.assertEqual(['index-2016.03.03', 'index-2016.03.04'], sorted(self.ilo.indices))
+        self.assertRaises(ValueError, self.ilo.filter_by_regex, kind='prefix', value=None)
+        self.assertEqual(['index-2016.03.03', 'index-2016.03.04'], sorted(self.ilo.indices))
+        self.ilo.filter_by_regex(kind='prefix', value=0)
+        self.assertEqual([], self.ilo.indices)
     def test_filter_by_regex_bad_kind(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        self.assertEqual(
-            ['index-2016.03.03', 'index-2016.03.04'],
-            sorted(il.indices)
-        )
-        self.assertRaises(ValueError, il.filter_by_regex, kind='invalid', value=None)
+        self.builder()
+        self.assertEqual(['index-2016.03.03', 'index-2016.03.04'], sorted(self.ilo.indices))
+        self.assertRaises(ValueError, self.ilo.filter_by_regex, kind='invalid', value=None)
 
 class TestIndexListFilterByAge(TestCase):
+    def builder(self, key='2'):
+        self.client = Mock()
+        self.client.info.return_value = get_es_ver()
+        self.client.cat.indices.return_value = get_testvals(key, 'state')
+        self.client.indices.get_settings.return_value = get_testvals(key, 'settings')
+        self.client.indices.stats.return_value = get_testvals(key, 'stats')
+        self.client.indices.exists_alias.return_value = False
+        self.ilo = IndexList(self.client)
     def test_missing_direction(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        self.assertRaises(MissingArgument,
-            il.filter_by_age, unit='days', unit_count=1
-        )
+        self.builder()
+        self.assertRaises(MissingArgument, self.ilo.filter_by_age, unit='days', unit_count=1)
     def test_bad_direction(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        self.assertRaises(ValueError, il.filter_by_age, unit='days',
+        self.builder()
+        self.assertRaises(ValueError, self.ilo.filter_by_age, unit='days',
             unit_count=1, direction="invalid"
         )
     def test_name_no_timestring(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
+        self.builder()
         self.assertRaises(MissingArgument,
-            il.filter_by_age,
+            self.ilo.filter_by_age,
             source='name', unit='days', unit_count=1, direction='older'
         )
     def test_name_older_than_now(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        il.filter_by_age(source='name', direction='older',
+        self.builder()
+        self.ilo.filter_by_age(source='name', direction='older',
             timestring='%Y.%m.%d', unit='days', unit_count=1
         )
-        self.assertEqual(
-            ['index-2016.03.03','index-2016.03.04'], sorted(il.indices)
-        )
+        self.assertEqual(['index-2016.03.03','index-2016.03.04'], sorted(self.ilo.indices))
     def test_name_older_than_now_exclude(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        il.filter_by_age(source='name', direction='older',
+        self.builder()
+        self.ilo.filter_by_age(source='name', direction='older',
             timestring='%Y.%m.%d', unit='days', unit_count=1, exclude=True
         )
-        self.assertEqual(
-            [], sorted(il.indices)
-        )
+        self.assertEqual([], sorted(self.ilo.indices))
     def test_name_younger_than_now(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        il.filter_by_age(source='name', direction='younger',
+        self.builder()
+        self.ilo.filter_by_age(source='name', direction='younger',
             timestring='%Y.%m.%d', unit='days', unit_count=1
         )
-        self.assertEqual([], sorted(il.indices))
+        self.assertEqual([], sorted(self.ilo.indices))
     def test_name_younger_than_now_exclude(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        il.filter_by_age(source='name', direction='younger',
+        self.builder()
+        self.ilo.filter_by_age(source='name', direction='younger',
             timestring='%Y.%m.%d', unit='days', unit_count=1, exclude=True
         )
-        self.assertEqual(
-            ['index-2016.03.03','index-2016.03.04'], sorted(il.indices))
+        self.assertEqual(['index-2016.03.03','index-2016.03.04'], sorted(self.ilo.indices))
     def test_name_younger_than_past_date(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        il.filter_by_age(source='name', direction='younger',
+        self.builder()
+        self.ilo.filter_by_age(source='name', direction='younger',
             timestring='%Y.%m.%d', unit='seconds', unit_count=0,
             epoch=1457049599
         )
-        self.assertEqual(['index-2016.03.04'], sorted(il.indices))
+        self.assertEqual(['index-2016.03.04'], sorted(self.ilo.indices))
     def test_name_older_than_past_date(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        il.filter_by_age(source='name', direction='older',
+        self.builder()
+        self.ilo.filter_by_age(source='name', direction='older',
             timestring='%Y.%m.%d', unit='seconds', unit_count=0,
             epoch=1456963201
         )
-        self.assertEqual(['index-2016.03.03'], sorted(il.indices))
+        self.assertEqual(['index-2016.03.03'], sorted(self.ilo.indices))
     def test_creation_date_older_than_now(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        il.filter_by_age(source='creation_date', direction='older', unit='days',
+        self.builder()
+        self.ilo.filter_by_age(source='creation_date', direction='older', unit='days',
             unit_count=1
         )
-        self.assertEqual(
-            ['index-2016.03.03','index-2016.03.04'], sorted(il.indices)
-        )
+        self.assertEqual(['index-2016.03.03','index-2016.03.04'], sorted(self.ilo.indices))
     def test_creation_date_older_than_now_raises(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        il.index_info['index-2016.03.03']['age'].pop('creation_date')
-        il.index_info['index-2016.03.04']['age'].pop('creation_date')
-        il.filter_by_age(
+        self.builder()
+        self.ilo.index_info['index-2016.03.03']['age'].pop('creation_date')
+        self.ilo.index_info['index-2016.03.04']['age'].pop('creation_date')
+        self.ilo.filter_by_age(
             source='creation_date', direction='older', unit='days', unit_count=1
         )
-        self.assertEqual([], il.indices)
+        self.assertEqual([], self.ilo.indices)
     def test_creation_date_younger_than_now(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        il.filter_by_age(source='creation_date', direction='younger',
+        self.builder()
+        self.ilo.filter_by_age(source='creation_date', direction='younger',
             unit='days', unit_count=1
         )
-        self.assertEqual([], sorted(il.indices))
+        self.assertEqual([], sorted(self.ilo.indices))
     def test_creation_date_younger_than_now_raises(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        il.index_info['index-2016.03.03']['age'].pop('creation_date')
-        il.index_info['index-2016.03.04']['age'].pop('creation_date')
-        il.filter_by_age(
+        self.builder()
+        self.ilo.index_info['index-2016.03.03']['age'].pop('creation_date')
+        self.ilo.index_info['index-2016.03.04']['age'].pop('creation_date')
+        self.ilo.filter_by_age(
             source='creation_date', direction='younger', unit='days',
             unit_count=1
         )
-        self.assertEqual([], il.indices)
+        self.assertEqual([], self.ilo.indices)
     def test_creation_date_younger_than_past_date(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        il.filter_by_age(source='creation_date', direction='younger',
+        self.builder()
+        self.ilo.filter_by_age(source='creation_date', direction='younger',
             unit='seconds', unit_count=0, epoch=1457049599
         )
-        self.assertEqual(['index-2016.03.04'], sorted(il.indices))
+        self.assertEqual(['index-2016.03.04'], sorted(self.ilo.indices))
     def test_creation_date_older_than_past_date(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        il.filter_by_age(source='creation_date', direction='older',
+        self.builder()
+        self.ilo.filter_by_age(source='creation_date', direction='older',
             unit='seconds', unit_count=0, epoch=1456963201
         )
-        self.assertEqual(['index-2016.03.03'], sorted(il.indices))
+        self.assertEqual(['index-2016.03.03'], sorted(self.ilo.indices))
     def test_field_stats_missing_field(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        self.assertRaises(MissingArgument, il.filter_by_age,
+        self.builder()
+        self.assertRaises(MissingArgument, self.ilo.filter_by_age,
             source='field_stats', direction='older', unit='days', unit_count=1
         )
     def test_field_stats_invalid_stats_result(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        self.assertRaises(ValueError, il.filter_by_age, field='timestamp',
+        self.builder()
+        self.assertRaises(ValueError, self.ilo.filter_by_age, field='timestamp',
             source='field_stats', direction='older', unit='days', unit_count=1,
             stats_result='invalid'
         )
     def test_field_stats_invalid_source(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        self.assertRaises(ValueError, il.filter_by_age,
+        self.builder()
+        self.assertRaises(ValueError, self.ilo.filter_by_age,
             source='invalid', direction='older', unit='days', unit_count=1
         )
 
 class TestIndexListFilterBySpace(TestCase):
+    def builder(self, key='2'):
+        self.client = Mock()
+        self.client.info.return_value = get_es_ver()
+        self.client.cat.indices.return_value = get_testvals(key, 'state')
+        self.client.indices.get_settings.return_value = get_testvals(key, 'settings')
+        self.client.indices.stats.return_value = get_testvals(key, 'stats')
+        self.client.search.return_value = get_testvals(key, 'fieldstats')
+        self.client.indices.exists_alias.return_value = False
+        self.ilo = IndexList(self.client)
     def test_missing_disk_space_value(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.field_stats.return_value = testvars.fieldstats_two
-        il = IndexList(client)
-        self.assertRaises(MissingArgument, il.filter_by_space)
+        self.builder()
+        self.assertRaises(MissingArgument, self.ilo.filter_by_space)
     def test_filter_result_by_name(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.field_stats.return_value = testvars.fieldstats_two
-        il = IndexList(client)
-        il.filter_by_space(disk_space=1.1)
-        self.assertEqual(['index-2016.03.03'], il.indices)
+        self.builder()
+        self.ilo.filter_by_space(disk_space=1.1)
+        self.assertEqual(['index-2016.03.03'], self.ilo.indices)
     def test_filter_result_by_name_reverse_order(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.field_stats.return_value = testvars.fieldstats_two
-        il = IndexList(client)
-        il.filter_by_space(disk_space=1.1, reverse=False)
-        self.assertEqual(['index-2016.03.04'], il.indices)
+        self.builder()
+        self.ilo.filter_by_space(disk_space=1.1, reverse=False)
+        self.assertEqual(['index-2016.03.04'], self.ilo.indices)
     def test_filter_result_by_name_exclude(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.field_stats.return_value = testvars.fieldstats_two
-        il = IndexList(client)
-        il.filter_by_space(disk_space=1.1, exclude=True)
-        self.assertEqual(['index-2016.03.04'], il.indices)
+        self.builder()
+        self.ilo.filter_by_space(disk_space=1.1, exclude=True)
+        self.assertEqual(['index-2016.03.04'], self.ilo.indices)
     def test_filter_result_by_date_raise(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
-        client.indices.stats.return_value = testvars.stats_four
-        client.field_stats.return_value = testvars.fieldstats_four
-        il = IndexList(client)
+        self.builder(key='4')
         self.assertRaises(ValueError,
-            il.filter_by_space, disk_space=2.1, use_age=True, source='invalid'
+            self.ilo.filter_by_space, disk_space=2.1, use_age=True, source='invalid'
         )
     def test_filter_result_by_date_timestring_raise(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
-        client.indices.stats.return_value = testvars.stats_four
-        client.field_stats.return_value = testvars.fieldstats_four
-        il = IndexList(client)
+        self.builder(key='4')
         self.assertRaises(MissingArgument,
-            il.filter_by_space, disk_space=2.1, use_age=True, source='name'
+            self.ilo.filter_by_space, disk_space=2.1, use_age=True, source='name'
         )
     def test_filter_result_by_date_timestring(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
-        client.indices.stats.return_value = testvars.stats_four
-        client.field_stats.return_value = testvars.fieldstats_four
-        il = IndexList(client)
-        il.filter_by_space(
+        self.builder(key='4')
+        self.ilo.filter_by_space(
             disk_space=2.1, use_age=True,
             source='name', timestring='%Y.%m.%d'
         )
-        self.assertEqual(['a-2016.03.03'], sorted(il.indices))
+        self.assertEqual(['a-2016.03.03'], sorted(self.ilo.indices))
     def test_filter_result_by_date_non_matching_timestring(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
-        client.indices.stats.return_value = testvars.stats_four
-        client.field_stats.return_value = testvars.fieldstats_four
-        il = IndexList(client)
-        il.filter_by_space(
+        self.builder(key='4')
+        self.ilo.filter_by_space(
             disk_space=2.1, use_age=True,
             source='name', timestring='%Y.%m.%d.%H'
         )
-        self.assertEqual([], sorted(il.indices))
+        self.assertEqual([], sorted(self.ilo.indices))
     def test_filter_threshold_behavior(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.field_stats.return_value = testvars.fieldstats_two
+        self.builder()
+        il_a = IndexList(self.client)
         # less than
-        il_a = IndexList(client)
         il_a.filter_by_space(
             disk_space=1.5, use_age=True,
             threshold_behavior='less_than'
         )
         self.assertEqual(['index-2016.03.04'], sorted(il_a.indices))
         # greater than
-        il_b = IndexList(client)
+        il_b = IndexList(self.client)
         il_b.filter_by_space(
             disk_space=1.5, use_age=True,
             threshold_behavior='greater_than'
         )
         self.assertEqual(['index-2016.03.03'], sorted(il_b.indices))
         # default case
-        il_c = IndexList(client)
+        il_c = IndexList(self.client)
         il_c.filter_by_space(
             disk_space=1.5, use_age=True
         )
         self.assertEqual(['index-2016.03.03'], sorted(il_c.indices))
     def test_filter_bad_threshold_behavior(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.field_stats.return_value = testvars.fieldstats_two
+        self.builder()
         # less than
-        il = IndexList(client)
         self.assertRaises(
             ValueError,
-            il.filter_by_space, disk_space=1.5, threshold_behavior='invalid'
+            self.ilo.filter_by_space, disk_space=1.5, threshold_behavior='invalid'
         )
     def test_filter_result_by_date_field_stats_raise(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
-        client.indices.stats.return_value = testvars.stats_four
-        client.search.return_value = testvars.fieldstats_query
-        il = IndexList(client)
+        self.builder(key='4')
+        self.client.search.return_value = testvars.fieldstats_query
         self.assertRaises(ValueError,
-            il.filter_by_space, disk_space=2.1, use_age=True,
+            self.ilo.filter_by_space, disk_space=2.1, use_age=True,
             source='min_value'
         )
     def test_filter_result_by_date_no_field_raise(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
-        client.indices.stats.return_value = testvars.stats_four
-        client.field_stats.return_value = testvars.fieldstats_four
-        il = IndexList(client)
+        self.builder(key='4')
         self.assertRaises(MissingArgument,
-            il.filter_by_space, disk_space=2.1, use_age=True,
+            self.ilo.filter_by_space, disk_space=2.1, use_age=True,
             source='field_stats'
         )
     def test_filter_result_by_date_invalid_stats_result_raise(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
-        client.indices.stats.return_value = testvars.stats_four
-        client.field_stats.return_value = testvars.fieldstats_four
-        il = IndexList(client)
+        self.builder(key='4')
         self.assertRaises(ValueError,
-            il.filter_by_space, disk_space=2.1, use_age=True,
+            self.ilo.filter_by_space, disk_space=2.1, use_age=True,
             source='field_stats', field='timestamp', stats_result='invalid'
         )
     def test_filter_result_by_creation_date(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
-        client.indices.stats.return_value = testvars.stats_four
-        client.field_stats.return_value = testvars.fieldstats_four
-        il = IndexList(client)
-        il.filter_by_space(disk_space=2.1, use_age=True)
-        self.assertEqual(['a-2016.03.03'], il.indices)
+        self.builder(key='4')
+        self.ilo.filter_by_space(disk_space=2.1, use_age=True)
+        self.assertEqual(['a-2016.03.03'], self.ilo.indices)
 
 class TestIndexListFilterKibana(TestCase):
+    def builder(self, key='2'):
+        self.client = Mock()
+        self.client.info.return_value = get_es_ver()
+        self.client.cat.indices.return_value = get_testvals(key, 'state')
+        self.client.indices.get_settings.return_value = get_testvals(key, 'settings')
+        self.client.indices.stats.return_value = get_testvals(key, 'stats')
+        self.client.search.return_value = get_testvals(key, 'fieldstats')
+        self.client.indices.exists_alias.return_value = False
+        self.ilo = IndexList(self.client)
     def test_filter_kibana_positive(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.field_stats.return_value = testvars.fieldstats_two
-        il = IndexList(client)
+        self.builder()
         # Establish the object per requirements, then overwrite
-        il.indices = ['.kibana', '.kibana-5', '.kibana-6', 'dummy']
-        il.filter_kibana()
-        self.assertEqual(['dummy'], il.indices)
+        self.ilo.indices = ['.kibana', '.kibana-5', '.kibana-6', 'dummy']
+        self.ilo.filter_kibana()
+        self.assertEqual(['dummy'], self.ilo.indices)
     def test_filter_kibana_positive_include(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.field_stats.return_value = testvars.fieldstats_two
-        il = IndexList(client)
+        self.builder()
         # Establish the object per requirements, then overwrite
-        il.indices = ['.kibana', '.kibana-5', '.kibana-6', 'dummy']
-        il.filter_kibana(exclude=False)
-        self.assertEqual(['.kibana', '.kibana-5', '.kibana-6'], il.indices)
+        self.ilo.indices = ['.kibana', '.kibana-5', '.kibana-6', 'dummy']
+        self.ilo.filter_kibana(exclude=False)
+        self.assertEqual(['.kibana', '.kibana-5', '.kibana-6'], self.ilo.indices)
     def test_filter_kibana_positive_exclude(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.field_stats.return_value = testvars.fieldstats_two
-        il = IndexList(client)
+        self.builder()
         # Establish the object per requirements, then overwrite
         kibana_indices = ['.kibana', '.kibana-5', '.kibana-6']
-        il.indices = kibana_indices
-        il.indices.append('dummy')
-        il.filter_kibana(exclude=True)
-        self.assertEqual(kibana_indices, il.indices)
+        self.ilo.indices = kibana_indices
+        self.ilo.indices.append('dummy')
+        self.ilo.filter_kibana(exclude=True)
+        self.assertEqual(kibana_indices, self.ilo.indices)
     def test_filter_kibana_negative(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.field_stats.return_value = testvars.fieldstats_two
-        il = IndexList(client)
+        self.builder()
         # Establish the object per requirements, then overwrite
-        il.indices = ['kibana', 'marvel-kibana', 'cabana-int', 'marvel-es-data', 'dummy']
-        il.filter_kibana()
+        self.ilo.indices = ['kibana', 'marvel-kibana', 'cabana-int', 'marvel-es-data', 'dummy']
+        self.ilo.filter_kibana()
         self.assertEqual(
             ['kibana', 'marvel-kibana', 'cabana-int', 'marvel-es-data', 'dummy'],
-             il.indices
+             self.ilo.indices
         )
 
 class TestIndexListFilterForceMerged(TestCase):
+    VERSION = {'version': {'number': '8.0.0'} }
+    def builder(self):
+        self.client = Mock()
+        self.client.info.return_value = get_es_ver()
+        self.client.cat.indices.return_value = testvars.state_one
+        self.client.indices.get_settings.return_value = testvars.settings_one
+        self.client.indices.stats.return_value = testvars.stats_one
+        self.client.indices.segments.return_value = testvars.shards
+        self.client.indices.exists_alias.return_value = False
+        self.ilo = IndexList(self.client)
     def test_filter_forcemerge_raise(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.segments.return_value = testvars.shards
-        il = IndexList(client)
-        self.assertRaises(MissingArgument, il.filter_forceMerged)
+        self.builder()
+        self.assertRaises(MissingArgument, self.ilo.filter_forceMerged)
     def test_filter_forcemerge_positive(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.segments.return_value = testvars.shards
-        il = IndexList(client)
-        il.filter_forceMerged(max_num_segments=2)
-        self.assertEqual([testvars.named_index], il.indices)
+        self.builder()
+        self.ilo.filter_forceMerged(max_num_segments=2)
+        self.assertEqual([testvars.named_index], self.ilo.indices)
     def test_filter_forcemerge_negative(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.segments.return_value = testvars.fm_shards
-        il = IndexList(client)
-        il.filter_forceMerged(max_num_segments=2)
-        self.assertEqual([], il.indices)
+        self.builder()
+        self.client.indices.segments.return_value = testvars.fm_shards
+        self.ilo.filter_forceMerged(max_num_segments=2)
+        self.assertEqual([], self.ilo.indices)
 
 class TestIndexListFilterOpened(TestCase):
     def test_filter_opened(self):
         client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
+        client.info.return_value = {'version': {'number': '8.0.0'} }
+        client.cat.indices.return_value = testvars.state_four
         client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
         client.indices.stats.return_value = testvars.stats_four
         client.field_stats.return_value = testvars.fieldstats_four
-        il = IndexList(client)
-        il.filter_opened()
-        self.assertEqual(['c-2016.03.05'], il.indices)
+        client.indices.exists_alias.return_value = False
+        ilo = IndexList(client)
+        ilo.filter_opened()
+        self.assertEqual(['c-2016.03.05'], ilo.indices)
 
 class TestIndexListFilterAllocated(TestCase):
+    def builder(self, key='2'):
+        self.client = Mock()
+        self.client.info.return_value = get_es_ver()
+        self.client.cat.indices.return_value = get_testvals(key, 'state')
+        self.client.indices.get_settings.return_value = get_testvals(key, 'settings')
+        self.client.indices.stats.return_value = get_testvals(key, 'stats')
+        self.client.indices.exists_alias.return_value = False
+        self.ilo = IndexList(self.client)
     def test_missing_key(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
+        self.builder()
         self.assertRaises(
-            MissingArgument, il.filter_allocated, value='foo',
+            MissingArgument, self.ilo.filter_allocated, value='foo',
             allocation_type='invalid'
         )
     def test_missing_value(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
+        self.builder()
         self.assertRaises(
-            MissingArgument, il.filter_allocated, key='tag',
+            MissingArgument, self.ilo.filter_allocated, key='tag',
             allocation_type='invalid'
         )
     def test_invalid_allocation_type(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
+        self.builder()
         self.assertRaises(
-            ValueError, il.filter_allocated, key='tag', value='foo',
+            ValueError, self.ilo.filter_allocated, key='tag', value='foo',
             allocation_type='invalid'
         )
     def test_success(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        il.filter_allocated(key='tag', value='foo', allocation_type='include')
-        self.assertEqual(['index-2016.03.04'], il.indices)
+        self.builder()
+        self.ilo.filter_allocated(key='tag', value='foo', allocation_type='include')
+        self.assertEqual(['index-2016.03.04'], self.ilo.indices)
     def test_invalid_tag(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        il.filter_allocated(
+        self.builder()
+        self.ilo.filter_allocated(
             key='invalid', value='foo', allocation_type='include')
         self.assertEqual(
-            ['index-2016.03.03','index-2016.03.04'], sorted(il.indices))
+            ['index-2016.03.03','index-2016.03.04'], sorted(self.ilo.indices))
 
 class TestIterateFiltersIndex(TestCase):
+    def builder(self, key='2'):
+        self.client = Mock()
+        self.client.info.return_value = get_es_ver()
+        self.client.cat.indices.return_value = get_testvals(key, 'state')
+        self.client.indices.get_settings.return_value = get_testvals(key, 'settings')
+        self.client.indices.stats.return_value = get_testvals(key, 'stats')
+        self.client.indices.exists_alias.return_value = False
+        self.ilo = IndexList(self.client)
     def test_no_filters(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
-        client.indices.stats.return_value = testvars.stats_four
-        ilo = IndexList(client)
-        ilo.iterate_filters({})
+        self.builder(key='4')
+        self.ilo.iterate_filters({})
         self.assertEqual(
             ['a-2016.03.03', 'b-2016.03.04', 'c-2016.03.05', 'd-2016.03.06'],
-            sorted(ilo.indices)
+            sorted(self.ilo.indices)
         )
     def test_no_filtertype(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
-        client.indices.stats.return_value = testvars.stats_four
-        ilo = IndexList(client)
+        self.builder(key='4')
         config = {'filters': [{'no_filtertype':'fail'}]}
         self.assertRaises(
-            ConfigurationError, ilo.iterate_filters, config)
+            ConfigurationError, self.ilo.iterate_filters, config)
     def test_invalid_filtertype(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
-        client.indices.stats.return_value = testvars.stats_four
-        ilo = IndexList(client)
+        self.builder(key='4')
         config = {'filters': [{'filtertype':12345.6789}]}
         self.assertRaises(
-            ConfigurationError, ilo.iterate_filters, config)
+            ConfigurationError, self.ilo.iterate_filters, config)
     def test_pattern_filtertype(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
-        client.indices.stats.return_value = testvars.stats_four
-        ilo = IndexList(client)
+        self.builder(key='4')
         config = yaml.load(testvars.pattern_ft, Loader=yaml.FullLoader)['actions'][1]
-        ilo.iterate_filters(config)
-        self.assertEqual(['a-2016.03.03'], ilo.indices)
+        self.ilo.iterate_filters(config)
+        self.assertEqual(['a-2016.03.03'], self.ilo.indices)
     def test_age_filtertype(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        ilo = IndexList(client)
+        self.builder()
         config = yaml.load(testvars.age_ft, Loader=yaml.FullLoader)['actions'][1]
-        ilo.iterate_filters(config)
-        self.assertEqual(['index-2016.03.03'], ilo.indices)
+        self.ilo.iterate_filters(config)
+        self.assertEqual(['index-2016.03.03'], self.ilo.indices)
     def test_space_filtertype(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
-        client.indices.stats.return_value = testvars.stats_four
-        client.field_stats.return_value = testvars.fieldstats_four
-        ilo = IndexList(client)
+        self.builder(key='4')
+        self.client.field_stats.return_value = testvars.fieldstats_four
         config = yaml.load(testvars.space_ft, Loader=yaml.FullLoader)['actions'][1]
-        ilo.iterate_filters(config)
-        self.assertEqual(['a-2016.03.03'], ilo.indices)
+        self.ilo.iterate_filters(config)
+        self.assertEqual(['a-2016.03.03'], self.ilo.indices)
     def test_forcemerge_filtertype(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        client.indices.segments.return_value = testvars.shards
-        ilo = IndexList(client)
+        self.builder(key='1')
+        self.client.indices.segments.return_value = testvars.shards
         config = yaml.load(testvars.forcemerge_ft, Loader=yaml.FullLoader)['actions'][1]
-        ilo.iterate_filters(config)
-        self.assertEqual([testvars.named_index], ilo.indices)
+        self.ilo.iterate_filters(config)
+        self.assertEqual([testvars.named_index], self.ilo.indices)
     def test_allocated_filtertype(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        ilo = IndexList(client)
+        self.builder()
         config = yaml.load(testvars.allocated_ft, Loader=yaml.FullLoader)['actions'][1]
-        ilo.iterate_filters(config)
-        self.assertEqual(['index-2016.03.04'], ilo.indices)
+        self.ilo.iterate_filters(config)
+        self.assertEqual(['index-2016.03.04'], self.ilo.indices)
     def test_kibana_filtertype(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.field_stats.return_value = testvars.fieldstats_two
-        ilo = IndexList(client)
+        self.builder()
+        self.client.field_stats.return_value = testvars.fieldstats_two
         # Establish the object per requirements, then overwrite
-        ilo.indices = [
-            '.kibana', '.kibana-5', '.kibana-6', 'dummy'
-        ]
+        self.ilo.indices = ['.kibana', '.kibana-5', '.kibana-6', 'dummy']
         config = yaml.load(testvars.kibana_ft, Loader=yaml.FullLoader)['actions'][1]
-        ilo.iterate_filters(config)
-        self.assertEqual(['dummy'], ilo.indices)
+        self.ilo.iterate_filters(config)
+        self.assertEqual(['dummy'], self.ilo.indices)
     def test_opened_filtertype(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
-        client.indices.stats.return_value = testvars.stats_four
-        client.field_stats.return_value = testvars.fieldstats_four
-        ilo = IndexList(client)
+        self.builder(key='4')
+        self.client.field_stats.return_value = testvars.fieldstats_four
         config = yaml.load(testvars.opened_ft, Loader=yaml.FullLoader)['actions'][1]
-        ilo.iterate_filters(config)
-        self.assertEqual(['c-2016.03.05'], ilo.indices)
+        self.ilo.iterate_filters(config)
+        self.assertEqual(['c-2016.03.05'], self.ilo.indices)
     def test_closed_filtertype(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_four
-        client.cluster.state.return_value = testvars.clu_state_four
-        client.indices.stats.return_value = testvars.stats_four
-        client.field_stats.return_value = testvars.fieldstats_four
-        ilo = IndexList(client)
+        self.builder(key='4')
+        self.client.field_stats.return_value = testvars.fieldstats_four
         config = yaml.load(testvars.closed_ft, Loader=yaml.FullLoader)['actions'][1]
-        ilo.iterate_filters(config)
+        self.ilo.iterate_filters(config)
         self.assertEqual(
-            ['a-2016.03.03','b-2016.03.04','d-2016.03.06'], sorted(ilo.indices))
+            ['a-2016.03.03','b-2016.03.04','d-2016.03.06'], sorted(self.ilo.indices))
     def test_none_filtertype(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        ilo = IndexList(client)
+        self.builder()
         config = yaml.load(testvars.none_ft, Loader=yaml.FullLoader)['actions'][1]
-        ilo.iterate_filters(config)
+        self.ilo.iterate_filters(config)
         self.assertEqual(
-            ['index-2016.03.03', 'index-2016.03.04'], sorted(ilo.indices))
+            ['index-2016.03.03', 'index-2016.03.04'], sorted(self.ilo.indices))
     def test_unknown_filtertype_raises(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        ilo = IndexList(client)
+        self.builder()
         config = yaml.load(testvars.invalid_ft, Loader=yaml.FullLoader)['actions'][1]
-        self.assertRaises(
-            ConfigurationError,
-            ilo.iterate_filters, config
-        )
+        self.assertRaises(ConfigurationError, self.ilo.iterate_filters, config)
     def test_ilm_filtertype_exclude(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '6.6.0'} }
+        self.builder()
         # If we don't deepcopy, then it munges the settings for future references.
         with_ilm = deepcopy(testvars.settings_two)
         with_ilm['index-2016.03.03']['settings']['index']['lifecycle'] = {'name':'mypolicy'}
-        client.indices.get_settings.return_value = with_ilm
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        ilo = IndexList(client)
+        self.client.indices.get_settings.return_value = with_ilm
         config = {'filters': [{'filtertype':'ilm','exclude':True}]}
-        ilo.iterate_filters(config)
-        self.assertEqual(['index-2016.03.04'], ilo.indices)
+        self.ilo.iterate_filters(config)
+        self.assertEqual(['index-2016.03.04'], self.ilo.indices)
     def test_ilm_filtertype_no_setting(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '6.6.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        ilo = IndexList(client)
+        self.builder()
         config = {'filters': [{'filtertype':'ilm','exclude':True}]}
-        ilo.iterate_filters(config)
-        self.assertEqual(['index-2016.03.03','index-2016.03.04'], sorted(ilo.indices))
+        self.ilo.iterate_filters(config)
+        self.assertEqual(['index-2016.03.03','index-2016.03.04'], sorted(self.ilo.indices))
     def test_size_filtertype(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        ilo = IndexList(client)
+        self.builder()
         config = yaml.load(testvars.size_ft, Loader=yaml.FullLoader)['actions'][1]
-        ilo.iterate_filters(config)
-        self.assertEqual(['index-2016.03.03'], ilo.indices)
+        self.ilo.iterate_filters(config)
+        self.assertEqual(['index-2016.03.03'], self.ilo.indices)
 
 class TestIndexListFilterAlias(TestCase):
+    def builder(self, key='2'):
+        self.client = Mock()
+        self.client.info.return_value = get_es_ver()
+        self.client.cat.indices.return_value = get_testvals(key, 'state')
+        self.client.indices.get_settings.return_value = get_testvals(key, 'settings')
+        self.client.indices.stats.return_value = get_testvals(key, 'stats')
+        self.client.indices.exists_alias.return_value = False
+        self.ilo = IndexList(self.client)
     def test_raise(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_one
-        client.cluster.state.return_value = testvars.clu_state_one
-        client.indices.stats.return_value = testvars.stats_one
-        il = IndexList(client)
-        self.assertRaises(MissingArgument, il.filter_by_alias)
+        self.builder(key='1')
+        self.assertRaises(MissingArgument, self.ilo.filter_by_alias)
     def test_positive(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.indices.get_alias.return_value = testvars.settings_2_get_aliases
-        il = IndexList(client)
-        il.filter_by_alias(aliases=['my_alias'])
-        self.assertEqual(
-            sorted(list(testvars.settings_two.keys())), sorted(il.indices))
+        self.builder()
+        self.client.indices.get_alias.return_value = testvars.settings_2_get_aliases
+        self.ilo.filter_by_alias(aliases=['my_alias'])
+        self.assertEqual(sorted(list(testvars.settings_two.keys())), sorted(self.ilo.indices))
     def test_negative(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.indices.get_alias.return_value = {}
-        il = IndexList(client)
-        il.filter_by_alias(aliases=['not_my_alias'])
-        self.assertEqual(
-            sorted([]), sorted(il.indices))
+        self.builder()
+        self.client.indices.get_alias.return_value = {}
+        self.ilo.filter_by_alias(aliases=['not_my_alias'])
+        self.assertEqual(sorted([]), sorted(self.ilo.indices))
     def test_get_alias_raises(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.indices.get_alias.side_effect = testvars.get_alias_fail
-        client.indices.get_alias.return_value = testvars.settings_2_get_aliases
-        il = IndexList(client)
-        il.filter_by_alias(aliases=['my_alias'])
-        self.assertEqual(
-            sorted([]), sorted(il.indices))
+        self.builder()
+        self.client.indices.get_alias.side_effect = testvars.get_alias_fail
+        self.client.indices.get_alias.return_value = testvars.settings_2_get_aliases
+        self.ilo.filter_by_alias(aliases=['my_alias'])
+        self.assertEqual(sorted([]), sorted(self.ilo.indices))
 
 class TestIndexListFilterCount(TestCase):
-    def builder(self):
+    def builder(self, key='2'):
         self.client = Mock()
-        self.client.info.return_value = {'version': {'number': '5.0.0'} }
-        self.client.indices.get_settings.return_value = testvars.settings_two
-        self.client.cluster.state.return_value = testvars.clu_state_two
-        self.client.indices.stats.return_value = testvars.stats_two
+        self.client.info.return_value = get_es_ver()
+        self.client.cat.indices.return_value = get_testvals(key, 'state')
+        self.client.indices.get_settings.return_value = get_testvals(key, 'settings')
+        self.client.indices.stats.return_value = get_testvals(key, 'stats')
+        self.client.indices.exists_alias.return_value = False
         self.client.indices.get_alias.return_value = testvars.settings_2_get_aliases
-        self.il = IndexList(self.client)
+        self.ilo = IndexList(self.client)
     def test_raise(self):
         self.builder()
-        self.assertRaises(MissingArgument, self.il.filter_by_count)
+        self.assertRaises(MissingArgument, self.ilo.filter_by_count)
     def test_without_age(self):
         self.builder()
-        self.il.filter_by_count(count=1)
-        self.assertEqual(['index-2016.03.03'], self.il.indices)
+        self.ilo.filter_by_count(count=1)
+        self.assertEqual(['index-2016.03.03'], self.ilo.indices)
     def test_without_age_reversed(self):
         self.builder()
-        self.il.filter_by_count(count=1, reverse=False)
-        self.assertEqual(['index-2016.03.04'], self.il.indices)
+        self.ilo.filter_by_count(count=1, reverse=False)
+        self.assertEqual(['index-2016.03.04'], self.ilo.indices)
     def test_with_age(self):
         self.builder()
-        self.il.filter_by_count(
-            count=1, use_age=True, source='name', timestring='%Y.%m.%d'
-        )
-        self.assertEqual(['index-2016.03.03'], self.il.indices)
+        self.ilo.filter_by_count(count=1, use_age=True, source='name', timestring='%Y.%m.%d')
+        self.assertEqual(['index-2016.03.03'], self.ilo.indices)
     def test_with_age_creation_date(self):
         self.builder()
-        self.il.filter_by_count(count=1, use_age=True)
-        self.assertEqual(['index-2016.03.03'], self.il.indices)
+        self.ilo.filter_by_count(count=1, use_age=True)
+        self.assertEqual(['index-2016.03.03'], self.ilo.indices)
     def test_with_age_reversed(self):
         self.builder()
-        self.il.filter_by_count(
+        self.ilo.filter_by_count(
             count=1, use_age=True, source='name', timestring='%Y.%m.%d',
             reverse=False
         )
-        self.assertEqual(['index-2016.03.04'], self.il.indices)
+        self.assertEqual(['index-2016.03.04'], self.ilo.indices)
     def test_pattern_no_regex_group(self):
         self.builder()
-        self.assertRaises(ActionError, self.il.filter_by_count,
+        self.assertRaises(ActionError, self.ilo.filter_by_count,
             count=1, use_age=True, pattern=' ', source='name', timestring='%Y.%m.%d',
         )
     def test_pattern_multiple_regex_groups(self):
         self.builder()
-        self.assertRaises(ActionError, self.il.filter_by_count,
+        self.assertRaises(ActionError, self.ilo.filter_by_count,
             count=1, use_age=True, pattern=r'^(\ )foo(\ )$', source='name', timestring='%Y.%m.%d',
         )
 
 class TestIndexListFilterShards(TestCase):
-    def builder(self):
+    def builder(self, key='2'):
         self.client = Mock()
-        self.client.info.return_value = {'version': {'number': '5.0.0'} }
-        self.client.indices.get_settings.return_value = testvars.settings_two
-        self.client.cluster.state.return_value = testvars.clu_state_two
-        self.client.indices.stats.return_value = testvars.stats_two
-        self.il = IndexList(self.client)
+        self.client.info.return_value = get_es_ver()
+        self.client.cat.indices.return_value = get_testvals(key, 'state')
+        self.client.indices.get_settings.return_value = get_testvals(key, 'settings')
+        self.client.indices.stats.return_value = get_testvals(key, 'stats')
+        self.client.indices.exists_alias.return_value = False
+        self.ilo = IndexList(self.client)
     def test_filter_shards_raise(self):
         self.builder()
-        self.assertRaises(MissingArgument, self.il.filter_by_shards)
+        self.assertRaises(MissingArgument, self.ilo.filter_by_shards)
     def test_bad_shard_count_raise_1(self):
         self.builder()
-        self.assertRaises(MissingArgument, self.il.filter_by_shards, number_of_shards=0)
+        self.assertRaises(MissingArgument, self.ilo.filter_by_shards, number_of_shards=0)
     def test_bad_shard_count_raise_2(self):
         self.builder()
-        self.assertRaises(ValueError, self.il.filter_by_shards, number_of_shards=1, shard_filter_behavior='less_than')
+        self.assertRaises(ValueError, self.ilo.filter_by_shards, number_of_shards=1, shard_filter_behavior='less_than')
     def test_bad_shard_count_raise_3(self):
         self.builder()
-        self.assertRaises(ValueError, self.il.filter_by_shards, number_of_shards=-1, shard_filter_behavior='greater_than')
+        self.assertRaises(ValueError, self.ilo.filter_by_shards, number_of_shards=-1, shard_filter_behavior='greater_than')
     def test_greater_than_or_equal(self):
         self.builder()
-        self.il.filter_by_shards(number_of_shards=5, shard_filter_behavior='greater_than_or_equal')
-        self.assertEqual(
-            sorted(['index-2016.03.03', 'index-2016.03.04']), sorted(self.il.indices))
+        self.ilo.filter_by_shards(number_of_shards=5, shard_filter_behavior='greater_than_or_equal')
+        self.assertEqual(sorted(['index-2016.03.03', 'index-2016.03.04']), sorted(self.ilo.indices))
     def test_greater_than_or_equal_exclude(self):
         self.builder()
-        self.il.filter_by_shards(number_of_shards=5, shard_filter_behavior='greater_than_or_equal', exclude=True)
-        self.assertEqual(
-            sorted([]), sorted(self.il.indices))
+        self.ilo.filter_by_shards(number_of_shards=5, shard_filter_behavior='greater_than_or_equal', exclude=True)
+        self.assertEqual(sorted([]), sorted(self.ilo.indices))
     def test_greater_than(self):
         self.builder()
-        self.il.filter_by_shards(number_of_shards=5)
-        self.assertEqual(
-            sorted([]), sorted(self.il.indices))
+        self.ilo.filter_by_shards(number_of_shards=5)
+        self.assertEqual(sorted([]), sorted(self.ilo.indices))
     def test_greater_than_exclude(self):
         self.builder()
-        self.il.filter_by_shards(number_of_shards=5, exclude=True)
-        self.assertEqual(
-            sorted(['index-2016.03.03', 'index-2016.03.04']), sorted(self.il.indices))
+        self.ilo.filter_by_shards(number_of_shards=5, exclude=True)
+        self.assertEqual(sorted(['index-2016.03.03', 'index-2016.03.04']), sorted(self.ilo.indices))
     def test_less_than_or_equal(self):
         self.builder()
-        self.il.filter_by_shards(number_of_shards=5, shard_filter_behavior='less_than_or_equal')
-        self.assertEqual(
-            sorted(['index-2016.03.03', 'index-2016.03.04']), sorted(self.il.indices))
+        self.ilo.filter_by_shards(number_of_shards=5, shard_filter_behavior='less_than_or_equal')
+        self.assertEqual(sorted(['index-2016.03.03', 'index-2016.03.04']), sorted(self.ilo.indices))
     def test_less_than_or_equal_exclude(self):
         self.builder()
-        self.il.filter_by_shards(number_of_shards=5, shard_filter_behavior='less_than_or_equal', exclude=True)
-        self.assertEqual(
-            sorted([]), sorted(self.il.indices))
+        self.ilo.filter_by_shards(number_of_shards=5, shard_filter_behavior='less_than_or_equal', exclude=True)
+        self.assertEqual(sorted([]), sorted(self.ilo.indices))
     def test_less_than(self):
         self.builder()
-        self.il.filter_by_shards(number_of_shards=5, shard_filter_behavior='less_than')
-        self.assertEqual(
-            sorted([]), sorted(self.il.indices))
+        self.ilo.filter_by_shards(number_of_shards=5, shard_filter_behavior='less_than')
+        self.assertEqual(sorted([]), sorted(self.ilo.indices))
     def test_less_than_exclude(self):
         self.builder()
-        self.il.filter_by_shards(number_of_shards=5, shard_filter_behavior='less_than', exclude=True)
-        self.assertEqual(
-            sorted(['index-2016.03.03', 'index-2016.03.04']), sorted(self.il.indices))
+        self.ilo.filter_by_shards(number_of_shards=5, shard_filter_behavior='less_than', exclude=True)
+        self.assertEqual(sorted(['index-2016.03.03', 'index-2016.03.04']), sorted(self.ilo.indices))
     def test_equal(self):
         self.builder()
-        self.il.filter_by_shards(number_of_shards=5, shard_filter_behavior='equal')
-        self.assertEqual(
-            sorted(['index-2016.03.03', 'index-2016.03.04']), sorted(self.il.indices))
+        self.ilo.filter_by_shards(number_of_shards=5, shard_filter_behavior='equal')
+        self.assertEqual(sorted(['index-2016.03.03', 'index-2016.03.04']), sorted(self.ilo.indices))
 
 class TestIndexListPeriodFilterName(TestCase):
+    def builder(self, key='2'):
+        self.client = Mock()
+        self.client.info.return_value = get_es_ver()
+        self.client.cat.indices.return_value = get_testvals(key, 'state')
+        self.client.indices.get_settings.return_value = get_testvals(key, 'settings')
+        self.client.indices.stats.return_value = get_testvals(key, 'stats')
+        self.client.indices.exists_alias.return_value = False
+        self.ilo = IndexList(self.client)
+        self.timestring = '%Y.%m.%d'
+        self.epoch = 1456963201
+        self.unit = 'days'
     def test_get_name_based_age_in_range(self):
-        unit = 'days'
         range_from = -1
         range_to = 0
-        timestring = '%Y.%m.%d'
-        epoch = 1456963201
         expected = ['index-2016.03.03']
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        il.filter_period(unit=unit, range_from=range_from, range_to=range_to,
-            source='name', timestring=timestring, epoch=epoch)
-        self.assertEqual(expected, il.indices)
+        self.builder()
+        self.ilo.filter_period(unit=self.unit, range_from=range_from, range_to=range_to,
+            source='name', timestring=self.timestring, epoch=self.epoch)
+        self.assertEqual(expected, self.ilo.indices)
     def test_get_name_based_age_not_in_range(self):
-        unit = 'days'
         range_from = -3
         range_to = -2
-        timestring = '%Y.%m.%d'
-        epoch = 1456963201
         expected = []
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        il.filter_period(unit=unit, range_from=range_from, range_to=range_to,
-            source='name', timestring=timestring, epoch=epoch)
-        self.assertEqual(expected, il.indices)
+        self.builder()
+        self.ilo.filter_period(unit=self.unit, range_from=range_from, range_to=range_to,
+            source='name', timestring=self.timestring, epoch=self.epoch)
+        self.assertEqual(expected, self.ilo.indices)
     def test_bad_arguments(self):
-        unit = 'days'
         range_from = -2
         range_to = -3
-        timestring = '%Y.%m.%d'
-        epoch = 1456963201
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
+        self.builder()
         self.assertRaises(FailedExecution,
-            il.filter_period, unit=unit, range_from=range_from,
-            range_to=range_to, source='name', timestring=timestring, epoch=epoch
+            self.ilo.filter_period, unit=self.unit, range_from=range_from,
+            range_to=range_to, source='name', timestring=self.timestring, epoch=self.epoch
         )
     def test_missing_creation_date_raises(self):
-        unit = 'days'
         range_from = -1
         range_to = 0
-        epoch = 1456963201
         expected = []
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        il.index_info['index-2016.03.03']['age'].pop('creation_date')
-        il.index_info['index-2016.03.04']['age'].pop('creation_date')
-        il.filter_period(unit=unit, range_from=range_from, range_to=range_to,
-            source='creation_date', epoch=epoch)
-        self.assertEqual(expected, il.indices)
+        self.builder()
+        self.ilo.index_info['index-2016.03.03']['age'].pop('creation_date')
+        self.ilo.index_info['index-2016.03.04']['age'].pop('creation_date')
+        self.ilo.filter_period(unit=self.unit, range_from=range_from, range_to=range_to,
+            source='creation_date', epoch=self.epoch)
+        self.assertEqual(expected, self.ilo.indices)
     def test_non_integer_range_value(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        self.assertRaises(ConfigurationError, il.filter_period, range_from='invalid')
+        self.builder()
+        self.assertRaises(ConfigurationError, self.ilo.filter_period, range_from='invalid')
 
 class TestPeriodFilterAbsolute(TestCase):
+    def builder(self, key='2'):
+        self.client = Mock()
+        self.client.info.return_value = get_es_ver()
+        self.client.cat.indices.return_value = get_testvals(key, 'state')
+        self.client.indices.get_settings.return_value = get_testvals(key, 'settings')
+        self.client.indices.stats.return_value = get_testvals(key, 'stats')
+        self.client.indices.exists_alias.return_value = False
+        self.ilo = IndexList(self.client)
     def test_bad_period_type(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
-        self.assertRaises(ValueError, il.filter_period, period_type='invalid')
+        self.builder()
+        self.assertRaises(ValueError, self.ilo.filter_period, period_type='invalid')
     def test_none_value_raises(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
+        self.builder()
         self.assertRaises(
-            ConfigurationError, il.filter_period, period_type='absolute', date_from=None)
+            ConfigurationError, self.ilo.filter_period, period_type='absolute', date_from=None)
     def test_fail_on_bad_date(self):
         unit = 'months'
         date_from =  '2016.17'
         date_from_format = '%Y.%m'
         date_to = '2017.01'
         date_to_format = '%Y.%m'
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        il = IndexList(client)
+        self.builder()
         self.assertRaises(
             FailedExecution,
-            il.filter_period, unit=unit, source='creation_date', period_type='absolute', date_from=date_from,
+            self.ilo.filter_period, unit=unit, source='creation_date', period_type='absolute', date_from=date_from,
             date_to=date_to, date_from_format=date_from_format, date_to_format=date_to_format
         )
 
-
 class TestIndexListFilterBySize(TestCase):
+    def builder(self, key='2'):
+        self.client = Mock()
+        self.client.info.return_value = get_es_ver()
+        self.client.cat.indices.return_value = get_testvals(key, 'state')
+        self.client.indices.get_settings.return_value = get_testvals(key, 'settings')
+        self.client.indices.stats.return_value = get_testvals(key, 'stats')
+        self.client.field_stats.return_value = get_testvals(key, 'fieldstats')
+        self.client.indices.exists_alias.return_value = False
+        self.ilo = IndexList(self.client)
     def test_missing_size_value(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.field_stats.return_value = testvars.fieldstats_two
-        il = IndexList(client)
-        self.assertRaises(MissingArgument, il.filter_by_size)
+        self.builder()
+        self.assertRaises(MissingArgument, self.ilo.filter_by_size)
     def test_filter_default_result(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.field_stats.return_value = testvars.fieldstats_two
-        il = IndexList(client)
-        il.filter_by_size(size_threshold=0.52)
-        self.assertEqual(['index-2016.03.04'], il.indices)
+        self.builder()
+        self.ilo.filter_by_size(size_threshold=0.52)
+        self.assertEqual(['index-2016.03.04'], self.ilo.indices)
     def test_filter_default_result_and_exclude(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.field_stats.return_value = testvars.fieldstats_two
-        il = IndexList(client)
-        il.filter_by_size(size_threshold=0.52, exclude=True)
-        self.assertEqual(['index-2016.03.03'], il.indices)
+        self.builder()
+        self.ilo.filter_by_size(size_threshold=0.52, exclude=True)
+        self.assertEqual(['index-2016.03.03'], self.ilo.indices)
     def test_filter_by_threshold_behavior_less_than(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.field_stats.return_value = testvars.fieldstats_two
-        il = IndexList(client)
-        il.filter_by_size(size_threshold=0.52, threshold_behavior='less_than')
-        self.assertEqual(['index-2016.03.03'], il.indices)
+        self.builder()
+        self.ilo.filter_by_size(size_threshold=0.52, threshold_behavior='less_than')
+        self.assertEqual(['index-2016.03.03'], self.ilo.indices)
     def test_filter_by_size_behavior_total(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.field_stats.return_value = testvars.fieldstats_two
-        il = IndexList(client)
-        il.filter_by_size(size_threshold=1.04, size_behavior='total')
-        self.assertEqual(['index-2016.03.04'], il.indices)
+        self.builder()
+        self.ilo.filter_by_size(size_threshold=1.04, size_behavior='total')
+        self.assertEqual(['index-2016.03.04'], self.ilo.indices)
     def test_filter_by_size_behavior_total_and_threshold_behavior_less_than(self):
-        client = Mock()
-        client.info.return_value = {'version': {'number': '5.0.0'} }
-        client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
-        client.indices.stats.return_value = testvars.stats_two
-        client.field_stats.return_value = testvars.fieldstats_two
-        il = IndexList(client)
-        il.filter_by_size(size_threshold=1.04, size_behavior='total', threshold_behavior='less_than')
-        self.assertEqual(['index-2016.03.03'], il.indices)
+        self.builder()
+        self.ilo.filter_by_size(size_threshold=1.04, size_behavior='total', threshold_behavior='less_than')
+        self.assertEqual(['index-2016.03.03'], self.ilo.indices)

--- a/tests/unit/test_helpers_utils.py
+++ b/tests/unit/test_helpers_utils.py
@@ -23,9 +23,10 @@ class TestShowDryRun(TestCase):
         """
         client = Mock()
         client.info.return_value = {'version': {'number': '8.0.0'} }
+        client.cat.indices.return_value = testvars.state_two
         client.indices.get_settings.return_value = testvars.settings_two
-        client.cluster.state.return_value = testvars.clu_state_two
         client.indices.stats.return_value = testvars.stats_two
+        client.indices.exists_alias.return_value = False
         client.field_stats.return_value = testvars.fieldstats_two
         ilst = IndexList(client)
         assert None is show_dry_run(ilst, 'test_action')

--- a/tests/unit/testvars.py
+++ b/tests/unit/testvars.py
@@ -206,9 +206,10 @@ synced_fails    = {
                     },
                   }
 
+state_one  = [{'index': named_index, 'status': 'open'}]
+
 settings_one   = {
     named_index: {
-        'state': 'open',
         'aliases': ['my_alias'],
         'mappings': {},
         'settings': {
@@ -224,9 +225,13 @@ settings_one   = {
 
 settings_1_get_aliases = { named_index: { "aliases" : { 'my_alias' : { } } } }
 
+state_two = [
+    {'index': 'index-2016.03.03', 'status': 'open'},
+    {'index': 'index-2016.03.04', 'status': 'open'}
+]
+
 settings_two  = {
     'index-2016.03.03': {
-        'state': 'open',
         'aliases': ['my_alias'],
         'mappings': {},
         'settings': {
@@ -239,7 +244,6 @@ settings_two  = {
         }
     },
     'index-2016.03.04': {
-        'state': 'open',
         'aliases': ['my_alias'],
         'mappings': {},
         'settings': {
@@ -258,9 +262,13 @@ settings_2_get_aliases = {
     "index-2016.03.04": { "aliases" : { 'my_alias' : { } } },
 }
 
+state_2_closed  = [
+    {'index': 'index-2016.03.03', 'status': 'close'},
+    {'index': 'index-2016.03.04', 'status': 'open'},
+]
+
 settings_2_closed = {
     'index-2016.03.03': {
-        'state': 'close',
         'aliases': ['my_alias'],
         'mappings': {},
         'settings': {
@@ -273,7 +281,6 @@ settings_2_closed = {
         }
     },
     'index-2016.03.04': {
-        'state': 'open',
         'aliases': ['my_alias'],
         'mappings': {},
         'settings': {
@@ -287,38 +294,15 @@ settings_2_closed = {
     }
 }
 
-settings_two_no_cd  = {
-    'index-2016.03.03': {
-        'state': 'open',
-        'aliases': ['my_alias'],
-        'mappings': {},
-        'settings': {
-            'index': {
-                'number_of_replicas': '1', 'uuid': 'random_uuid_string_here',
-                'number_of_shards': '5', 'creation_date': '1456963200172',
-                'routing': {'allocation': {'include': {'tag': 'foo'}}},
-                'version': {'created': '2020099'}, 'refresh_interval': '5s'
-            }
-        }
-    },
-    'index-2016.03.04': {
-        'state': 'open',
-        'aliases': ['my_alias'],
-        'mappings': {},
-        'settings': {
-            'index': {
-                'number_of_replicas': '1', 'uuid': 'another_random_uuid_string',
-                'number_of_shards': '5',
-                'routing': {'allocation': {'include': {'tag': 'bar'}}},
-                'version': {'created': '2020099'}, 'refresh_interval': '5s'
-            }
-        }
-    }
-}
+state_four  = [
+    {'index': 'a-2016.03.03', 'status': 'open'},
+    {'index': 'b-2016.03.04', 'status': 'open'},
+    {'index': 'c-2016.03.05', 'status': 'close'},
+    {'index': 'd-2016.03.06', 'status': 'open'},
+]
 
 settings_four  = {
     'a-2016.03.03': {
-        'state': 'open',
         'aliases': ['my_alias'],
         'mappings': {},
         'settings': {
@@ -331,7 +315,6 @@ settings_four  = {
         }
     },
     'b-2016.03.04': {
-        'state': 'open',
         'aliases': ['my_alias'],
         'mappings': {},
         'settings': {
@@ -344,7 +327,6 @@ settings_four  = {
         }
     },
     'c-2016.03.05': {
-        'state': 'close',
         'aliases': ['my_alias'],
         'mappings': {},
         'settings': {
@@ -357,7 +339,6 @@ settings_four  = {
         }
     },
     'd-2016.03.06': {
-        'state': 'open',
         'aliases': ['my_alias'],
         'mappings': {},
         'settings': {
@@ -371,9 +352,13 @@ settings_four  = {
     }
 }
 
+state_named  = [
+    {'index': 'index-2015.01.01', 'status': 'open'},
+    {'index': 'index-2015.02.01', 'status': 'open'},
+]
+
 settings_named = {
     'index-2015.01.01': {
-        'state': 'open',
         'aliases': ['my_alias'],
         'mappings': {},
         'settings': {
@@ -386,7 +371,6 @@ settings_named = {
         }
     },
     'index-2015.02.01': {
-        'state': 'open',
         'aliases': ['my_alias'],
         'mappings': {},
         'settings': {
@@ -397,32 +381,6 @@ settings_named = {
                 'version': {'created': '2020099'}, 'refresh_interval': '5s'
             }
         }
-    }
-}
-
-clu_state_one  = {
-    'metadata': {
-        'indices': settings_one
-    }
-}
-clu_state_two  = {
-    'metadata': {
-        'indices': settings_two
-    }
-}
-cs_two_closed  = {
-    'metadata': {
-        'indices': settings_2_closed
-    }
-}
-clu_state_two_no_cd  = {
-    'metadata': {
-        'indices': settings_two_no_cd
-    }
-}
-clu_state_four = {
-    'metadata': {
-        'indices': settings_four
     }
 }
 


### PR DESCRIPTION
There are no changes in this release that change how Curator will appear to behave to the user. However...

This release ends the practice of collecting all stats and metadata at IndexList initiation. This should make execution much faster for users with enormous clusters with hundreds to thousands of indices. In the past, this was handled at IndexList instantiation by making a cluster state API call. This is rather heavy, and can be so much data as to slow down Curator for minutes on clusters with hundreds to thousands of shards. This is all changed in this release.

For example, the pattern filter requires no index metadata, as it only works against the index name. If you use a pattern filter first, the actionable list of indices is reduced. Then if you need to filter based on age using the ``creation_date``, the age filter will call ``get_index_settings`` to pull the necessary data for that filter to complete. Some filters will not work against closed indices. Those filters will automatically call ``get_index_state`` to get the open/close status of the indices in the actionable list. The disk space filter will require the index state as it won't work on closed indices, and will call ``get_index_stats`` to pull the size_in_bytes stats.

Additionally, the cat API is used to get index state (open/close), now, as it is the only API call besides the cluster state which can inform on this matter. Not calling for a huge dump of the entire cluster state should drastically reduce memory requirements, though that may vary for some users still after all of the index data is polled, depending on what filters are used.

There is a potential caveat to all this rejoicing, however. Searchable snapshot behavior with ILM policies usually keeps indices out of Curator's vision. You need to manually tell Curator to allow it to work on ILM enabled indices. But for some users who need to restore a snapshot to remove PII or other data from an index, it can't be in ILM anymore. This has caused some headaches. For example, if you are tracking an index in the hot tier named 'index1' and it is in process of being migrated to the cold tier as a searchable snapshot, it may suddenly disappear from the system as 'index1' and suddenly re-appear as 'restored-index1'. The original index may now be an alias that points to the newly mounted cold-tier index. Before this version, Curator would choke if it encountered this scenario. In fact, one user saw it repeatedly. See the last comment of issue 1682 in the GitHub repository for more information.

To combat this, many repeated checks for index integrity have become necessary. This also involves verifying that indices in the IndexList are not actually aliases. Elasticsearch provides ``exists`` tests for these, but they cannot be performed in bulk. They are, however, very lightweight. But network turnaround times could make large clusters slower. For this reason, it is highly recommended that regex filters be used first, early, and often, before using any other filters. This will reduce the number of indices Curator has to check and/or verify during execution, which will speed things up drastically.


## Other Changes

Most of the unit tests needed updating due to these changes (adding a few more Mock responses), so I took the time to refactor them to use a builder method instead of repeating the same few lines of code in each test. This represents the vast majority of code deletions (2,085 lines!). All of the tests are passing, both integration and unit tests.