### PR TITLE
Release prep for 8.0.14

### DIFF
--- a/curator/_version.py
+++ b/curator/_version.py
@@ -1,2 +1,2 @@
 """Curator Version"""
-__version__ = '8.0.14.dev1'
+__version__ = '8.0.14'

--- a/curator/_version.py
+++ b/curator/_version.py
@@ -1,2 +1,2 @@
 """Curator Version"""
-__version__ = '8.0.13'
+__version__ = '8.0.14.dev1'

--- a/curator/actions/alias.py
+++ b/curator/actions/alias.py
@@ -47,7 +47,7 @@ class Alias:
         :type ilo: :py:class:`~.curator.indexlist.IndexList`
         """
         verify_index_list(ilo)
-        self.loggit.debug('ADD -> ILO = %s', ilo)
+        self.loggit.debug('ADD -> ILO = %s', ilo.indices)
         if not self.client:
             self.client = ilo.client
         self.name = parse_datemath(self.client, self.name)
@@ -80,7 +80,7 @@ class Alias:
         :type ilo: :py:class:`~.curator.indexlist.IndexList`
         """
         verify_index_list(ilo)
-        self.loggit.debug('REMOVE -> ILO = %s', ilo)
+        self.loggit.debug('REMOVE -> ILO = %s', ilo.indices)
         if not self.client:
             self.client = ilo.client
         self.name = parse_datemath(self.client, self.name)

--- a/curator/classdef.py
+++ b/curator/classdef.py
@@ -150,7 +150,16 @@ class ActionDef:
             wrapper = getattr(self, attribute)
         except AttributeError as exc:
             raise AttributeError(f'Bad Attribute: {attribute}. Exception: {exc}') from exc
-        setattr(self, attribute, self.get_obj_instance(wrapper, *args, **kwargs))
+        # setattr(self, attribute, self.get_obj_instance(wrapper, *args, **kwargs))
+        ### DEBUG
+        from curator.exceptions import NoIndices
+        try:
+            setattr(self, attribute, self.get_obj_instance(wrapper, *args, **kwargs))
+        except NoIndices as noidx:
+            raise NoIndices from noidx
+        except Exception as exc:
+            raise AttributeError(f'Set Attribute FAILURE: {attribute}. Exception: {exc}. Args: {args} Kwargs: {kwargs}') from exc
+        ### END DEBUG
 
     def get_obj_instance(self, wrapper, *args, **kwargs):
         """Get the class instance wrapper identified by ``wrapper``
@@ -177,8 +186,17 @@ class ActionDef:
         Set :py:attr:`list_obj` to :py:class:`~.curator.SnapshotList` when
         :py:attr:`~.curator.classdef.ActionDef.action` is ``delete_snapshots`` or ``restore``
         """
-
-        self.action_cls = Wrapper(CLASS_MAP[self.action])
+        # self.action_cls = Wrapper(CLASS_MAP[self.action])
+        ### DEBUGGING
+        try:
+            self.action_cls = Wrapper(CLASS_MAP[self.action])
+        except Exception as exc:
+            msg = (
+                f"Failed to set self.action_cls to Wrapper(CLASS_MAP[self.action]). "
+                f"Exception: {exc}"
+            )
+            raise BaseException(msg) from exc
+        ### END DEBUGGING
         if self.action == 'alias':
             self.set_alias_extras()
         if self.action in ['delete_snapshots', 'restore']:
@@ -197,10 +215,34 @@ class ActionDef:
             'timeout_override' : 'timeout_override'
         }
         for key in self.action_dict['options']:
+            # if key in attmap:
+            #     setattr(self, attmap[key], self.action_dict['options'][key])
+            # else:
+            #     self.options[key] = self.action_dict['options'][key]
+            ### DEBUGGING
+            logger = logging.getLogger(__name__)
             if key in attmap:
-                setattr(self, attmap[key], self.action_dict['options'][key])
+                try:
+                    setattr(self, attmap[key], self.action_dict['options'][key])
+                except Exception as exc:
+                    logger.critical('setattr FAIL for %s', key)
+                    msg = (
+                        f"Failed to setattr attmap[key] ({attmap[key]}) to "
+                        f"self.action_dict['options'][key] ({self.action_dict['options'][key]}) "
+                        f"Exception: {exc}"
+                    )
+                    raise BaseException(msg) from exc
             else:
-                self.options[key] = self.action_dict['options'][key]
+                try:
+                    self.options[key] = self.action_dict['options'][key]
+                except Exception as exc:
+                    msg = (
+                        f"Failed to set self.options[key] ({self.options[key]}) to "
+                        f"self.action_dict['options'][key] ({self.action_dict['options'][key]}) "
+                        f"Exception: {exc}"
+                    )
+                    raise BaseException(msg) from exc
+            ### END DEBUGGING
 
     def set_root_attrs(self):
         """

--- a/curator/classdef.py
+++ b/curator/classdef.py
@@ -150,16 +150,7 @@ class ActionDef:
             wrapper = getattr(self, attribute)
         except AttributeError as exc:
             raise AttributeError(f'Bad Attribute: {attribute}. Exception: {exc}') from exc
-        # setattr(self, attribute, self.get_obj_instance(wrapper, *args, **kwargs))
-        ### DEBUG
-        from curator.exceptions import NoIndices
-        try:
-            setattr(self, attribute, self.get_obj_instance(wrapper, *args, **kwargs))
-        except NoIndices as noidx:
-            raise NoIndices from noidx
-        except Exception as exc:
-            raise AttributeError(f'Set Attribute FAILURE: {attribute}. Exception: {exc}. Args: {args} Kwargs: {kwargs}') from exc
-        ### END DEBUG
+        setattr(self, attribute, self.get_obj_instance(wrapper, *args, **kwargs))
 
     def get_obj_instance(self, wrapper, *args, **kwargs):
         """Get the class instance wrapper identified by ``wrapper``
