### PR TITLE
Fix wrong log level for several debug messages

### DIFF
--- a/curator/cli.py
+++ b/curator/cli.py
@@ -88,7 +88,7 @@ def process_action(client, action_def, dry_run=False):
     mykwargs = {}
     search_pattern = '_all'
 
-    logger.critical('INITIAL Action kwargs: %s', mykwargs)
+    logger.debug('INITIAL Action kwargs: %s', mykwargs)
     # Add some settings to mykwargs...
     if action_def.action == 'delete_indices':
         mykwargs['master_timeout'] = 30
@@ -101,7 +101,7 @@ def process_action(client, action_def, dry_run=False):
         search_pattern = mykwargs.pop('search_pattern')
 
     logger.debug('Action kwargs: %s', mykwargs)
-    logger.critical('Post search_pattern Action kwargs: %s', mykwargs)
+    logger.debug('Post search_pattern Action kwargs: %s', mykwargs)
 
     ### Set up the action ###
     logger.debug('Running "%s"', action_def.action.upper())
@@ -130,7 +130,7 @@ def process_action(client, action_def, dry_run=False):
         else:
             action_def.instantiate('list_obj', client, search_pattern=search_pattern)
         action_def.list_obj.iterate_filters({'filters': action_def.filters})
-        logger.critical('Pre Instantiation Action kwargs: %s', mykwargs)
+        logger.debug('Pre Instantiation Action kwargs: %s', mykwargs)
         action_def.instantiate('action_cls', action_def.list_obj, **mykwargs)
     ### Do the action
     if dry_run:


### PR DESCRIPTION
This PR fixes some (forgotten?) debug statements logged with CRITICAL level.

Example output of a normal curator 8.0.15 run:
```
Jul  4 06:00:09 elk01 curator[527005]: 2024-07-04 06:00:09,741 CRITICAL  INITIAL Action kwargs: {}
Jul  4 06:00:09 elk01 curator[527005]: 2024-07-04 06:00:09,741 CRITICAL  Post search_pattern Action kwargs: {'ignore_unavailable': False, 'include_global_state': True, 'partial': False, 'repository': 'my_backup', '
skip_repo_fs_check': False, 'wait_for_completion': True, 'max_wait': -1, 'wait_interval': 9, 'name': 'curator-%Y%m%d%H%M%S'}
Jul  4 06:00:09 elk01 curator[527005]: 2024-07-04 06:00:09,886 CRITICAL  Pre Instantiation Action kwargs: {'ignore_unavailable': False, 'include_global_state': True, 'partial': False, 'repository': 'my_backup', 'sk
ip_repo_fs_check': False, 'wait_for_completion': True, 'max_wait': -1, 'wait_interval': 9, 'name': 'curator-%Y%m%d%H%M%S'}
Jul  4 06:00:37 elk01 curator[527005]: 2024-07-04 06:00:37,148 CRITICAL  INITIAL Action kwargs: {}
Jul  4 06:00:37 elk01 curator[527005]: 2024-07-04 06:00:37,148 CRITICAL  Post search_pattern Action kwargs: {'repository': 'my_backup', 'retry_interval': 120, 'retry_count': 3}
Jul  4 06:00:41 elk01 curator[527005]: 2024-07-04 06:00:41,593 CRITICAL  Pre Instantiation Action kwargs: {'retry_interval': 120, 'retry_count': 3}
```