### PR TITLE
Use build in unittest.mock

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -34,7 +34,6 @@ An example is listed below:
 
        [project.optional-dependencies]
        test = [
-           "mock",
            "requests",
            "pytest >=7.2.1",
            "pytest-cov",
@@ -45,7 +44,7 @@ before running the following:
 
 .. code-block:: shell
 
-       pip install -U mock requests pytest pytest-cov
+       pip install -U requests pytest pytest-cov
 
 It should be simpler to run the regular method, but if you have some reason to do this manually,
 those are the steps.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "mock",
     "requests",
     "pytest >=7.2.1",
     "pytest-cov",
@@ -85,7 +84,6 @@ exclude = [
 [tool.hatch.envs.test]
 dependencies = [
     "coverage[toml]",
-    "mock",
     "requests",
     "pytest >=7.2.1",
     "pytest-cov",

--- a/tests/integration/test_es_repo_mgr.py
+++ b/tests/integration/test_es_repo_mgr.py
@@ -14,7 +14,7 @@ HOST = os.environ.get('TEST_ES_SERVER', 'http://127.0.0.1:9200')
 
 # class TestLoggingModules(CuratorTestCase):
 #     def test_logger_without_null_handler(self):
-#         from mock import patch, Mock
+#         from unittest.mock import patch, Mock
 #         mock = Mock()
 #         modules = {'logger': mock, 'logger.NullHandler': mock.module}
 #         self.write_config(

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -4,7 +4,7 @@ import tempfile
 import random
 import string
 from unittest import SkipTest, TestCase
-from mock import Mock
+from unittest.mock import Mock
 from .testvars import *
 
 class CLITestCase(TestCase):

--- a/tests/unit/test_action_alias.py
+++ b/tests/unit/test_action_alias.py
@@ -1,7 +1,7 @@
 """Alias unit tests"""
 # pylint: disable=missing-function-docstring, missing-class-docstring, invalid-name, line-too-long, attribute-defined-outside-init
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from curator import IndexList
 from curator.exceptions import ActionError, FailedExecution, MissingArgument, NoIndices
 from curator.actions.alias import Alias

--- a/tests/unit/test_action_allocation.py
+++ b/tests/unit/test_action_allocation.py
@@ -1,7 +1,7 @@
 """Alias unit tests"""
 # pylint: disable=missing-function-docstring, missing-class-docstring, invalid-name, line-too-long, attribute-defined-outside-init
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from curator import IndexList
 from curator.exceptions import MissingArgument
 from curator.actions.allocation import Allocation

--- a/tests/unit/test_action_close.py
+++ b/tests/unit/test_action_close.py
@@ -1,7 +1,7 @@
 """Alias unit tests"""
 # pylint: disable=missing-function-docstring, missing-class-docstring, invalid-name, line-too-long, attribute-defined-outside-init
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from curator import IndexList
 from curator.exceptions import FailedExecution
 from curator.actions.close import Close

--- a/tests/unit/test_action_clusterrouting.py
+++ b/tests/unit/test_action_clusterrouting.py
@@ -1,6 +1,6 @@
 """test_action_clusterrouting"""
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from curator.actions import ClusterRouting
 # Get test variables and constants from a single source
 from . import testvars

--- a/tests/unit/test_action_cold2frozen.py
+++ b/tests/unit/test_action_cold2frozen.py
@@ -1,7 +1,7 @@
 """test_action_cold2frozen"""
 # pylint: disable=attribute-defined-outside-init
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 import pytest
 from curator.actions import Cold2Frozen
 from curator.exceptions import CuratorException, SearchableSnapshotException

--- a/tests/unit/test_action_create_index.py
+++ b/tests/unit/test_action_create_index.py
@@ -1,6 +1,6 @@
 """Unit tests for create_index action"""
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from curator.actions import CreateIndex
 from curator.exceptions import ConfigurationError, FailedExecution
 # Get test variables and constants from a single source

--- a/tests/unit/test_action_delete_indices.py
+++ b/tests/unit/test_action_delete_indices.py
@@ -1,7 +1,7 @@
 """test_action_delete_indices"""
 # pylint: disable=missing-function-docstring, missing-class-docstring, protected-access, attribute-defined-outside-init
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from curator.actions import DeleteIndices
 from curator.exceptions import FailedExecution
 from curator import IndexList

--- a/tests/unit/test_action_delete_snapshots.py
+++ b/tests/unit/test_action_delete_snapshots.py
@@ -1,6 +1,6 @@
 """test_action_delete_snapshots"""
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from curator.actions import DeleteSnapshots
 from curator.exceptions import FailedExecution
 from curator import SnapshotList

--- a/tests/unit/test_action_forcemerge.py
+++ b/tests/unit/test_action_forcemerge.py
@@ -1,7 +1,7 @@
 """test_action_forcemerge"""
 # pylint: disable=missing-function-docstring, missing-class-docstring, protected-access, attribute-defined-outside-init
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from curator.actions import ForceMerge
 from curator.exceptions import FailedExecution, MissingArgument
 from curator import IndexList

--- a/tests/unit/test_action_indexsettings.py
+++ b/tests/unit/test_action_indexsettings.py
@@ -1,7 +1,7 @@
 """test_action_indexsettings"""
 # pylint: disable=missing-function-docstring, missing-class-docstring, protected-access, attribute-defined-outside-init
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from curator.actions import IndexSettings
 from curator.exceptions import ActionError, ConfigurationError, MissingArgument
 from curator import IndexList

--- a/tests/unit/test_action_open.py
+++ b/tests/unit/test_action_open.py
@@ -1,7 +1,7 @@
 """test_action_open"""
 # pylint: disable=missing-function-docstring, missing-class-docstring, protected-access, attribute-defined-outside-init
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from curator.actions import Open
 from curator.exceptions import FailedExecution
 from curator import IndexList

--- a/tests/unit/test_action_reindex.py
+++ b/tests/unit/test_action_reindex.py
@@ -1,7 +1,7 @@
 """test_action_reindex"""
 # pylint: disable=missing-function-docstring, missing-class-docstring, protected-access, attribute-defined-outside-init
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from curator.actions import Reindex
 from curator.exceptions import ConfigurationError, CuratorException, FailedExecution, NoIndices
 from curator import IndexList

--- a/tests/unit/test_action_replicas.py
+++ b/tests/unit/test_action_replicas.py
@@ -1,7 +1,7 @@
 """test_action_replicas"""
 # pylint: disable=missing-function-docstring, missing-class-docstring, protected-access, attribute-defined-outside-init
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from curator.actions import Replicas
 from curator.exceptions import FailedExecution, MissingArgument
 from curator import IndexList

--- a/tests/unit/test_action_restore.py
+++ b/tests/unit/test_action_restore.py
@@ -1,7 +1,7 @@
 """test_action_restore"""
 # pylint: disable=missing-function-docstring, missing-class-docstring, protected-access, attribute-defined-outside-init
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from curator.actions import Restore
 from curator.exceptions import CuratorException, FailedExecution, FailedRestore, SnapshotInProgress
 from curator import SnapshotList

--- a/tests/unit/test_action_rollover.py
+++ b/tests/unit/test_action_rollover.py
@@ -1,7 +1,7 @@
 """test_action_rollover"""
 # pylint: disable=missing-function-docstring, missing-class-docstring, protected-access, attribute-defined-outside-init
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from curator.actions import Rollover
 from curator.exceptions import ConfigurationError
 

--- a/tests/unit/test_action_shrink.py
+++ b/tests/unit/test_action_shrink.py
@@ -1,7 +1,7 @@
 """test_action_shrink"""
 # pylint: disable=missing-function-docstring, missing-class-docstring, line-too-long, protected-access, attribute-defined-outside-init
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from curator.actions import Shrink
 from curator.exceptions import ActionError, ConfigurationError
 from curator import IndexList

--- a/tests/unit/test_action_snapshot.py
+++ b/tests/unit/test_action_snapshot.py
@@ -1,7 +1,7 @@
 """test_action_snapshot"""
 # pylint: disable=missing-function-docstring, missing-class-docstring, line-too-long, protected-access, attribute-defined-outside-init
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from curator.actions import Snapshot
 from curator.exceptions import ActionError, CuratorException, FailedExecution, FailedSnapshot, MissingArgument, SnapshotInProgress
 from curator import IndexList

--- a/tests/unit/test_class_index_list.py
+++ b/tests/unit/test_class_index_list.py
@@ -2,7 +2,7 @@
 # pylint: disable=missing-function-docstring, missing-class-docstring, line-too-long, attribute-defined-outside-init, protected-access
 from unittest import TestCase
 from copy import deepcopy
-from mock import Mock
+from unittest.mock import Mock
 import yaml
 from curator.exceptions import ActionError, ConfigurationError, FailedExecution, MissingArgument, NoIndices
 from curator.helpers.date_ops import fix_epoch

--- a/tests/unit/test_class_snapshot_list.py
+++ b/tests/unit/test_class_snapshot_list.py
@@ -1,6 +1,6 @@
 """test_class_snapshot_list"""
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 import yaml
 from curator import SnapshotList
 from curator.exceptions import ConfigurationError, FailedExecution, MissingArgument, NoSnapshots

--- a/tests/unit/test_helpers_date_ops.py
+++ b/tests/unit/test_helpers_date_ops.py
@@ -2,7 +2,7 @@
 from unittest import TestCase
 from datetime import datetime
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 from elasticsearch8 import NotFoundError
 from elastic_transport import ApiResponseMeta
 from curator.exceptions import ConfigurationError

--- a/tests/unit/test_helpers_getters.py
+++ b/tests/unit/test_helpers_getters.py
@@ -1,6 +1,6 @@
 """Unit testing for helpers.creators functions"""
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 import pytest
 from elastic_transport import ApiResponseMeta
 from elasticsearch8 import NotFoundError, TransportError

--- a/tests/unit/test_helpers_testers.py
+++ b/tests/unit/test_helpers_testers.py
@@ -1,7 +1,7 @@
 """Unit tests for utils"""
 from unittest import TestCase
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 from elastic_transport import ApiResponseMeta
 from elasticsearch8 import Elasticsearch
 from elasticsearch8.exceptions import AuthenticationException, NotFoundError

--- a/tests/unit/test_helpers_utils.py
+++ b/tests/unit/test_helpers_utils.py
@@ -1,7 +1,7 @@
 """Unit tests for utils"""
 from unittest import TestCase
 # import pytest
-from mock import Mock
+from unittest.mock import Mock
 # from curator.exceptions import MissingArgument
 from curator.indexlist import IndexList
 from curator.helpers.utils import chunk_index_list, show_dry_run, to_csv

--- a/tests/unit/test_helpers_waiters.py
+++ b/tests/unit/test_helpers_waiters.py
@@ -1,7 +1,7 @@
 """Unit tests for utils"""
 from unittest import TestCase
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 from curator.exceptions import ActionTimeout, ConfigurationError, CuratorException, MissingArgument
 from curator.helpers.waiters import (
     health_check, restore_check, snapshot_check,task_check, wait_for_it)


### PR DESCRIPTION
Since Python 3.3 the unittest module provides mock.


## Proposed Changes

- Use unittest.mock instead of an external mock dependency