@@ -186,17 +177,8 @@ class ActionDef:
         Set :py:attr:`list_obj` to :py:class:`~.curator.SnapshotList` when
         :py:attr:`~.curator.classdef.ActionDef.action` is ``delete_snapshots`` or ``restore``
         """
-        # self.action_cls = Wrapper(CLASS_MAP[self.action])
-        ### DEBUGGING
-        try:
-            self.action_cls = Wrapper(CLASS_MAP[self.action])
-        except Exception as exc:
-            msg = (
-                f"Failed to set self.action_cls to Wrapper(CLASS_MAP[self.action]). "
-                f"Exception: {exc}"
-            )
-            raise BaseException(msg) from exc
-        ### END DEBUGGING
+
+        self.action_cls = Wrapper(CLASS_MAP[self.action])
         if self.action == 'alias':
             self.set_alias_extras()
         if self.action in ['delete_snapshots', 'restore']:
@@ -215,34 +197,10 @@ class ActionDef:
             'timeout_override' : 'timeout_override'
         }
         for key in self.action_dict['options']:
-            # if key in attmap:
-            #     setattr(self, attmap[key], self.action_dict['options'][key])
-            # else:
-            #     self.options[key] = self.action_dict['options'][key]
-            ### DEBUGGING
-            logger = logging.getLogger(__name__)
             if key in attmap:
-                try:
-                    setattr(self, attmap[key], self.action_dict['options'][key])
-                except Exception as exc:
-                    logger.critical('setattr FAIL for %s', key)
-                    msg = (
-                        f"Failed to setattr attmap[key] ({attmap[key]}) to "
-                        f"self.action_dict['options'][key] ({self.action_dict['options'][key]}) "
-                        f"Exception: {exc}"
-                    )
-                    raise BaseException(msg) from exc
+                setattr(self, attmap[key], self.action_dict['options'][key])
             else:
-                try:
-                    self.options[key] = self.action_dict['options'][key]
-                except Exception as exc:
-                    msg = (
-                        f"Failed to set self.options[key] ({self.options[key]}) to "
-                        f"self.action_dict['options'][key] ({self.action_dict['options'][key]}) "
-                        f"Exception: {exc}"
-                    )
-                    raise BaseException(msg) from exc
-            ### END DEBUGGING
+                self.options[key] = self.action_dict['options'][key]
 
     def set_root_attrs(self):
         """

--- a/curator/cli.py
+++ b/curator/cli.py
@@ -83,18 +83,18 @@ def process_action(client, action_def, dry_run=False):
     :type action_def: :py:class:`~.curator.classdef.ActionDef`
     :rtype: None
     """
+    result = True # DEBUGGING
     logger = logging.getLogger(__name__)
     logger.debug('Configuration dictionary: %s', action_def.action_dict)
     mykwargs = {}
-
+    noindices = False
     # Add some settings to mykwargs...
     if action_def.action == 'delete_indices':
         mykwargs['master_timeout'] = 30
-
+    logger.critical('MYKWARGS PRE-PRUNE = %s', action_def.options)
     ### Update the defaults with whatever came with opts, minus any Nones
     mykwargs.update(prune_nones(action_def.options))
     logger.debug('Action kwargs: %s', mykwargs)
-
     ### Set up the action ###
     logger.debug('Running "%s"', action_def.action.upper())
     if action_def.action == 'alias':
@@ -120,15 +120,58 @@ def process_action(client, action_def, dry_run=False):
             mykwargs.pop('repository') # We don't need to send this value to the action
             action_def.instantiate('list_obj', client, repository=action_def.options['repository'])
         else:
-            action_def.instantiate('list_obj', client)
-        action_def.list_obj.iterate_filters({'filters': action_def.filters})
-        action_def.instantiate('action_cls', action_def.list_obj, **mykwargs)
+            # action_def.instantiate('list_obj', client)
+            ### DEBUGGING
+            try:
+                logger.debug('Action %s: action_def.instantiate.list_obj', action_def.action)
+                action_def.instantiate('list_obj', client)
+            except Exception as exc:
+                logger.critical('Action %s: action_def.instantiate.list_obj FAILED', action_def.action)
+                exception_handler(action_def, exc)
+            ### END DEBUGGING
+
+        # action_def.list_obj.iterate_filters({'filters': action_def.filters})
+        ### DEBUGGING
+        try:
+            logger.debug('Action %s: action_def.list_obj.iterate_filters', action_def.action)
+            action_def.list_obj.iterate_filters({'filters': action_def.filters})
+        except Exception as exc:
+            logger.critical('Action %s: action_def.list_obj.iterate_filters FAILED', action_def.action)
+            exception_handler(action_def, exc)
+        ### END DEBUGGING
+
+        # action_def.instantiate('action_cls', action_def.list_obj, **mykwargs)
+        ### DEBUGGING
+        try:
+            logger.debug('Action %s: action_def.instantiate.action_cls, KWARGS: %s', action_def.action, mykwargs)
+            action_def.instantiate('action_cls', action_def.list_obj, **mykwargs)
+        except Exception as exc:
+            if isinstance(exc, NoIndices):
+                noindices = True
+            logger.critical('Action %s: action_def.instantiate.action_cls FAILED', action_def.action)
+            exception_handler(action_def, exc)
+        ### END DEBUGGING
+
     ### Do the action
     if dry_run:
         action_def.action_cls.do_dry_run()
     else:
-        logger.debug('Doing the action here.')
-        action_def.action_cls.do_action()
+        # logger.debug('Doing the action here.')
+        # action_def.action_cls.do_action()
+        ### DEBUGGING
+        try:
+            logger.debug('Action %s: action_def.action_cls.do_action()', action_def.action)
+            action_def.action_cls.do_action()
+        except Exception as exc:
+            if isinstance(exc, AttributeError):
+                if noindices:
+                    exception_handler(action_def, NoIndices())
+            else:
+                logger.critical('Action %s: action_def.action_cls.do_action() FAILED', action_def.action)
+                exception_handler(action_def, exc)
+        ### END DEBUGGING
+
+    return result # DEBUGGING
 
 def run(ctx: click.Context) -> None:
     """
