### PR TITLE
Release 8.0.12

### DIFF
--- a/curator/_version.py
+++ b/curator/_version.py
@@ -1,2 +1,2 @@
 """Curator Version"""
-__version__ = '8.0.11'
+__version__ = '8.0.12'

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,13 @@
 Changelog
 =========
 
+8.0.12 (20 March 2024)
+----------------------
+
+**Bugfix**
+
+  * ``six`` dependency erroneously removed from ``es_client``. It's back in ``es_client==8.12.8``
+
 8.0.11 (20 March 2024)
 ----------------------
 

--- a/docs/asciidoc/index.asciidoc
+++ b/docs/asciidoc/index.asciidoc
@@ -1,4 +1,4 @@
-:curator_version: 8.0.11
+:curator_version: 8.0.12
 :curator_major: 8
 :curator_doc_tree: 8.0
 :es_py_version: 8.12.1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,8 +72,8 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 
 intersphinx_mapping = {
 	'python': ('https://docs.python.org/3.11', None),
-    'es_client': ('https://es-client.readthedocs.io/en/v8.12.4', None),
-	'elasticsearch8': ('https://elasticsearch-py.readthedocs.io/en/v8.12.0', None),
+    'es_client': ('https://es-client.readthedocs.io/en/v8.12.8', None),
+	'elasticsearch8': ('https://elasticsearch-py.readthedocs.io/en/v8.12.1', None),
     'voluptuous': ('http://alecthomas.github.io/voluptuous/docs/_build/html', None),
     'click': ('https://click.palletsprojects.com/en/8.1.x', None),
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ keywords = [
     'index-expiry'
 ]
 dependencies = [
-    "es_client==8.12.6"
+    "es_client==8.12.8"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
**Bugfix**

  * ``six`` dependency erroneously removed from ``es_client``. It's back in ``es_client==8.12.8``