### PR TITLE
Fix unescaped characater error in docstring

### DIFF
--- a/curator/indexlist.py
+++ b/curator/indexlist.py
@@ -883,7 +883,7 @@ class IndexList(object):
         source='creation_date', timestring=None, field=None,
         stats_result='min_value', exclude=True):
         # pylint: disable=W1401
-        """
+        r"""
         Remove indices from the actionable list beyond the number `count`,
         sorted reverse-alphabetically by default.  If you set `reverse` to
         `False`, it will be sorted alphabetically.


### PR DESCRIPTION
There is an unescaped character in the docstring of `indexlist` module which has been [deprecated since Python 3.6](https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior).

This causes an issue during `pytest`'s test collection phase when running tests on modules that import curator as a library on later versions of Python: `"SyntaxError: invalid escape sequence '\d'"`

In popular python linters e.g. ruff and flake8 this [violates rule W605](https://docs.astral.sh/ruff/rules/invalid-escape-sequence/).

Upon linting the entire source code, this is the only file that has this rule violation. This commit fixes this error.
![LintForW605](https://github.com/elastic/curator/assets/46828701/26df5f4f-3485-4ff9-b4bf-21adff152e87)

The change has been tested by modifying a local copy of the library and running my test suite that originally failed against it, and the exception no longer occurs.

## Proposed Changes
* Fix docstring unescaped character error, specifically for 7.x releases.
