### PR TITLE
Release prep for 8.0.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
-ARG PYVER=3.11.7
-ARG ALPTAG=3.18
+ARG PYVER=3.11.9
+ARG ALPTAG=3.19
 FROM python:${PYVER}-alpine${ALPTAG} as builder
 
 # Add the community repo for access to patchelf binary package

--- a/curator/_version.py
+++ b/curator/_version.py
@@ -1,2 +1,2 @@
 """Curator Version"""
-__version__ = '8.0.14'
+__version__ = '8.0.15'

--- a/curator/actions/alias.py
+++ b/curator/actions/alias.py
@@ -98,7 +98,7 @@ class Alias:
 
             # Re-raise the exceptions.NoIndices so it will behave as before
             raise NoIndices('No indices to remove from alias') from exc
-        aliases = self.client.indices.get_alias()
+        aliases = self.client.indices.get_alias(expand_wildcards=['open', 'closed'])
         for index in ilo.working_list():
             if index in aliases:
                 self.loggit.debug('Index %s in get_aliases output', index)

--- a/curator/indexlist.py
+++ b/curator/indexlist.py
@@ -927,7 +927,6 @@ class IndexList:
     def filter_by_count(self, count=None, reverse=True, use_age=False, pattern=None,
             source='creation_date', timestring=None, field=None, stats_result='min_value',
             exclude=True):
