### PR TITLE
fix(#1701): Bump pyyaml requirement to 6.0.1 for PEP-517.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "boto3>=1.24.54",
     "requests_aws4auth>=1.1.2",
     "click==8.1.3",
-    "pyyaml==6.0.0",
+    "pyyaml==6.0.1",
     "voluptuous>=0.13.1",
     "certifi>=2022.12.7",
     "six>=1.16.0",


### PR DESCRIPTION
Fixes #1701 

## Proposed Changes

  - Update `pyyaml` package pin from `6.0.0` to `6.0.1` (which supports PEP-517 for modern build systems) specifically for `6.x` releases.
