### PR TITLE
Fix/name based ages

### DIFF
--- a/curator/indexlist.py
+++ b/curator/indexlist.py
@@ -2,6 +2,8 @@
 import re
 import itertools
 import logging
+import sys
+
 from elasticsearch8.exceptions import NotFoundError, TransportError
 from es_client.helpers.schemacheck import SchemaCheck
 from es_client.helpers.utils import ensure_list
@@ -426,6 +428,8 @@ class IndexList:
             epoch = tstr.get_epoch(index)
             if isinstance(epoch, int):
                 self.index_info[index]['age']['name'] = epoch
+            else:
+                self.index_info[index]['age']['name'] = sys.maxsize
 
 
     def _get_field_stats_dates(self, field='@timestamp'):

--- a/tests/integration/test_delete_indices.py
+++ b/tests/integration/test_delete_indices.py
@@ -55,7 +55,6 @@ class TestActionFileDeleteIndices(CuratorTestCase):
                 'age', 'name', 'older', '\'%Y.%m.%d\'', 'days', 30, '_([0-9]+)_', ' ', ' ', ' '))
         self.invoke_runner()
         self.assertEqual(15, len(exclude_ilm_history(get_indices(self.client))))
-
     def test_retention_from_name_days_keep_exclude_false_after_failed_match(self):
         # Test extraction of unit_count from index name and confirm correct
         # behavior after a failed regex match with no fallback time - see gh issue 1206


### PR DESCRIPTION
Fixes #1727 

## Proposed Changes

Discard any index that do not match the timestring provided to avoid keeping the 0 age value.
Add 2 tests that were failing before this fix. 
