### PR TITLE
Add option include_hidden

### DIFF
--- a/curator/cli.py
+++ b/curator/cli.py
@@ -128,18 +128,23 @@ def process_action(client, action_def, dry_run=False):
     mykwargs.update(prune_nones(action_def.options))
 
     # Pop out the search_pattern option, if present.
-    search_pattern = mykwargs.pop('search_pattern', '*')
+    ptrn = mykwargs.pop('search_pattern', '*')
+    hidn = mykwargs.pop('include_hidden', False)
 
     logger.debug('Action kwargs: %s', mykwargs)
-    logger.debug('Post search_pattern Action kwargs: %s', mykwargs)
+    logger.debug('Post search_pattern & include_hidden Action kwargs: %s', mykwargs)
 
     # Set up the action
     logger.debug('Running "%s"', action_def.action.upper())
     if action_def.action == 'alias':
         # Special behavior for this action, as it has 2 index lists
         action_def.instantiate('action_cls', **mykwargs)
-        action_def.instantiate('alias_adds', client, search_pattern=search_pattern)
-        action_def.instantiate('alias_removes', client, search_pattern=search_pattern)
+        action_def.instantiate(
+            'alias_adds', client, search_pattern=ptrn, include_hidden=hidn
+        )
+        action_def.instantiate(
+            'alias_removes', client, search_pattern=ptrn, include_hidden=hidn
+        )
         if 'remove' in action_def.action_dict:
             logger.debug('Removing indices from alias "%s"', action_def.options['name'])
             action_def.alias_removes.iterate_filters(action_def.action_dict['remove'])
@@ -163,7 +168,9 @@ def process_action(client, action_def, dry_run=False):
                 'list_obj', client, repository=action_def.options['repository']
             )
         else:
-            action_def.instantiate('list_obj', client, search_pattern=search_pattern)
+            action_def.instantiate(
+                'list_obj', client, search_pattern=ptrn, include_hidden=hidn
+            )
         action_def.list_obj.iterate_filters({'filters': action_def.filters})
         logger.debug('Pre Instantiation Action kwargs: %s', mykwargs)
         action_def.instantiate('action_cls', action_def.list_obj, **mykwargs)

--- a/curator/cli_singletons/alias.py
+++ b/curator/cli_singletons/alias.py
@@ -36,9 +36,22 @@ from curator.cli_singletons.utils import json_to_dict, validate_filter_json
     default=False,
     show_default=True,
 )
+@click.option(
+    '--include_hidden/--no-include_hidden',
+    help='Allow Curator to operate on hidden indices (and data_streams).',
+    default=False,
+    show_default=True,
+)
 @click.pass_context
 def alias(
-    ctx, name, add, remove, warn_if_no_indices, extra_settings, allow_ilm_indices
+    ctx,
+    name,
+    add,
+    remove,
+    warn_if_no_indices,
+    extra_settings,
+    allow_ilm_indices,
+    include_hidden,
 ):
     """
     Add/Remove Indices to/from Alias
@@ -48,6 +61,7 @@ def alias(
         'name': name,
         'extra_settings': extra_settings,
         'allow_ilm_indices': allow_ilm_indices,
+        'include_hidden': include_hidden,
     }
     logger.debug('manual_options %s', manual_options)
     # ctx.info_name is the name of the function or name specified in

--- a/curator/cli_singletons/allocation.py
+++ b/curator/cli_singletons/allocation.py
@@ -44,6 +44,12 @@ from curator.cli_singletons.utils import validate_filter_json
     show_default=True,
 )
 @click.option(
+    '--include_hidden/--no-include_hidden',
+    help='Allow Curator to operate on hidden indices (and data_streams).',
+    default=False,
+    show_default=True,
+)
+@click.option(
     '--filter_list',
     callback=validate_filter_json,
     help='JSON array of filters selecting indices to act on.',
@@ -61,6 +67,7 @@ def allocation(
     wait_interval,
     ignore_empty_list,
     allow_ilm_indices,
+    include_hidden,
     filter_list,
 ):
     """