-        # pylint: disable=anomalous-backslash-in-string
         """
         Remove indices from the actionable list beyond the number ``count``, sorted
         reverse-alphabetically by default.  If you set ``reverse=False``, it will be sorted
@@ -951,7 +950,7 @@ class IndexList:
         :param pattern: Select indices to count from a regular expression pattern. This pattern
             must have one and only one capture group. This can allow a single ``count`` filter
             instance to operate against any number of matching patterns, and keep ``count`` of each
-            index in that group.  For example, given a ``pattern`` of ``'^(.*)-\d{6}$'``, it will
+            index in that group.  For example, given a ``pattern`` of ``'^(.*)-\\d{6}$'``, it will
             match both ``rollover-000001`` and ``index-999990``, but not ``logstash-2017.10.12``.
             Following the same example, if my cluster also had ``rollover-000002`` through
             ``rollover-000010`` and ``index-888888`` through ``index-999999``, it will process both

--- a/docker_test/.env
+++ b/docker_test/.env
@@ -1,0 +1,1 @@
+export REMOTE_ES_SERVER="http://172.19.2.14:9201"

--- a/docker_test/scripts/create.sh
+++ b/docker_test/scripts/create.sh
@@ -127,13 +127,11 @@ echo "Please select one of these environment variables to prepend your 'pytest' 
 echo
 
 for IP in $IPLIST; do
-  echo "REMOTE_ES_SERVER=\"http://$IP:${REMOTE_PORT}\""
-  if [ "$AUTO_EXPORT" == "y" ]; then
-    # This puts our curatortestenv file where it can be purged easily by destroy.sh
-    cd $SCRIPTPATH
-    cd ..
-    echo "export REMOTE_ES_SERVER=http://$IP:$REMOTE_PORT" > curatortestenv
-  fi
+  REMOTE="REMOTE_ES_SERVER=\"http://$IP:${REMOTE_PORT}\""
+  echo ${REMOTE}
+  cd $SCRIPTPATH
+  cd ..
+  echo "export ${REMOTE}" > .env
 done
 
 echo

--- a/docker_test/scripts/destroy.sh
+++ b/docker_test/scripts/destroy.sh
@@ -26,7 +26,7 @@ UPONE=$(pwd | awk -F\/ '{print $NF}')
 
 if [[ "$UPONE" = "docker_test" ]]; then
   rm -rf $(pwd)/repo/*
-  rm -rf $(pwd)/curatortestenv
+  cp /dev/null $(pwd)/.env
 else
   echo "WARNING: Unable to automatically empty bind mounted repo path."
   echo "Please manually empty the contents of the repo directory!"

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,36 @@
 Changelog
 =========
 
+8.0.15 (10 April 2024)
+----------------------
+
+**Announcement**
+
+  * Python 3.12 support becomes official. A few changes were necessary to ``datetime`` calls
+    which were still using naive timestamps. Tests across all minor Python versions from 3.8 - 3.12
+    verify everything is working as expected with regards to those changes. Note that Docker builds
+    are still running Python 3.11 as cx_Freeze still does not officially support Python 3.12.
+  * Added infrastructure to test multiple versions of Python against the code base. This requires
+    you to run:
+        * ``pip install -U hatch hatchling`` -- Install prerequisites
+        * ``hatch run docker:create X.Y.Z`` -- where ``X.Y.Z`` is an ES version on Docker Hub
+        * ``hatch run test:pytest`` -- Run the test suite for each supported version of Python
+        * ``hatch run docker:destroy`` -- Cleanup the Docker containers created in ``docker:create``
+
+**Bugfix**
+
+  * A bug reported in ``es_client`` with Python versions 3.8 and 3.9 has been addressed. Going
+    forward, testing protocol will be to ensure that Curator works with all supported versions of
+    Python, or support will be removed (when 3.8 is EOL, for example).
+
+**Changes**
+
+  * Address deprecation warning in ``get_alias()`` call by limiting indices to only open and
+    closed indices via ``expand_wildcards=['open', 'closed']``.
+  * Address test warnings for an improperly escaped ``\d`` in a docstring in ``indexlist.py``
+  * Updated Python version in Docker build. See Dockerfile for more information.
+  * Docker test scripts updated to make Hatch matrix testing easier (.env file)
+
 8.0.14 (2 April 2024)
 ---------------------
 

--- a/docs/asciidoc/index.asciidoc
+++ b/docs/asciidoc/index.asciidoc
@@ -1,10 +1,10 @@
-:curator_version: 8.0.14
+:curator_version: 8.0.15
 :curator_major: 8
 :curator_doc_tree: 8.0
 :es_py_version: 8.13.0
 :es_doc_tree: 8.13
 :stack_doc_tree: 8.13
-:pybuild_ver: 3.11.7
+:pybuild_ver: 3.11.9
 :copyright_years: 2011-2024
 :ref:  http://www.elastic.co/guide/en/elasticsearch/reference/{es_doc_tree}
 :esref: http://www.elastic.co/guide/en/elasticsearch/reference/{stack_doc_tree}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 
 intersphinx_mapping = {
 	'python': ('https://docs.python.org/3.11', None),
-    'es_client': ('https://es-client.readthedocs.io/en/v8.13.0', None),
+    'es_client': ('https://es-client.readthedocs.io/en/v8.13.1', None),
 	'elasticsearch8': ('https://elasticsearch-py.readthedocs.io/en/v8.13.0', None),
     'voluptuous': ('http://alecthomas.github.io/voluptuous/docs/_build/html', None),
     'click': ('https://click.palletsprojects.com/en/8.1.x', None),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 keywords = [
     'elasticsearch',
@@ -28,7 +29,7 @@ keywords = [
     'index-expiry'
 ]
 dependencies = [
-    "es_client==8.13.0"
+    "es_client==8.13.1"
 ]
 
 [project.optional-dependencies]
@@ -74,27 +75,40 @@ exclude = [
     "tests",
 ]
 
+### Docker Environment
+[tool.hatch.envs.docker]
+platforms = ["linux", "macos"]
+
+[tool.hatch.envs.docker.scripts]
+create = "docker_test/scripts/create.sh {args}"
+destroy = "docker_test/scripts/destroy.sh"
+
+### Lint environment
+[tool.hatch.envs.lint.scripts]
+run-pyright = "pyright {args:.}"
+run-black = "black --quiet --check --diff {args:.}"
+run-ruff = "ruff check --quiet {args:.}"
+run-curlylint = "curlylint {args:.}"
+python = ["run-pyright", "run-black", "run-ruff"]
+templates = ["run-curlylint"]
+all = ["python", "templates"]
+
+### Test environment
 [tool.hatch.envs.test]
+platforms = ["linux", "macos"]
 dependencies = [
-    "coverage[toml]",
     "requests",
     "pytest >=7.2.1",
-    "pytest-cov",
+    "pytest-cov"
 ]
 
-[tool.hatch.envs.test.scripts]
-step0 = "$(docker_test/scripts/destroy.sh 2&>1 /dev/null)"
-step1 = "step0 ; echo 'Starting test environment in Docker...' ; $(AUTO_EXPORT=y docker_test/scripts/create.sh 8.12.1 2&>1 /dev/null)"
-step2 = "step1 ; source docker_test/curatortestenv; echo 'Running tests:'"
-step3 = "step2 ; pytest ; EXITCODE=$?"
-step4 = "step3 ; echo 'Tests complete! Destroying Docker test environment...' "
-full = "step4 ; $(docker_test/scripts/destroy.sh 2&>1 /dev/null ) ;  exit $EXITCODE"
-run-coverage = "pytest --cov-config=pyproject.toml --cov=curator --cov=tests"
-run = "run-coverage --no-cov"
-
 [[tool.hatch.envs.test.matrix]]
-python = ["3.9", "3.10", "3.11"]
-version = ["8.0.11"]
+python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
+[tool.hatch.envs.test.scripts]
+pytest = "source docker_test/.env; pytest"
+pytest-cov = "source docker_test/.env; pytest --cov=curator"
+pytest-cov-report = "source docker_test/.env; pytest --cov=curator --cov-report=term-missing"
 
 [tool.pytest.ini_options]
 pythonpath = [".", "curator"]

--- a/tests/integration/test_alias.py
+++ b/tests/integration/test_alias.py
@@ -2,7 +2,7 @@
 # pylint: disable=missing-function-docstring, missing-class-docstring, invalid-name, line-too-long
 import os
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import pytest
 from elasticsearch8.exceptions import NotFoundError
 from . import CuratorTestCase
@@ -76,7 +76,7 @@ class TestActionFileAlias(CuratorTestCase):
         assert expected == self.client.indices.get_alias(name=alias)
     def test_add_and_remove_datemath(self):
         alias = '<testalias-{now-1d/d}>'
-        alias_parsed = f"testalias-{(datetime.utcnow()-timedelta(days=1)).strftime('%Y.%m.%d')}"
+        alias_parsed = f"testalias-{(datetime.now(timezone.utc)-timedelta(days=1)).strftime('%Y.%m.%d')}"
         self.write_config(self.args['configfile'], testvars.client_config.format(HOST))
         self.write_config(self.args['actionfile'], testvars.alias_add_remove.format(alias))
         idx1, idx2 = ('dummy', 'my_index')

--- a/tests/integration/test_datemath.py
+++ b/tests/integration/test_datemath.py
@@ -1,6 +1,6 @@
 """Test date math with indices"""
 # pylint: disable=missing-function-docstring, missing-class-docstring, line-too-long
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta, timezone
 from curator.helpers.date_ops import parse_datemath
 
 from . import CuratorTestCase
@@ -13,12 +13,12 @@ class TestParseDateMath(CuratorTestCase):
     #     assert expected == parse_datemath(self.client, test_string)
     def test_assorted_datemaths(self):
         for test_string, expected in [
-            ('<prefix-{now}-suffix>', f"prefix-{datetime.utcnow().strftime('%Y.%m.%d')}-suffix"),
-            ('<prefix-{now-1d/d}>', f"prefix-{(datetime.utcnow()-timedelta(days=1)).strftime('%Y.%m.%d')}"),
-            ('<{now+1d/d}>', f"{(datetime.utcnow()+timedelta(days=1)).strftime('%Y.%m.%d')}"),
-            ('<{now+1d/d}>', f"{(datetime.utcnow()+timedelta(days=1)).strftime('%Y.%m.%d')}"),
-            ('<{now+10d/d{yyyy-MM}}>', f"{(datetime.utcnow()+timedelta(days=10)).strftime('%Y-%m')}"),
+            ('<prefix-{now}-suffix>', f"prefix-{datetime.now(timezone.utc).strftime('%Y.%m.%d')}-suffix"),
+            ('<prefix-{now-1d/d}>', f"prefix-{(datetime.now(timezone.utc)-timedelta(days=1)).strftime('%Y.%m.%d')}"),
+            ('<{now+1d/d}>', f"{(datetime.now(timezone.utc)+timedelta(days=1)).strftime('%Y.%m.%d')}"),
+            ('<{now+1d/d}>', f"{(datetime.now(timezone.utc)+timedelta(days=1)).strftime('%Y.%m.%d')}"),
+            ('<{now+10d/d{yyyy-MM}}>', f"{(datetime.now(timezone.utc)+timedelta(days=10)).strftime('%Y-%m')}"),
             ### This test will remain commented until https://github.com/elastic/elasticsearch/issues/92892 is resolved
-            # ('<{now+10d/h{yyyy-MM-dd-HH|-07:00}}>', f"{(datetime.utcnow()+timedelta(days=10)-timedelta(hours=7)).strftime('%Y-%m-%d-%H')}"),
+            # ('<{now+10d/h{yyyy-MM-dd-HH|-07:00}}>', f"{(datetime.now(timezone.utc)+timedelta(days=10)-timedelta(hours=7)).strftime('%Y-%m-%d-%H')}"),
           ]:
             assert expected == parse_datemath(self.client, test_string)

--- a/tests/integration/test_snapshot.py
+++ b/tests/integration/test_snapshot.py
@@ -1,7 +1,7 @@
 """Test snapshot action functionality"""
 # pylint: disable=missing-function-docstring, missing-class-docstring, line-too-long
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from curator.helpers.getters import get_indices, get_snapshot
 from . import CuratorTestCase
 from . import testvars
@@ -23,7 +23,7 @@ class TestActionFileSnapshot(CuratorTestCase):
         self.create_indices(5)
         self.create_repository()
         snap_name = '<snapshot-{now-1d/d}>'
-        snap_name_parsed = f"snapshot-{(datetime.utcnow()-timedelta(days=1)).strftime('%Y.%m.%d')}"
+        snap_name_parsed = f"snapshot-{(datetime.now(timezone.utc)-timedelta(days=1)).strftime('%Y.%m.%d')}"
         self.write_config(self.args['configfile'], testvars.client_config.format(HOST))
         self.write_config(self.args['actionfile'], testvars.snapshot_test.format(self.args['repository'], snap_name, 1, 30))
         self.invoke_runner()

--- a/tests/unit/test_helpers_date_ops.py
+++ b/tests/unit/test_helpers_date_ops.py
@@ -1,8 +1,8 @@
 """test_helpers_date_ops"""
-from unittest import TestCase
 from datetime import datetime
-import pytest
+from unittest import TestCase
 from unittest.mock import Mock
+import pytest
 from elasticsearch8 import NotFoundError
 from elastic_transport import ApiResponseMeta
 from curator.exceptions import ConfigurationError


### PR DESCRIPTION
**Announcement**

  * Python 3.12 support becomes official. A few changes were necessary to ``datetime`` calls
    which were still using naive timestamps. Tests across all minor Python versions from 3.8 - 3.12
    verify everything is working as expected with regards to those changes. Note that Docker builds
    are still running Python 3.11 as cx_Freeze still does not officially support Python 3.12.
  * Added infrastructure to test multiple versions of Python against the code base. This requires
    you to run:
        * ``pip install -U hatch hatchling`` -- Install prerequisites
        * ``hatch run docker:create X.Y.Z`` -- where ``X.Y.Z`` is an ES version on Docker Hub
        * ``hatch run test:pytest`` -- Run the test suite for each supported version of Python
        * ``hatch run docker:destroy`` -- Cleanup the Docker containers created in ``docker:create``

**Bugfix**

  * A bug reported in ``es_client`` with Python versions 3.8 and 3.9 has been addressed. Going
    forward, testing protocol will be to ensure that Curator works with all supported versions of
    Python, or support will be removed (when 3.8 is EOL, for example).

**Changes**

  * Address deprecation warning in ``get_alias()`` call by limiting indices to only open and
    closed indices via ``expand_wildcards=['open', 'closed']``.
  * Address test warnings for an improperly escaped ``\d`` in a docstring in ``indexlist.py``
  * Updated Python version in Docker build. See Dockerfile for more information.
  * Docker test scripts updated to make Hatch matrix testing easier (.env file)