@@ -179,13 +222,21 @@ def run(ctx: click.Context) -> None:
         ### Process the action ###
         ##########################
         msg = f'Trying Action ID: {idx}, "{action_def.action}": {action_def.description}'
-        try:
-            logger.info(msg)
-            process_action(client, action_def, dry_run=ctx.params['dry_run'])
-        # pylint: disable=broad-except
-        except Exception as err:
-            exception_handler(action_def, err)
-        logger.info('Action ID: %s, "%s" completed.', idx, action_def.action)
+        # try:
+        #     logger.info(msg)
+        #     process_action(client, action_def, dry_run=ctx.params['dry_run'])
+        # # pylint: disable=broad-except
+        # except Exception as err:
+        #     exception_handler(action_def, err)
+        # logger.info('Action ID: %s, "%s" completed.', idx, action_def.action)
+        ### DEBUGGING
+        logger.info(msg)
+        result = process_action(client, action_def, dry_run=ctx.params['dry_run'])
+        if result:
+            logger.info('Action ID: %s, "%s" completed.', idx, action_def.action)
+        else:
+            exception_handler(action_def, BaseException('NO IDEA HERE YET'))
+        ### END DEBUGGING
     logger.info('All actions completed.')
 
 # pylint: disable=unused-argument, redefined-builtin, too-many-arguments, too-many-locals, line-too-long

--- a/curator/cli_singletons/allocation.py
+++ b/curator/cli_singletons/allocation.py
@@ -4,6 +4,7 @@ from curator.cli_singletons.object_class import CLIAction
 from curator.cli_singletons.utils import validate_filter_json
 
 @click.command()
+@click.option('--search_pattern', type=str, default='_all', help='Elasticsearch Index Search Pattern')
 @click.option('--key', type=str, required=True, help='Node identification tag')
 @click.option('--value', type=str, default=None, help='Value associated with --key')
 @click.option('--allocation_type', type=click.Choice(['require', 'include', 'exclude']))
