### PR TITLE
Version bumps

### DIFF
--- a/curator/_version.py
+++ b/curator/_version.py
@@ -1,2 +1,2 @@
 """Curator Version"""
-__version__ = '8.0.9'
+__version__ = '8.0.10'

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,18 @@
 Changelog
 =========
 
+8.0.10 (1 February 2024)
+------------------------
+
+**Changes**
+
+The upstream dependency, ``es_client``, needed to be patched to address a
+Docker logging permission issue. This release only version bumps that
+dependency:
+
+  * ``es_client==8.12.4``
+
+
 8.0.9 (31 January 2024)
 -----------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 
 intersphinx_mapping = {
 	'python': ('https://docs.python.org/3.11', None),
-    'es_client': ('https://es-client.readthedocs.io/en/v8.12.3', None),
+    'es_client': ('https://es-client.readthedocs.io/en/v8.12.4', None),
 	'elasticsearch8': ('https://elasticsearch-py.readthedocs.io/en/v8.12.0', None),
     'voluptuous': ('http://alecthomas.github.io/voluptuous/docs/_build/html', None),
     'click': ('https://click.palletsprojects.com/en/8.1.x', None),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ keywords = [
     'index-expiry'
 ]
 dependencies = [
-    "es_client==8.12.3"
+    "es_client==8.12.4"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Bump Curator version to 8.0.10
Bump es_client dependency to 8.12.4 to address Docker logging permissions issue
