### PR TITLE
Updates for 7.0.1 release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ html_docs/
 index.html
 msi_guid.txt
 nosetests.xml
+pytest.ini
 samples
 scratch
 test/.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYVER=3.11.1
+ARG PYVER=3.11.4
 ARG ALPTAG=3.17
 FROM python:${PYVER}-alpine${ALPTAG} as builder
 

--- a/curator/_version.py
+++ b/curator/_version.py
@@ -1,2 +1,2 @@
 """Curator Version"""
-__version__ = '7.0.0'
+__version__ = '7.0.1'

--- a/curator/actions.py
+++ b/curator/actions.py
@@ -57,7 +57,7 @@ class Alias(object):
             # Add a warning if there are no indices to add, if so set in options
             if warn_if_no_indices:
                 self.warn_if_no_indices = True
-                self.loggit.warn(
+                self.loggit.warning(
                     'No indices found after processing filters. '
                     'Nothing to add to {0}'.format(self.name)
                 )
@@ -91,7 +91,7 @@ class Alias(object):
             # Add a warning if there are no indices to add, if so set in options
             if warn_if_no_indices:
                 self.warn_if_no_indices = True
-                self.loggit.warn(
+                self.loggit.warning(
                     'No indices found after processing filters. '
                     'Nothing to remove from {0}'.format(self.name)
                 )
@@ -326,7 +326,7 @@ class Close(object):
                         self.client.indices.delete_alias(index=lst_as_csv, name='_all')
                         self.loggit.debug('Deleted aliases from: {0}'.format(lst))
                     except Exception as err:
-                        self.loggit.warn(
+                        self.loggit.warning(
                             'Some indices may not have had aliases.  Exception:'
                             ' {0}'.format(err)
                         )
@@ -337,7 +337,7 @@ class Close(object):
                         if not self.ignore_sync_failures:
                             raise ConflictError(err.status_code, err.error, err.info)
                         else:
-                            self.loggit.warn(
+                            self.loggit.warning(
                                 'Ignoring flushed sync failures: '
                                 '{0} {1}'.format(err.error, err.info)
                             )
@@ -495,7 +495,7 @@ class CreateIndex(object):
         except RequestError as err:
             match_list = ["index_already_exists_exception", "resource_already_exists_exception"]
             if err.error in match_list and self.ignore_existing:
-                self.loggit.warn('Index %s already exists.' % self.name)
+                self.loggit.warning('Index %s already exists.' % self.name)
             else:
                 raise exceptions.FailedExecution('Index %s already exists.' % self.name)
         except Exception as err:
@@ -751,7 +751,7 @@ class IndexSettings(object):
                 # Act here if the case is different for some settings.
                 pass
             else:
-                self.loggit.warn(
+                self.loggit.warning(
                     '"{0}" is not a setting Curator recognizes and may or may '
                     'not work.'.format(k)
                 )
@@ -1518,7 +1518,7 @@ class Reindex(object):
                     self._post_run_quick_check(dest, response['task'])
 
                 else:
-                    self.loggit.warn(
+                    self.loggit.warning(
                         '"wait_for_completion" set to {0}.  Remember '
                         'to check task_id "{1}" for successful completion '
                         'manually.'.format(self.wfc, response['task'])
@@ -1682,7 +1682,7 @@ class Snapshot(object):
                 )
                 self.report_state()
             else:
-                self.loggit.warn(
+                self.loggit.warning(
                     '"wait_for_completion" set to {0}.'
                     'Remember to check for successful completion '
                     'manually.'.format(self.wait_for_completion)
@@ -1752,7 +1752,7 @@ class Restore(object):
         self.name = name if name else most_recent
         # Stop here now, if it's not a successful snapshot.
         if slo.snapshot_info[self.name]['state'] == 'PARTIAL' and partial:
-            self.loggit.warn(
+            self.loggit.warning(
                 'Performing restore of snapshot in state PARTIAL.')
         elif slo.snapshot_info[self.name]['state'] != 'SUCCESS':
             raise exceptions.CuratorException(
@@ -1918,7 +1918,7 @@ class Restore(object):
                 )
                 self.report_state()
             else:
-                self.loggit.warn(
+                self.loggit.warning(
                     '"wait_for_completion" set to {0}. '
                     'Remember to check for successful completion '
                     'manually.'.format(self.wfc)
@@ -2061,7 +2061,7 @@ class Shrink(object):
             self.loggit.info('Skipping node "{0}": master node'.format(name))
             return False
         elif 'master' in roles and self.node_filters['permit_masters']:
-            self.loggit.warn(
+            self.loggit.warning(
                 'Not skipping node "{0}" which is a master node (not recommended), but '
                 'permit_masters is True'.format(name)
             )
@@ -2152,7 +2152,7 @@ class Shrink(object):
         if not dry_run:
             raise exceptions.ActionError(error_msg)
         else:
-            self.loggit.warn('DRY-RUN: {0}'.format(error_msg))
+            self.loggit.warning('DRY-RUN: {0}'.format(error_msg))
 
     def _block_writes(self, idx):
         block = {'index.blocks.write': True}

--- a/curator/indexlist.py
+++ b/curator/indexlist.py
@@ -204,7 +204,7 @@ class IndexList(object):
                         wl['settings'] = alt_wl['settings']
 
                     if 'creation_date' not in wl['settings']['index']:
-                        self.loggit.warn(
+                        self.loggit.warning(
                             'Index: {0} has no "creation_date"! This implies '
                             'that the index predates Elasticsearch v1.4. For '
                             'safety, this index will be removed from the '
@@ -974,7 +974,7 @@ class IndexList(object):
         for group in groups:
             if use_age:
                 if source != 'name':
-                    self.loggit.warn(
+                    self.loggit.warning(
                         'Cannot get age information from closed indices unless '
                         'source="name".  Omitting any closed indices.'
                     )

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -793,7 +793,7 @@ def process_auth_args(data):
     password = data.pop('password', False)
     if http_auth:
         # No change to http_auth
-        LOGGER.warn(
+        LOGGER.warning(
             'Use of "http_auth" is deprecated. Please use "username" and "password" instead.')
     elif username and password:
         http_auth = (username, password)
@@ -934,7 +934,7 @@ def do_version_check(client, skip):
     Do a test of the Elasticsearch version, unless ``skip`` is ``True``
     """
     if skip:
-        LOGGER.warn(
+        LOGGER.warning(
             'Skipping Elasticsearch version verification. This is '
             'acceptable for remote reindex operations.'
         )
@@ -1699,13 +1699,13 @@ def snapshot_check(client, snapshot=None, repository=None):
         LOGGER.info(
             'Snapshot {0} successfully completed.'.format(snapshot))
     elif state == 'PARTIAL':
-        LOGGER.warn(
+        LOGGER.warning(
             'Snapshot {0} completed with state PARTIAL.'.format(snapshot))
     elif state == 'FAILED':
         LOGGER.error(
             'Snapshot {0} completed with state FAILED.'.format(snapshot))
     else:
-        LOGGER.warn(
+        LOGGER.warning(
             'Snapshot {0} completed with state: {0}'.format(snapshot))
     return True
 

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,20 @@
 Changelog
 =========
 
+7.0.1 (16 August 2023)
+----------------------
+
+**Changes**
+
+  * This release brings some Python modules up to current releases, namely:
+      * ``certifi>=2023.5.7``
+      * ``click==8.1.4``
+      * ``elasticsearch7==7.17.9``
+      * ``pyyaml==6.0.1``
+  * The PyYAML change is notable as the Cython 3.0 upgrade caused it to no longer work.
+    Version 6.0.1 fixes that, enabling Curator to build again.
+  * ``cx_Freeze`` changed some configurations to be more Pythonic. #1681 fixes that.
+
 7.0.0 (31 January 2023)
 -----------------------
 

--- a/docs/asciidoc/index.asciidoc
+++ b/docs/asciidoc/index.asciidoc
@@ -1,10 +1,10 @@
-:curator_version: 7.0.0
+:curator_version: 7.0.1
 :curator_major: 7
 :curator_doc_tree: 7.0
-:es_py_version: 7.17.8
+:es_py_version: 7.17.9
 :es_doc_tree: 7.17
 :stack_doc_tree: 7.17
-:pybuild_ver: 3.11.1
+:pybuild_ver: 3.11.4
 :copyright_years: 2011-2023
 :ref:  http://www.elastic.co/guide/en/elasticsearch/reference/{es_doc_tree}
 :esref: http://www.elastic.co/guide/en/elasticsearch/reference/{stack_doc_tree}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphin
 
 intersphinx_mapping = {
 	'python': ('https://docs.python.org/3.11', None),
-	'elasticsearch7': ('http://elasticsearch-py.readthedocs.io/en/7.17.8', None),
+	'elasticsearch7': ('http://elasticsearch-py.readthedocs.io/en/7.17.9', None),
 }
 
 autoclass_content = "both"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,14 +29,14 @@ keywords = [
     'index-expiry'
 ]
 dependencies = [
-    "elasticsearch7==7.17.8",
+    "elasticsearch7==7.17.9",
     "requests>=2.28.1",
     "boto3>=1.24.54",
     "requests_aws4auth>=1.1.2",
-    "click==8.1.3",
+    "click==8.1.4",
     "pyyaml==6.0.1",
     "voluptuous>=0.13.1",
-    "certifi>=2022.12.7",
+    "certifi>=2023.5.7",
     "six>=1.16.0",
 ]
 


### PR DESCRIPTION
**Changes**

  * This release brings some Python modules up to current releases, namely:
      * ``certifi>=2023.5.7``
      * ``click==8.1.4``
      * ``elasticsearch7==7.17.9``
      * ``pyyaml==6.0.1``
  * The PyYAML change is notable as the Cython 3.0 upgrade caused it to no longer work.
    Version 6.0.1 fixes that, enabling Curator to build again.
  * ``cx_Freeze`` changed some configurations to be more Pythonic. #1681 fixes that.