@@ -47,6 +48,7 @@ from curator.cli_singletons.utils import validate_filter_json
 @click.pass_context
 def allocation(
         ctx,
+        search_pattern,
         key,
         value,
         allocation_type,
@@ -61,6 +63,7 @@ def allocation(
     Shard Routing Allocation
     """
     manual_options = {
+        'search_pattern': search_pattern,
         'key': key,
         'value': value,
         'allocation_type': allocation_type,

--- a/curator/cli_singletons/close.py
+++ b/curator/cli_singletons/close.py
@@ -4,6 +4,7 @@ from curator.cli_singletons.object_class import CLIAction
 from curator.cli_singletons.utils import validate_filter_json
 
 @click.command()
+@click.option('--search_pattern', type=str, default='_all', help='Elasticsearch Index Search Pattern')
 @click.option('--delete_aliases', is_flag=True, help='Delete all aliases from indices to be closed')
 @click.option('--skip_flush', is_flag=True, help='Skip flush phase for indices to be closed')
 @click.option(
@@ -24,11 +25,14 @@ from curator.cli_singletons.utils import validate_filter_json
     required=True
 )
 @click.pass_context
-def close(ctx, delete_aliases, skip_flush, ignore_empty_list, allow_ilm_indices, filter_list):
+def close(
+        ctx, search_pattern, delete_aliases, skip_flush, ignore_empty_list, allow_ilm_indices,
+        filter_list):
     """
     Close Indices
     """
     manual_options = {
+        'search_pattern': search_pattern,
         'skip_flush': skip_flush,
         'delete_aliases': delete_aliases,
         'allow_ilm_indices': allow_ilm_indices,

--- a/curator/cli_singletons/delete.py
+++ b/curator/cli_singletons/delete.py
@@ -5,6 +5,7 @@ from curator.cli_singletons.utils import validate_filter_json
 
 #### Indices ####
 @click.command()
+@click.option('--search_pattern', type=str, default='_all', help='Elasticsearch Index Search Pattern')
 @click.option(
     '--ignore_empty_list',
     is_flag=True,
@@ -23,7 +24,7 @@ from curator.cli_singletons.utils import validate_filter_json
     required=True
 )
 @click.pass_context
-def delete_indices(ctx, ignore_empty_list, allow_ilm_indices, filter_list):
+def delete_indices(ctx, search_pattern, ignore_empty_list, allow_ilm_indices, filter_list):
     """
     Delete Indices
     """
@@ -31,7 +32,7 @@ def delete_indices(ctx, ignore_empty_list, allow_ilm_indices, filter_list):
     action = CLIAction(
         'delete_indices',
         ctx.obj['configdict'],
-        {'allow_ilm_indices':allow_ilm_indices},
+        {'search_pattern': search_pattern, 'allow_ilm_indices':allow_ilm_indices},
         filter_list,
         ignore_empty_list
     )

--- a/curator/cli_singletons/forcemerge.py
+++ b/curator/cli_singletons/forcemerge.py
@@ -4,6 +4,7 @@ from curator.cli_singletons.object_class import CLIAction
 from curator.cli_singletons.utils import validate_filter_json
 
 @click.command()
+@click.option('--search_pattern', type=str, default='_all', help='Elasticsearch Index Search Pattern')
 @click.option(
     '--max_num_segments',
     type=int,
@@ -32,11 +33,14 @@ from curator.cli_singletons.utils import validate_filter_json
     help='JSON array of filters selecting indices to act on.',
     required=True)
 @click.pass_context
-def forcemerge(ctx, max_num_segments, delay, ignore_empty_list, allow_ilm_indices, filter_list):
+def forcemerge(
+        ctx, search_pattern, max_num_segments, delay, ignore_empty_list, allow_ilm_indices,
+        filter_list):
     """
     forceMerge Indices (reduce segment count)
     """
     manual_options = {
+        'search_pattern': search_pattern,
         'max_num_segments': max_num_segments,
         'delay': delay,
         'allow_ilm_indices': allow_ilm_indices,

--- a/curator/cli_singletons/object_class.py
+++ b/curator/cli_singletons/object_class.py
@@ -76,6 +76,12 @@ class CLIAction():
             self.check_options(option_dict)
         else:
             self.options = option_dict
+
+        # Pop out search_pattern if it's there
+        self.search_pattern = '_all'
+        if 'search_pattern' in self.options:
+            self.search_pattern = self.options.pop('search_pattern')
+
         # Extract allow_ilm_indices so it can be handled separately.
         if 'allow_ilm_indices' in self.options:
             self.allow_ilm = self.options.pop('allow_ilm_indices')

--- a/curator/cli_singletons/open_indices.py
+++ b/curator/cli_singletons/open_indices.py
@@ -4,6 +4,7 @@ from curator.cli_singletons.object_class import CLIAction
 from curator.cli_singletons.utils import validate_filter_json
 
 @click.command(name='open')
+@click.option('--search_pattern', type=str, default='_all', help='Elasticsearch Index Search Pattern')
 @click.option(
     '--ignore_empty_list',
     is_flag=True,
@@ -22,7 +23,7 @@ from curator.cli_singletons.utils import validate_filter_json
     required=True
 )
 @click.pass_context
-def open_indices(ctx, ignore_empty_list, allow_ilm_indices, filter_list):
+def open_indices(ctx, search_pattern, ignore_empty_list, allow_ilm_indices, filter_list):
     """
     Open Indices
     """
@@ -30,7 +31,7 @@ def open_indices(ctx, ignore_empty_list, allow_ilm_indices, filter_list):
     action = CLIAction(
         ctx.info_name,
         ctx.obj['configdict'],
-        {'allow_ilm_indices':allow_ilm_indices},
+        {'search_pattern': search_pattern, 'allow_ilm_indices':allow_ilm_indices},
         filter_list,
         ignore_empty_list
     )

--- a/curator/cli_singletons/replicas.py
+++ b/curator/cli_singletons/replicas.py
@@ -4,6 +4,7 @@ from curator.cli_singletons.object_class import CLIAction
 from curator.cli_singletons.utils import validate_filter_json
 
 @click.command()
+@click.option('--search_pattern', type=str, default='_all', help='Elasticsearch Index Search Pattern')
 @click.option('--count', type=int, required=True, help='Number of replicas (max 10)')
 @click.option(
     '--wait_for_completion/--no-wait_for_completion',
@@ -29,11 +30,14 @@ from curator.cli_singletons.utils import validate_filter_json
     required=True
 )
 @click.pass_context
-def replicas(ctx, count, wait_for_completion, ignore_empty_list, allow_ilm_indices, filter_list):
+def replicas(
+        ctx, search_pattern, count, wait_for_completion, ignore_empty_list, allow_ilm_indices,
+        filter_list):
     """
     Change Replica Count
     """
     manual_options = {
+        'search_pattern': search_pattern,
         'count': count,
         'wait_for_completion': wait_for_completion,
         'allow_ilm_indices': allow_ilm_indices,

--- a/curator/cli_singletons/show.py
+++ b/curator/cli_singletons/show.py
@@ -11,6 +11,7 @@ from curator._version import __version__
 
 # pylint: disable=line-too-long
 @click.command(epilog=footer(__version__, tail='singleton-cli.html#_show_indicessnapshots'))
+@click.option('--search_pattern', type=str, default='_all', help='Elasticsearch Index Search Pattern')
 @click.option('--verbose', help='Show verbose output.', is_flag=True, show_default=True)
 @click.option('--header', help='Print header if --verbose', is_flag=True, show_default=True)
 @click.option('--epoch', help='Print time as epoch if --verbose', is_flag=True, show_default=True)
@@ -18,7 +19,9 @@ from curator._version import __version__
 @click.option('--allow_ilm_indices/--no-allow_ilm_indices', help='Allow Curator to operate on Index Lifecycle Management monitored indices.', default=False, show_default=True)
 @click.option('--filter_list', callback=validate_filter_json, default='{"filtertype":"none"}', help='JSON string representing an array of filters.')
 @click.pass_context
-def show_indices(ctx, verbose, header, epoch, ignore_empty_list, allow_ilm_indices, filter_list):
+def show_indices(
+        ctx, search_pattern, verbose, header, epoch, ignore_empty_list, allow_ilm_indices,
+        filter_list):
     """
     Show Indices
     """
@@ -26,7 +29,7 @@ def show_indices(ctx, verbose, header, epoch, ignore_empty_list, allow_ilm_indic
     action = CLIAction(
         'show_indices',
         ctx.obj['configdict'],
-        {'allow_ilm_indices': allow_ilm_indices},
+        {'search_pattern': search_pattern, 'allow_ilm_indices': allow_ilm_indices},
         filter_list,
         ignore_empty_list
     )

--- a/curator/cli_singletons/shrink.py
+++ b/curator/cli_singletons/shrink.py
@@ -5,6 +5,7 @@ from curator.cli_singletons.utils import json_to_dict, validate_filter_json
 
 # pylint: disable=line-too-long
 @click.command()
+@click.option('--search_pattern', type=str, default='_all', help='Elasticsearch Index Search Pattern')
 @click.option('--shrink_node', default='DETERMINISTIC', type=str, help='Named node, or DETERMINISTIC', show_default=True)
 @click.option('--node_filters', help='JSON version of node_filters (see documentation)', callback=json_to_dict)
 @click.option('--number_of_shards', default=1, type=int, help='Shrink to this many shards per index')
@@ -25,8 +26,8 @@ from curator.cli_singletons.utils import json_to_dict, validate_filter_json
 @click.option('--filter_list', callback=validate_filter_json, help='JSON array of filters selecting indices to act on.', required=True)
 @click.pass_context
 def shrink(
-        ctx, shrink_node, node_filters, number_of_shards, number_of_replicas, shrink_prefix,
-        shrink_suffix, copy_aliases, delete_after, post_allocation, extra_settings,
+        ctx, search_pattern, shrink_node, node_filters, number_of_shards, number_of_replicas,
+        shrink_prefix, shrink_suffix, copy_aliases, delete_after, post_allocation, extra_settings,
         wait_for_active_shards, wait_for_rebalance, wait_for_completion, wait_interval, max_wait,
         ignore_empty_list, allow_ilm_indices, filter_list
     ):
@@ -34,6 +35,7 @@ def shrink(
     Shrink Indices to --number_of_shards
     """
     manual_options = {
+        'search_pattern': search_pattern,
         'shrink_node': shrink_node,
         'node_filters': node_filters,
         'number_of_shards': number_of_shards,

--- a/curator/cli_singletons/snapshot.py
+++ b/curator/cli_singletons/snapshot.py
@@ -5,6 +5,7 @@ from curator.cli_singletons.utils import validate_filter_json
 
 # pylint: disable=line-too-long
 @click.command()
+@click.option('--search_pattern', type=str, default='_all', help='Elasticsearch Index Search Pattern')
 @click.option('--repository', type=str, required=True, help='Snapshot repository')
 @click.option('--name', type=str, help='Snapshot name', show_default=True, default='curator-%Y%m%d%H%M%S')
 @click.option('--ignore_unavailable', is_flag=True, show_default=True, help='Ignore unavailable shards/indices.')
@@ -19,7 +20,7 @@ from curator.cli_singletons.utils import validate_filter_json
 @click.option('--filter_list', callback=validate_filter_json, help='JSON array of filters selecting indices to act on.', required=True)
 @click.pass_context
 def snapshot(
-        ctx, repository, name, ignore_unavailable, include_global_state, partial,
+        ctx, search_pattern, repository, name, ignore_unavailable, include_global_state, partial,
         skip_repo_fs_check, wait_for_completion, wait_interval, max_wait, ignore_empty_list,
         allow_ilm_indices, filter_list
     ):
@@ -27,6 +28,7 @@ def snapshot(
     Snapshot Indices
     """
     manual_options = {
+        'search_pattern': search_pattern,
         'name': name,
         'repository': repository,
         'ignore_unavailable': ignore_unavailable,

--- a/curator/defaults/option_defaults.py
+++ b/curator/defaults/option_defaults.py
@@ -380,6 +380,12 @@ def cluster_routing_value():
     """
     return {Required('value'): Any('all', 'primaries', 'none', 'new_primaries', 'replicas')}
 
+def search_pattern():
+    """
+    :returns: ``{Optional('search_pattern', default='_all'): Any(*string_types)}``
+    """
+    return {Optional('search_pattern', default='_all'): Any(*string_types)}
+
 def shrink_node():
     """
     :returns: ``{Required('shrink_node'): Any(*string_types)}``

--- a/curator/indexlist.py
+++ b/curator/indexlist.py
@@ -18,7 +18,7 @@ from curator.validators.filter_functions import filterstructure
 
 class IndexList:
     """IndexList class"""
-    def __init__(self, client):
+    def __init__(self, client, search_pattern='_all'):
         verify_client_object(client)
         self.loggit = logging.getLogger('curator.indexlist')
         #: An :py:class:`~.elasticsearch.Elasticsearch` client object passed from param ``client``
@@ -34,7 +34,7 @@ class IndexList:
         #: All indices in the cluster at instance creation time.
         #: **Type:** :py:class:`list`
         self.all_indices = []
-        self.__get_indices()
+        self.__get_indices(search_pattern)
         self.age_keyfield = None
 
     def __actionable(self, idx):
@@ -62,12 +62,12 @@ class IndexList:
         if msg:
             self.loggit.debug('%s: %s', text, msg)
 
-    def __get_indices(self):
+    def __get_indices(self, pattern):
         """
         Pull all indices into ``all_indices``, then populate ``indices`` and ``index_info``
         """
-        self.loggit.debug('Getting all indices')
-        self.all_indices = get_indices(self.client)
+        self.loggit.debug('Getting indices matching search_pattern: "%s"', pattern)
+        self.all_indices = get_indices(self.client, search_pattern=pattern)
         self.indices = self.all_indices[:]
         # if self.indices:
         #     for index in self.indices:

--- a/curator/repomgrcli.py
+++ b/curator/repomgrcli.py
@@ -86,10 +86,13 @@ def create_repo(ctx, repo_name=None, repo_type=None, repo_settings=None, verify=
     :rtype: None
     """
     logger = logging.getLogger('curator.repomgrcli.create_repo')
-    esclient = get_client(ctx)
+    client = get_client(ctx)
+    request_body = {
+        'type': repo_type,
+        'settings': repo_settings
+    }
     try:
-        esclient.snapshot.create_repository(
-            name=repo_name, settings=repo_settings, type=repo_type, verify=verify)
+        client.snapshot.create_repository(name=repo_name, body=request_body, verify=verify)
     except ApiError as exc:
         if exc.meta.status >= 500:
             logger.critical('Server-side error!')

--- a/curator/validators/options.py
+++ b/curator/validators/options.py
@@ -22,6 +22,7 @@ def action_specific(action):
             option_defaults.extra_settings(),
         ],
         'allocation' : [
+            option_defaults.search_pattern(),
             option_defaults.key(),
             option_defaults.value(),
             option_defaults.allocation_type(),
@@ -30,6 +31,7 @@ def action_specific(action):
             option_defaults.max_wait(action),
         ],
         'close' : [
+            option_defaults.search_pattern(),
             option_defaults.delete_aliases(),
             option_defaults.skip_flush(),
         ],
@@ -42,6 +44,7 @@ def action_specific(action):
             option_defaults.max_wait(action),
         ],
         'cold2frozen' : [
+            option_defaults.search_pattern(),
             option_defaults.c2f_index_settings(),
             option_defaults.c2f_ignore_index_settings(),
             option_defaults.wait_for_completion('cold2frozen'),
@@ -51,22 +54,28 @@ def action_specific(action):
             option_defaults.ignore_existing(),
             option_defaults.extra_settings(),
         ],
-        'delete_indices' : [],
+        'delete_indices' : [
+            option_defaults.search_pattern(),
+        ],
         'delete_snapshots' : [
             option_defaults.repository(),
             option_defaults.retry_interval(),
             option_defaults.retry_count(),
         ],
         'forcemerge' : [
+            option_defaults.search_pattern(),
             option_defaults.delay(),
             option_defaults.max_num_segments(),
         ],
         'index_settings' : [
+            option_defaults.search_pattern(),
             option_defaults.index_settings(),
             option_defaults.ignore_unavailable(),
             option_defaults.preserve_existing(),
         ],
-        'open' : [],
+        'open' : [
+            option_defaults.search_pattern(),
+        ],
         'reindex' : [
             option_defaults.request_body(),
             option_defaults.refresh(),
@@ -85,6 +94,7 @@ def action_specific(action):
             option_defaults.migration_suffix(),
         ],
         'replicas' : [
+            option_defaults.search_pattern(),
             option_defaults.count(),
             option_defaults.wait_for_completion(action),
             option_defaults.wait_interval(action),
@@ -114,6 +124,7 @@ def action_specific(action):
             option_defaults.skip_repo_fs_check(),
         ],
         'snapshot' : [
+            option_defaults.search_pattern(),
             option_defaults.repository(),
             option_defaults.name(action),
             option_defaults.ignore_unavailable(),
@@ -125,6 +136,7 @@ def action_specific(action):
             option_defaults.skip_repo_fs_check(),
         ],
         'shrink' : [
+            option_defaults.search_pattern(),
             option_defaults.shrink_node(),
             option_defaults.node_filters(),
             option_defaults.number_of_shards(),

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,42 @@
 Changelog
 =========
 
+8.0.14 (2 April 2024)
+---------------------
+
+**Announcement**
+
+  * A long awaited feature has been added, stealthily. It's fully in the documentation, but I do
+    not yet plan to make a big announcement about it. In actions that search through indices, you
+    can now specify a ``search_pattern`` to limit the number of indices that will be filtered. If
+    no search pattern is specified, the behavior will be the same as it ever was: it will search
+    through ``_all`` indices. The actions that support this option are: allocation, close,
+    cold2frozen, delete_indices, forcemerge, index_settings, open, replicas, shrink, and snapshot.
+
+**Bugfix**
+
+  * A mixup with naming conventions from the PII redacter tool got in the way of the cold2frozen
+    action completing properly.
+
+**Changes**
+
+  * Version bump: ``es_client==8.13.0``
+      * With the version bump to ``es_client`` comes a necessary change to calls to create a
+        repository. In https://github.com/elastic/elasticsearch-specification/pull/2255 it became
+        clear that using ``type`` and ``settings`` as it has been was insufficient for repository
+        settings, so we go back to using a request ``body`` as in older times. This change affects
+        ``esrepomgr`` in one place, and otherwise only in snapshot/restore testing.
+  * Added the curator.helpers.getters.meta_getter to reduce near duplicate functions.
+  * Changed curator.helpers.getters.get_indices to use the _cat API to pull indices. The primary
+    driver for this is that it avoids pulling in the full mapping and index settings when all we
+    really need to return is a list of index names. This should help keep memory from ballooning
+    quite as much. The function also now allows for a search_pattern kwarg to search only for
+    indices matching a pattern. This will also potentially make the initial index return list much
+    smaller, and the list of indices needing to be filtered that much smaller.
+  * Tests were added to ensure that the changes for ``get_indices`` work everywhere.
+  * Tests were added to ensure that the new ``search_pattern`` did not break anything, and does
+    behave as expected.
+
 8.0.13 (26 March 2024)
 ----------------------
 

--- a/docs/asciidoc/actions.asciidoc
+++ b/docs/asciidoc/actions.asciidoc
@@ -153,6 +153,7 @@ defined by `wait_interval`.
 
 === Optional settings
 
+* <<option_search_pattern,search_pattern>>
 * <<option_allocation_type,allocation_type>>
 * <<option_value,value>>
 * <<option_wfc,wait_for_completion>>
@@ -191,6 +192,7 @@ aliases beforehand.
 
 === Optional settings
 
+* <<option_search_pattern,search_pattern>>
 * <<option_delete_aliases,delete_aliases>>
 * <<option_skip_flush,skip_flush>>
 * <<option_ignore_empty,ignore_empty_list>>
@@ -347,6 +349,7 @@ NOTE: If unset, the default behavior is to ensure that the `index.refresh_interv
 
 === Optional settings
 
+* <<option_search_pattern,search_pattern>>
 * <<option_wfc,wait_for_completion>>
 * <<option_ignore_empty,ignore_empty_list>>
 * <<option_timeout_override,timeout_override>>
@@ -511,6 +514,7 @@ filters:
 
 === Optional settings
 
+* <<option_search_pattern,search_pattern>>
 * <<option_ignore_empty,ignore_empty_list>>
 * <<option_timeout_override,timeout_override>>
 * <<option_continue,continue_if_exception>>
@@ -613,6 +617,7 @@ filters:
 
 === Optional settings
 
+* <<option_search_pattern,search_pattern>>
 * <<option_delay,delay>>
 * <<option_ignore_empty,ignore_empty_list>>
 * <<option_timeout_override,timeout_override>>
@@ -683,6 +688,7 @@ settings, and to be able to verify configurational integrity in the YAML file,
 
 === Optional settings
 
+* <<option_search_pattern,search_pattern>>
 * <<option_ignore_empty,ignore_empty_list>>
 * <<option_timeout_override,timeout_override>>
 * <<option_continue,continue_if_exception>>
@@ -714,6 +720,7 @@ This action opens the selected indices.
 
 === Optional settings
 
+* <<option_search_pattern,search_pattern>>
 * <<option_ignore_empty,ignore_empty_list>>
 * <<option_timeout_override,timeout_override>>
 * <<option_continue,continue_if_exception>>
@@ -836,6 +843,7 @@ defined by `wait_interval`.
 
 === Optional settings
 
+* <<option_search_pattern,search_pattern>>
 * <<option_wfc,wait_for_completion>>
 * <<option_max_wait,max_wait>>
 * <<option_wait_interval,wait_interval>>
@@ -1174,6 +1182,7 @@ as needed.
 
 === Optional settings
 
+* <<option_search_pattern,search_pattern>>
 * <<option_continue,continue_if_exception>>
 * <<option_ignore_empty,ignore_empty_list>>
 * <<option_copy_aliases,copy_aliases>>
@@ -1233,6 +1242,7 @@ read about them and change them accordingly.
 
 === Optional settings
 
+* <<option_search_pattern,search_pattern>>
 * <<option_name,name>>
 * <<option_ignore,ignore_unavailable>>
 * <<option_include_gs,include_global_state>>

--- a/docs/asciidoc/index.asciidoc
+++ b/docs/asciidoc/index.asciidoc
@@ -1,9 +1,9 @@
-:curator_version: 8.0.13
+:curator_version: 8.0.14
 :curator_major: 8
 :curator_doc_tree: 8.0
-:es_py_version: 8.12.1
-:es_doc_tree: 8.12
-:stack_doc_tree: 8.12
+:es_py_version: 8.13.0
+:es_doc_tree: 8.13
+:stack_doc_tree: 8.13
 :pybuild_ver: 3.11.7
 :copyright_years: 2011-2024
 :ref:  http://www.elastic.co/guide/en/elasticsearch/reference/{es_doc_tree}

--- a/docs/asciidoc/options.asciidoc
+++ b/docs/asciidoc/options.asciidoc
@@ -48,6 +48,7 @@ Options are settings used by <<actions,actions>>.
 * <<option_retry_count,retry_count>>
 * <<option_retry_interval,retry_interval>>
 * <<option_routing_type,routing_type>>
+* <<option_search_pattern,search_pattern>>
 * <<option_setting,setting>>
 * <<option_shrink_node,shrink_node>>
 * <<option_slices,slices>>
@@ -2150,6 +2151,30 @@ The value of this setting must be either `allocation` or `rebalance`
 
 There is no default value. This setting must be set by the user or an exception
 will be raised, and execution will halt.
+
+[[option_search_pattern]]
+== search_pattern
+
+NOTE: This setting is only used by the
+  <<allocation>>, <<close>>, <<cold2frozen>>, <<delete_indices>>, <<forcemerge>>,
+  <<index_settings>>, <<open>>, <<replicas>>, <<shrink>>, and <<snapshot>> actions.
+
+[source,yaml]
+-------------
+action: delete_indices
+description: "Delete selected indices"
+options:
+  search_pattern: 'index-*'
+filters:
+- filtertype: ...
+-------------
+
+The value of this option can be a comma-separated list of data streams, indices, and aliases used
+to limit the request. Supports wildcards (*). To target all data streams and indices, omit this
+parameter or use * or _all. If using wildcards it is highly recommended to encapsulate the entire
+search pattern in single quotes, e.g. `search_pattern: 'a*,b*,c*'`
+
+The default value is `_all`.
 
 [[option_setting]]
 == setting

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,8 +72,8 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 
 intersphinx_mapping = {
 	'python': ('https://docs.python.org/3.11', None),
-    'es_client': ('https://es-client.readthedocs.io/en/v8.12.9', None),
-	'elasticsearch8': ('https://elasticsearch-py.readthedocs.io/en/v8.12.1', None),
+    'es_client': ('https://es-client.readthedocs.io/en/v8.13.0', None),
+	'elasticsearch8': ('https://elasticsearch-py.readthedocs.io/en/v8.13.0', None),
     'voluptuous': ('http://alecthomas.github.io/voluptuous/docs/_build/html', None),
     'click': ('https://click.palletsprojects.com/en/8.1.x', None),
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ keywords = [
     'index-expiry'
 ]
 dependencies = [
-    "es_client==8.12.9"
+    "es_client==8.13.0"
 ]
 
 [project.optional-dependencies]

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -178,8 +178,11 @@ class CuratorTestCase(TestCase):
         )
 
     def create_repository(self):
-        args = {'location': self.args['location']}
-        self.client.snapshot.create_repository(name=self.args['repository'], type='fs', settings=args)
+        request_body = {
+            'type': 'fs',
+            'settings': {'location': self.args['location']}
+        }
+        self.client.snapshot.create_repository(name=self.args['repository'], body=request_body)
 
     def delete_repositories(self):
         result = self.client.snapshot.get_repository(name='*')

--- a/tests/integration/test_integrations.py
+++ b/tests/integration/test_integrations.py
@@ -149,3 +149,13 @@ class TestIndexList(CuratorTestCase):
         ilo.get_index_stats()
         ilo.get_index_stats() # This time index_info is already populated and it will skip
         assert ilo.index_info[self.IDX1][key] == 0
+    def test_search_pattern_1(self):
+        """Check to see if providing a search_pattern limits the index list"""
+        pattern = 'd*'
+        self.create_index(self.IDX1)
+        self.create_index(self.IDX2)
+        self.create_index(self.IDX3)
+        ilo1 = IndexList(self.client)
+        ilo2 = IndexList(self.client, search_pattern=pattern)
+        assert ilo1.indices == [self.IDX1, self.IDX2, self.IDX3]
+        assert ilo2.indices == [self.IDX1, self.IDX2]

--- a/tests/unit/test_action_cold2frozen.py
+++ b/tests/unit/test_action_cold2frozen.py
@@ -38,7 +38,6 @@ class TestActionCold2Frozen(TestCase):
         settings_ss   = {
             testvars.named_index: {
                 'aliases': {'my_alias': {}},
-                'mappings': {},
                 'settings': {
                     'index': {
                         'creation_date': '1456963200172',
@@ -58,7 +57,9 @@ class TestActionCold2Frozen(TestCase):
                 }
             }
         }
-        self.client.indices.get.return_value = settings_ss
+
+        self.client.indices.get_settings.return_value = settings_ss
+        self.client.indices.get_alias.return_value = settings_ss
         roles = ['data_content']
         self.client.nodes.info.return_value = {'nodes': {'nodename': {'roles': roles}}}
         c2f = Cold2Frozen(self.ilo)
@@ -92,7 +93,7 @@ class TestActionCold2Frozen(TestCase):
                 'settings': {'index': {'lifecycle': {'name': 'guaranteed_fail'}}}
             }
         }
-        self.client.indices.get.return_value = settings_ss
+        self.client.indices.get_settings.return_value = settings_ss
         c2f = Cold2Frozen(self.ilo)
         with pytest.raises(CuratorException, match='associated with an ILM policy'):
             for result in c2f.action_generator():
@@ -110,7 +111,7 @@ class TestActionCold2Frozen(TestCase):
                 }
             }
         }
-        self.client.indices.get.return_value = settings_ss
+        self.client.indices.get_settings.return_value = settings_ss
         c2f = Cold2Frozen(self.ilo)
         with pytest.raises(SearchableSnapshotException, match='Index is already in frozen tier'):
             for result in c2f.action_generator():

--- a/tests/unit/test_action_restore.py
+++ b/tests/unit/test_action_restore.py
@@ -100,6 +100,7 @@ class TestActionRestore(TestCase):
         client.info.return_value = {'version': {'number': '5.0.0'} }
         client.snapshot.get.return_value = testvars.snapshot
         client.snapshot.get_repository.return_value = testvars.test_repo
+        client.cat.indices.return_value = testvars.state_named
         client.indices.get_settings.return_value = testvars.settings_named
         slo = SnapshotList(client, repository=testvars.repo_name)
         ro = Restore(slo)
@@ -109,6 +110,7 @@ class TestActionRestore(TestCase):
         client.info.return_value = {'version': {'number': '5.0.0'} }
         client.snapshot.get.return_value = testvars.snapshots
         client.snapshot.get_repository.return_value = testvars.test_repo
+        client.cat.indices.return_value = testvars.state_one
         client.indices.get_settings.return_value = testvars.settings_one
         slo = SnapshotList(client, repository=testvars.repo_name)
         ro = Restore(
@@ -121,6 +123,7 @@ class TestActionRestore(TestCase):
         client.snapshot.get_repository.return_value = testvars.test_repo
         client.snapshot.status.return_value = testvars.nosnap_running
         client.snapshot.verify_repository.return_value = testvars.verified_nodes
+        client.cat.indices.return_value = testvars.state_named
         client.indices.get_settings.return_value = testvars.settings_named
         client.indices.recovery.return_value = testvars.recovery_output
         slo = SnapshotList(client, repository=testvars.repo_name)

--- a/tests/unit/test_class_index_list.py
+++ b/tests/unit/test_class_index_list.py
@@ -52,7 +52,7 @@ class TestIndexListClientAndInit(TestCase):
         self.assertRaises(TypeError, IndexList, client)
     def test_init_get_indices_exception(self):
         self.builder()
-        self.client.indices.get_settings.side_effect = testvars.fake_fail
+        self.client.cat.indices.side_effect = testvars.fake_fail
         self.assertRaises(FailedExecution, IndexList, self.client)
     def test_init(self):
         self.builder()


### PR DESCRIPTION
**Announcement**

  * A long awaited feature has been added, stealthily. It's fully in the documentation, but I do
    not yet plan to make a big announcement about it. In actions that search through indices, you
    can now specify a ``search_pattern`` to limit the number of indices that will be filtered. If
    no search pattern is specified, the behavior will be the same as it ever was: it will search
    through ``_all`` indices. The actions that support this option are: allocation, close,
    cold2frozen, delete_indices, forcemerge, index_settings, open, replicas, shrink, and snapshot.

**Bugfix**

  * A mixup with naming conventions from the PII redacter tool got in the way of the cold2frozen
    action completing properly.

**Changes**

  * Version bump: ``es_client==8.13.0``
      * With the version bump to ``es_client`` comes a necessary change to calls to create a
        repository. In https://github.com/elastic/elasticsearch-specification/pull/2255 it became
        clear that using ``type`` and ``settings`` as it has been was insufficient for repository
        settings, so we go back to using a request ``body`` as in older times. This change affects
        ``esrepomgr`` in one place, and otherwise only in snapshot/restore testing.
  * Added the curator.helpers.getters.meta_getter to reduce near duplicate functions.
  * Changed curator.helpers.getters.get_indices to use the _cat API to pull indices. The primary
    driver for this is that it avoids pulling in the full mapping and index settings when all we
    really need to return is a list of index names. This should help keep memory from ballooning
    quite as much. The function also now allows for a search_pattern kwarg to search only for
    indices matching a pattern. This will also potentially make the initial index return list much
    smaller, and the list of indices needing to be filtered that much smaller.
  * Tests were added to ensure that the changes for ``get_indices`` work everywhere.
  * Tests were added to ensure that the new ``search_pattern`` did not break anything, and does
    behave as expected.