@@ -75,6 +82,7 @@ def allocation(
         'max_wait': max_wait,
         'wait_interval': wait_interval,
         'allow_ilm_indices': allow_ilm_indices,
+        'include_hidden': include_hidden,
     }
     # ctx.info_name is the name of the function or name specified in
     # @click.command decorator

--- a/curator/cli_singletons/close.py
+++ b/curator/cli_singletons/close.py
@@ -29,6 +29,12 @@ from curator.cli_singletons.utils import validate_filter_json
     show_default=True,
 )
 @click.option(
+    '--include_hidden/--no-include_hidden',
+    help='Allow Curator to operate on hidden indices (and data_streams).',
+    default=False,
+    show_default=True,
+)
+@click.option(
     '--filter_list',
     callback=validate_filter_json,
     help='JSON array of filters selecting indices to act on.',
@@ -42,6 +48,7 @@ def close(
     skip_flush,
     ignore_empty_list,
     allow_ilm_indices,
+    include_hidden,
     filter_list,
 ):
     """
@@ -52,6 +59,7 @@ def close(
         'skip_flush': skip_flush,
         'delete_aliases': delete_aliases,
         'allow_ilm_indices': allow_ilm_indices,
+        'include_hidden': include_hidden,
     }
     # ctx.info_name is the name of the function or name specified in
     # @click.command decorator

--- a/curator/cli_singletons/delete.py
+++ b/curator/cli_singletons/delete.py
@@ -68,6 +68,12 @@ def delete_indices(
     show_default=True,
 )
 @click.option(
+    '--include_hidden/--no-include_hidden',
+    help='Allow Curator to operate on hidden indices (and data_streams).',
+    default=False,
+    show_default=True,
+)
+@click.option(
     '--filter_list',
     callback=validate_filter_json,
     help='JSON array of filters selecting snapshots to act on.',
@@ -81,6 +87,7 @@ def delete_snapshots(
     retry_interval,
     ignore_empty_list,
     allow_ilm_indices,
+    include_hidden,
     filter_list,
 ):
     """
@@ -90,6 +97,7 @@ def delete_snapshots(
         'retry_count': retry_count,
         'retry_interval': retry_interval,
         'allow_ilm_indices': allow_ilm_indices,
+        'include_hidden': include_hidden,
     }
     # ctx.info_name is the name of the function or name specified in @click.command
     # decorator

--- a/curator/cli_singletons/forcemerge.py
+++ b/curator/cli_singletons/forcemerge.py
@@ -32,6 +32,12 @@ from curator.cli_singletons.utils import validate_filter_json
     show_default=True,
 )
 @click.option(
+    '--include_hidden/--no-include_hidden',
+    help='Allow Curator to operate on hidden indices (and data_streams).',
+    default=False,
+    show_default=True,
+)
+@click.option(
     '--filter_list',
     callback=validate_filter_json,
     help='JSON array of filters selecting indices to act on.',
@@ -45,6 +51,7 @@ def forcemerge(
     delay,
     ignore_empty_list,
     allow_ilm_indices,
+    include_hidden,
     filter_list,
 ):
     """
@@ -55,6 +62,7 @@ def forcemerge(
         'max_num_segments': max_num_segments,
         'delay': delay,
         'allow_ilm_indices': allow_ilm_indices,
+        'include_hidden': include_hidden,
     }
     # ctx.info_name is the name of the function or name specified in
     # @click.command decorator

--- a/curator/cli_singletons/object_class.py
+++ b/curator/cli_singletons/object_class.py
@@ -100,6 +100,7 @@ class CLIAction:
             self.options = option_dict
 
         self.search_pattern = self.options.pop('search_pattern', '*')
+        self.include_hidden = self.options.pop('include_hidden', False)
 
         # Extract allow_ilm_indices so it can be handled separately.
         if 'allow_ilm_indices' in self.options:
@@ -214,7 +215,9 @@ class CLIAction:
             self.list_object = SnapshotList(self.client, repository=self.repository)
         else:
             self.list_object = IndexList(
-                self.client, search_pattern=self.search_pattern
+                self.client,
+                search_pattern=self.search_pattern,
+                include_hidden=self.include_hidden,
             )
 
     def get_alias_obj(self):
@@ -230,7 +233,9 @@ class CLIAction:
                 )
                 self.logger.debug(msg)
                 self.alias[k]['ilo'] = IndexList(
-                    self.client, search_pattern=self.search_pattern
+                    self.client,
+                    search_pattern=self.search_pattern,
+                    include_hidden=self.include_hidden,
                 )
                 self.alias[k]['ilo'].iterate_filters(
                     {'filters': self.alias[k]['filters']}

--- a/curator/cli_singletons/open_indices.py
+++ b/curator/cli_singletons/open_indices.py
@@ -21,6 +21,12 @@ from curator.cli_singletons.utils import validate_filter_json
     show_default=True,
 )
 @click.option(
+    '--include_hidden/--no-include_hidden',
+    help='Allow Curator to operate on hidden indices (and data_streams).',
+    default=False,
+    show_default=True,
+)
+@click.option(
     '--filter_list',
     callback=validate_filter_json,
     help='JSON array of filters selecting indices to act on.',
@@ -28,7 +34,12 @@ from curator.cli_singletons.utils import validate_filter_json
 )
 @click.pass_context
 def open_indices(
-    ctx, search_pattern, ignore_empty_list, allow_ilm_indices, filter_list
+    ctx,
+    search_pattern,
+    ignore_empty_list,
+    allow_ilm_indices,
+    include_hidden,
+    filter_list,
 ):
     """
     Open Indices
@@ -38,7 +49,11 @@ def open_indices(
     action = CLIAction(
         ctx.info_name,
         ctx.obj['configdict'],
-        {'search_pattern': search_pattern, 'allow_ilm_indices': allow_ilm_indices},
+        {
+            'search_pattern': search_pattern,
+            'allow_ilm_indices': allow_ilm_indices,
+            'include_hidden': include_hidden,
+        },
         filter_list,
         ignore_empty_list,
     )

--- a/curator/cli_singletons/replicas.py
+++ b/curator/cli_singletons/replicas.py
@@ -28,6 +28,12 @@ from curator.cli_singletons.utils import validate_filter_json
     show_default=True,
 )
 @click.option(
+    '--include_hidden/--no-include_hidden',
+    help='Allow Curator to operate on hidden indices (and data_streams).',
+    default=False,
+    show_default=True,
+)
+@click.option(
     '--filter_list',
     callback=validate_filter_json,
     help='JSON array of filters selecting indices to act on.',
@@ -41,6 +47,7 @@ def replicas(
     wait_for_completion,
     ignore_empty_list,
     allow_ilm_indices,
+    include_hidden,
     filter_list,
 ):
     """
@@ -51,6 +58,7 @@ def replicas(
         'count': count,
         'wait_for_completion': wait_for_completion,
         'allow_ilm_indices': allow_ilm_indices,
+        'include_hidden': include_hidden,
     }
     # ctx.info_name is the name of the function or name specified in
     # @click.command decorator

--- a/curator/cli_singletons/restore.py
+++ b/curator/cli_singletons/restore.py
@@ -90,6 +90,12 @@ from curator.cli_singletons.utils import json_to_dict, validate_filter_json
     show_default=True,
 )
 @click.option(
+    '--include_hidden/--no-include_hidden',
+    help='Allow Curator to operate on hidden indices (and data_streams).',
+    default=False,
+    show_default=True,
+)
+@click.option(
     '--filter_list',
     callback=validate_filter_json,
     help='JSON array of filters selecting snapshots to act on.',
@@ -114,6 +120,7 @@ def restore(
     skip_repo_fs_check,
     ignore_empty_list,
     allow_ilm_indices,
+    include_hidden,
     filter_list,
 ):
     """
@@ -135,6 +142,7 @@ def restore(
         'max_wait': max_wait,
         'wait_interval': wait_interval,
         'allow_ilm_indices': allow_ilm_indices,
+        'include_hidden': include_hidden,
     }
     # ctx.info_name is the name of the function or name specified in
     # @click.command decorator

--- a/curator/cli_singletons/rollover.py
+++ b/curator/cli_singletons/rollover.py
@@ -38,6 +38,12 @@ from curator.cli_singletons.utils import json_to_dict
     default=False,
     show_default=True,
 )
+@click.option(
+    '--include_hidden/--no-include_hidden',
+    help='Allow Curator to operate on hidden indices (and data_streams).',
+    default=False,
+    show_default=True,
+)
 @click.pass_context
 def rollover(
     ctx,
@@ -49,6 +55,7 @@ def rollover(
     new_index,
     wait_for_active_shards,
     allow_ilm_indices,
+    include_hidden,
 ):
     """
     Rollover Index associated with Alias
@@ -64,6 +71,7 @@ def rollover(
         'name': name,
         'conditions': conditions,
         'allow_ilm_indices': allow_ilm_indices,
+        'include_hidden': include_hidden,
     }
     # ctx.info_name is the name of the function or name specified in
     # @click.command decorator

--- a/curator/cli_singletons/show.py
+++ b/curator/cli_singletons/show.py
@@ -37,6 +37,12 @@ from curator._version import __version__
     show_default=True,
 )
 @click.option(
+    '--include_hidden/--no-include_hidden',
+    help='Allow Curator to operate on hidden indices (and data_streams).',
+    default=False,
+    show_default=True,
+)
+@click.option(
     '--filter_list',
     callback=validate_filter_json,
     default='{"filtertype":"none"}',
@@ -51,6 +57,7 @@ def show_indices(
     epoch,
     ignore_empty_list,
     allow_ilm_indices,
+    include_hidden,
     filter_list,
 ):
     """
@@ -61,7 +68,11 @@ def show_indices(
     action = CLIAction(
         'show_indices',
         ctx.obj['configdict'],
-        {'search_pattern': search_pattern, 'allow_ilm_indices': allow_ilm_indices},
+        {
+            'search_pattern': search_pattern,
+            'allow_ilm_indices': allow_ilm_indices,
+            'include_hidden': include_hidden,
+        },
         filter_list,
         ignore_empty_list,
     )

--- a/curator/cli_singletons/shrink.py
+++ b/curator/cli_singletons/shrink.py
@@ -104,6 +104,12 @@ from curator.cli_singletons.utils import json_to_dict, validate_filter_json
     show_default=True,
 )
 @click.option(
+    '--include_hidden/--no-include_hidden',
+    help='Allow Curator to operate on hidden indices (and data_streams).',
+    default=False,
+    show_default=True,
+)
+@click.option(
     '--filter_list',
     callback=validate_filter_json,
     help='JSON array of filters selecting indices to act on.',
@@ -130,6 +136,7 @@ def shrink(
     max_wait,
     ignore_empty_list,
     allow_ilm_indices,
+    include_hidden,
     filter_list,
 ):
     """
@@ -153,6 +160,7 @@ def shrink(
         'wait_interval': wait_interval,
         'max_wait': max_wait,
         'allow_ilm_indices': allow_ilm_indices,
+        'include_hidden': include_hidden,
     }
     # ctx.info_name is the name of the function or name specified in
     # @click.command decorator

--- a/curator/cli_singletons/snapshot.py
+++ b/curator/cli_singletons/snapshot.py
@@ -72,6 +72,12 @@ from curator.cli_singletons.utils import validate_filter_json
     show_default=True,
 )
 @click.option(
+    '--include_hidden/--no-include_hidden',
+    help='Allow Curator to operate on hidden indices (and data_streams).',
+    default=False,
+    show_default=True,
+)
+@click.option(
     '--filter_list',
     callback=validate_filter_json,
     help='JSON array of filters selecting indices to act on.',
@@ -92,6 +98,7 @@ def snapshot(
     max_wait,
     ignore_empty_list,
     allow_ilm_indices,
+    include_hidden,
     filter_list,
 ):
     """
@@ -109,6 +116,7 @@ def snapshot(
         'max_wait': max_wait,
         'wait_interval': wait_interval,
         'allow_ilm_indices': allow_ilm_indices,
+        'include_hidden': include_hidden,
     }
     # ctx.info_name is the name of the function or name specified in
     # @click.command decorator

--- a/curator/defaults/option_defaults.py
+++ b/curator/defaults/option_defaults.py
@@ -218,6 +218,17 @@ def include_global_state(action):
     }
 
 
+def include_hidden():
+    """
+    :returns:
+        {Optional('include_hidden', default=False):
+            Any(bool, All(Any(str), Boolean()))}
+    """
+    return {
+        Optional('include_hidden', default=False): Any(bool, All(Any(str), Boolean()))
+    }
+
+
 def index_settings():
     """
     :returns: {Required('index_settings'): {'index': dict}}

--- a/curator/defaults/settings.py
+++ b/curator/defaults/settings.py
@@ -189,13 +189,14 @@ def default_options():
     :returns: The default values for these options:
         {'allow_ilm_indices': False, 'continue_if_exception': False,
         'disable_action': False, 'ignore_empty_list': False,
-        'timeout_override': None}
+        'include_hidden': False, 'timeout_override': None}
     """
     return {
         'allow_ilm_indices': False,
         'continue_if_exception': False,
         'disable_action': False,
         'ignore_empty_list': False,
+        'include_hidden': False,
         'timeout_override': None,
     }
 

--- a/curator/helpers/getters.py
+++ b/curator/helpers/getters.py
@@ -101,24 +101,37 @@ def get_data_tiers(client):
     return retval
 
 
-def get_indices(client, search_pattern='*'):
+def get_indices(client, search_pattern='*', include_hidden=False):
     """
     Calls :py:meth:`~.elasticsearch.client.CatClient.indices`
 
-    :param client: A client connection object
-    :type client: :py:class:`~.elasticsearch.Elasticsearch`
+    Will use the provided ``search_pattern`` to get a list of indices from the
+    cluster. If ``include_hidden`` is ``True``, it will include hidden indices
+    in 'expand_wildcards'.
 
-    :returns: The current list of indices from the cluster
+    :param
+        client: A client connection object
+        search_pattern: The index search pattern to use
+        include_hidden: Include hidden indices in the list
+    :type
+        client: :py:class:`~.elasticsearch.Elasticsearch`
+        search_pattern: str
+        include_hidden: bool
+
+
+    :returns: The matching list of indices from the cluster
     :rtype: list
     """
     logger = logging.getLogger(__name__)
     indices = []
+    expand = 'open,closed,hidden' if include_hidden else 'open,closed'
+    logger.debug('expand = %s', expand)
     try:
         # Doing this in two stages because IndexList also calls for these args,
         # and the unit tests need to Mock this call the same exact way.
         resp = client.cat.indices(
             index=search_pattern + ',' + EXCLUDE_SYSTEM,
-            expand_wildcards='open,closed',
+            expand_wildcards=expand,
             h='index,status',
             format='json',
         )

--- a/curator/indexlist.py
+++ b/curator/indexlist.py
@@ -31,7 +31,7 @@ from curator.validators.filter_functions import filterstructure
 class IndexList:
     """IndexList class"""
 
-    def __init__(self, client, search_pattern='*'):
+    def __init__(self, client, search_pattern='*', include_hidden=False):
         verify_client_object(client)
         self.loggit = logging.getLogger('curator.indexlist')
         #: An :py:class:`~.elasticsearch.Elasticsearch` client object passed from
@@ -48,7 +48,7 @@ class IndexList:
         #: All indices in the cluster at instance creation time.
         #: **Type:** :py:class:`list`
         self.all_indices = []
-        self.__get_indices(search_pattern)
+        self.__get_indices(search_pattern, include_hidden)
         self.age_keyfield = None
 
     def __actionable(self, idx):
@@ -76,13 +76,15 @@ class IndexList:
         if msg:
             self.loggit.debug('%s: %s', text, msg)
 
-    def __get_indices(self, pattern):
+    def __get_indices(self, pattern, include_hidden):
         """
         Pull all indices into ``all_indices``, then populate ``indices`` and
         ``index_info``
         """
         self.loggit.debug('Getting indices matching search_pattern: "%s"', pattern)
-        self.all_indices = get_indices(self.client, search_pattern=pattern)
+        self.all_indices = get_indices(
+            self.client, search_pattern=pattern, include_hidden=include_hidden
+        )
         self.indices = self.all_indices[:]
         # if self.indices:
         #     for index in self.indices:

--- a/curator/validators/options.py
+++ b/curator/validators/options.py
@@ -177,6 +177,7 @@ def get_schema(action):
         option_defaults.continue_if_exception(),
         option_defaults.disable_action(),
         option_defaults.ignore_empty_list(),
+        option_defaults.include_hidden(),
         option_defaults.timeout_override(action),
     ]
     for each in defaults:

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,8 +3,41 @@
 Changelog
 =========
 
-(? ? ?) (?? ???? ????)
-----------------------
+(8.0.19) (5 March 2025)
+-----------------------
+
+**Announcement**
+
+The ability to include hidden indices is now available in Curator. This is now
+an option you can include in the ``options`` section of your configuration file.
+
+.. code-block:: yaml
+
+    options:
+      include_hidden: True
+
+This will allow Curator to include hidden indices in its actions. This will not
+suddenly reveal system indices, but it will allow you to include indices that
+are hidden, such as indices backing certain data_streams.
+
+This is also an option flag for the CLI Singletons, e.g. ``--include-hidden``,
+with the default value being the equivalent of ``--no-include_hidden``.
+
+There's an odd caveat to this, however, and it is probaby a bug in Elasticsearch.
+If you have an index that starts with a dot, e.g. ``.my_index``, and you set your
+multi-target search pattern to also start with a dot, e.g. ``.my_*``, and you
+set the index settings for ``.my_index`` to be ``hidden: true``, the index will
+not be excluded from the search results when the ``expand_wildcards`` parameter
+is set to include hidden indices, e.g. ``open,closed,hidden``.
+
+This is a bug in Elasticsearch, and not in Curator. I've reported it to the
+Elasticsearch team at https://github.com/elastic/elasticsearch/issues/124167,
+but I'm not sure when it will be addressed. In the meantime, if you need to
+guarantee hidden indices stay excluded, use ``search_pattern`` and filters
+to exclude anything that needs to stay excluded.
+
+All tests pass on versions 7.17.25 and 8.17.2 of Elasticsearch.
+
 
 **Changes**
 
@@ -17,6 +50,8 @@ Changelog
   * PEP8 formatting changes to ``tests/integration/testvars.py`` as well as adding
     the ``filter_closed`` YAML sample.
   * Updated ``docs/conf.py`` to reflect the modules being used.
+  * Add support to include hidden indices. This is done by adding ``hidden`` to
+    the ``expand_wildcards`` keyword arg, which will make it ``open,closed,hidden``.
   
 
 8.0.18 (27 February 2025)

--- a/docs/asciidoc/index.asciidoc
+++ b/docs/asciidoc/index.asciidoc
@@ -1,4 +1,4 @@
-:curator_version: 8.0.18
+:curator_version: 8.0.19
 :curator_major: 8
 :curator_doc_tree: 8.0
 :es_py_version: 8.17.1

--- a/docs/asciidoc/options.asciidoc
+++ b/docs/asciidoc/options.asciidoc
@@ -19,6 +19,7 @@ Options are settings used by <<actions,actions>>.
 * <<option_ignore,ignore_unavailable>>
 * <<option_include_aliases,include_aliases>>
 * <<option_include_gs,include_global_state>>
+* <<option_include_hidden,include_hidden>>
 * <<option_indices,indices>>
 * <<option_key,key>>
 * <<option_max_age,max_age>>
@@ -103,6 +104,31 @@ action: delete_indices
 description: "Delete the specified indices"
 options:
   allow_ilm_indices: true
+filters:
+- filtertype: ...
+-------------
+
+The value of this setting must be either `true` or `false`.
+
+The default value for this setting is `false`.
+
+[[option_include_hidden]]
+== include_hidden
+
+This option allows Curator to act on indices with the setting `hidden: true`,
+which is common with data_streams.
+
+IMPORTANT: If data_stream backing indices are matched by the `search_pattern`
+    and/or after the filters, any attempt to delete the active backing index
+    will result in an error code. The only way to delete all of a data_stream
+    is via the data_stream API.
+
+[source,yaml]
+-------------
+action: delete_indices
+description: "Delete the specified indices"
+options:
+  include_hidden: true
 filters:
 - filtertype: ...
 -------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.12', None),
-    'es_client': ('https://es-client.readthedocs.io/en/v8.17.2', None),
+    'es_client': ('https://es-client.readthedocs.io/en/v8.17.3', None),
     'elasticsearch8': ('https://elasticsearch-py.readthedocs.io/en/v8.17.1', None),
     'voluptuous': ('http://alecthomas.github.io/voluptuous/docs/_build/html', None),
     'click': ('https://click.palletsprojects.com/en/8.1.x', None),

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -7,7 +7,7 @@ Compatibility
 =============
 
 Elasticsearch Curator version 8 is compatible with Elasticsearch version 8.x, and supports Python
-versions 3.8, 3.9, 3.10, and 3.11 officially.
+versions 3.8, 3.9, 3.10, 3.11, and 3.12 officially.
 
 Installation
 ============
@@ -33,7 +33,7 @@ Example API Usage
 
     client = elasticsearch8.Elasticsearch()
 
-    ilo = curator.IndexList(client)
+    ilo = curator.IndexList(client, search_pattern='logstash-*', include_hidden=False)
     ilo.filter_by_regex(kind='prefix', value='logstash-')
     ilo.filter_by_age(source='name', direction='older', timestring='%Y.%m.%d', unit='days', unit_count=30)
     delete_indices = curator.DeleteIndices(ilo)
@@ -97,4 +97,4 @@ Blacklisting logs by way of the ``blacklist`` setting should remain configured w
 Curator action tracing.
 
 .. _the Python ECS Log Formatter: https://www.elastic.co/guide/en/ecs-logging/python/current/index.html
-.. _logging library: http://docs.python.org/3.11/library/logging.html
+.. _logging library: http://docs.python.org/3.12/library/logging.html


### PR DESCRIPTION
The ability to include hidden indices is now available in Curator. This is now an option you can include in the `options` section of your configuration file.

```yaml
    options:
      include_hidden: True
```

This will allow Curator to include hidden indices in its actions. This will not suddenly reveal system indices, but it will allow you to include indices that are hidden, such as indices backing certain data_streams.

This is also an option flag for the CLI Singletons, e.g. `--include-hidden`, with the default value being the equivalent of `--no-include_hidden`.

There's an odd caveat to this, however, and it is probaby a bug in Elasticsearch. If you have an index that starts with a dot, e.g. `.my_index`, and you set your multi-target search pattern to also start with a dot, e.g. `.my_*`, and you set the index settings for `.my_index` to be `hidden: true`, the index will not be excluded from the search results when the `expand_wildcards` parameter is set to include hidden indices, e.g. `open,closed,hidden`.

This is a bug in Elasticsearch, and not in Curator. I've reported it to the Elasticsearch team at https://github.com/elastic/elasticsearch/issues/124167, but I'm not sure when it will be addressed. In the meantime, if you need to guarantee hidden indices stay excluded, use `search_pattern` and filters to exclude anything that needs to stay excluded.

All tests pass on versions 7.17.25 and 8.17.2 of Elasticsearch.

Fixes #1744
