### PR TITLE
Bump `pyyaml` requirement to 6.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "boto3>=1.24.54",
     "requests_aws4auth>=1.1.2",
     "click==8.1.3",
-    "pyyaml==6.0.0",
+    "pyyaml==6.0.1",
     "voluptuous>=0.13.1",
     "certifi>=2022.12.7",
     "six>=1.16.0",


### PR DESCRIPTION
Elasticsearch Curator 7.x fails to install (tested on Python 3.9 & 3.10) as the `pyyaml` requirement of 6.0.0 fails:

```
Collecting pyyaml==6.0.0
  Using cached PyYAML-6.0.tar.gz (124 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  ERROR: Command errored out with exit status 1:
[...]
    File "/tmp/pip-build-env-8g9pbe4r/overlay/lib/python3.9/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
      raise AttributeError(attr)
  AttributeError: cython_sources
  ----------------------------------------
ERROR: Could not find a version that satisfies the requirement pyyaml==6.0.0 (from elasticsearch-curator) (from versions: 3.10, 3.11, 3.12, 3.13b1, 3.13rc1, 3.13, 4.2b1, 4.2b2, 4.2b4, 5.1b1, 5.1b3, 5.1b5, 5.1, 5.1.1, 5.1.2, 5.2b1, 5.2, 5.3b1, 5.3, 5.3.1, 5.4b1, 5.4b2, 5.4, 5.4.1, 6.0b1, 6.0, 6.0.1)
ERROR: No matching distribution found for pyyaml==6.0.0
```

The same Error raises when running a standalone install of `pyyaml==6.0` while 6.0.1 works without issues. 

## Proposed Changes

  - Bump pyyaml requirement to 6.0.1
  