### PR TITLE
[docs] Fix various syntax and rendering errors

### DIFF
--- a/docs/reference/alias.md
+++ b/docs/reference/alias.md
@@ -51,7 +51,7 @@ Before creating a filtered alias, first ensure that the fields already exist in 
 ::::
 
 
-Learn more about adding filtering and routing to aliases in the [Elasticsearch Alias API documentation](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/indices-aliases.md).
+Learn more about adding filtering and routing to aliases in the [Elasticsearch Alias API documentation](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-update-aliases).
 
 ## Required settings [_required_settings]
 

--- a/docs/reference/allocation.md
+++ b/docs/reference/allocation.md
@@ -23,7 +23,7 @@ Empty values and commented lines will result in the default value, if any, being
 
 This action changes the shard routing allocation for the selected indices.
 
-See [http://www.elastic.co/guide/en/elasticsearch/reference/8.15/shard-allocation-filtering.html](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/shard-allocation-filtering.html) for more information.
+See [Index-level shard allocation](docs-content://deploy-manage/distributed-architecture/shard-allocation-relocation-recovery/index-level-shard-allocation.md) for more information.
 
 You can optionally set `wait_for_completion` to `True` to have Curator wait for the shard routing to complete before continuing:
 

--- a/docs/reference/cluster_routing.md
+++ b/docs/reference/cluster_routing.md
@@ -21,7 +21,7 @@ Empty values and commented lines will result in the default value, if any, being
 
 This action changes the shard routing allocation for the selected indices.
 
-See [http://www.elastic.co/guide/en/elasticsearch/reference/8.15/shards-allocation.html](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/shards-allocation.md) for more information.
+See [Cluster-level shard allocation settings](elasticsearch://reference/elasticsearch/configuration-reference/cluster-level-shard-allocation-routing-settings.md#cluster-shard-allocation-settings) for more information.
 
 You can optionally set `wait_for_completion` to `True` to have Curator wait for the shard routing to complete before continuing:
 

--- a/docs/reference/cold2frozen.md
+++ b/docs/reference/cold2frozen.md
@@ -32,7 +32,7 @@ This action migrates the selected non-ILM indices from the cold tier to the froz
 
 Settings that should be added to the index when it is mounted. This should be a YAML dictionary containing anything under what would normally appear in `settings`.
 
-See [http://www.elastic.co/guide/en/elasticsearch/reference/8.15/searchable-snapshots-api-mount-snapshot.html](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/searchable-snapshots-api-mount-snapshot.md)
+See the [Elasticsearch Searchable snapshots API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-searchable-snapshots-mount).
 
 ```yaml
 action: cold2frozen
@@ -59,7 +59,7 @@ If unset, the default behavior is to ensure that the `_tier_preference` is `data
 
 This should be a YAML list of index settings the migrated index should ignore after mount.
 
-See [http://www.elastic.co/guide/en/elasticsearch/reference/8.15/searchable-snapshots-api-mount-snapshot.html](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/searchable-snapshots-api-mount-snapshot.md)
+See the [Elasticsearch Searchable snapshots API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-searchable-snapshots-mount).
 
 ```yaml
 action: cold2frozen

--- a/docs/reference/create_index.md
+++ b/docs/reference/create_index.md
@@ -55,9 +55,9 @@ options:
   # ...
 ```
 
-For the `create_index` action, the [name](/reference/option_name.md) option can be in Elasticsearch [date math](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/api-conventions.md#api-date-math-index-names) format.  This allows index names containing dates to use deterministic math to set a date name in the past or the future.
+For the `create_index` action, the [name](/reference/option_name.md) option can be in Elasticsearch [date math](elasticsearch://reference/elasticsearch/rest-apis/api-conventions.md#api-date-math-index-names) format.  This allows index names containing dates to use deterministic math to set a date name in the past or the future.
 
-For example, if today’s date were 2017-03-27, the name `<logstash-{now/d}>` will create an index named `logstash-2017.03.27`. If you wanted to create *tomorrow’s* index, you would use the name `<logstash-{now/d+1d}>`, which adds 1 day.  This pattern creates an index named `logstash-2017.03.28`.  For many more configuration options, read the Elasticsearch [date math](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/api-conventions.md#api-date-math-index-names) documentation.
+For example, if today’s date were 2017-03-27, the name `<logstash-{now/d}>` will create an index named `logstash-2017.03.27`. If you wanted to create *tomorrow’s* index, you would use the name `<logstash-{now/d+1d}>`, which adds 1 day.  This pattern creates an index named `logstash-2017.03.28`.  For many more configuration options, read the Elasticsearch [date math](elasticsearch://reference/elasticsearch/rest-apis/api-conventions.md#api-date-math-index-names) documentation.
 
 
 ## Extra Settings [_extra_settings]
@@ -90,7 +90,7 @@ options:
 
 ## Optional settings [_optional_settings_6]
 
-* [extra_settings](/reference/option_extra_settings.md) No default value.  You can add any acceptable index settings and mappings as nested YAML.  See the [Elasticsearch Create Index API documentation](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/indices-create-index.md) for more information.
+* [extra_settings](/reference/option_extra_settings.md) No default value.  You can add any acceptable index settings and mappings as nested YAML.  See the [Elasticsearch Create Index API documentation](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-create) for more information.
 * [timeout_override](/reference/option_timeout_override.md)
 * [continue_if_exception](/reference/option_continue.md)
 * [disable_action](/reference/option_disable.md)

--- a/docs/reference/curator-ilm.md
+++ b/docs/reference/curator-ilm.md
@@ -6,5 +6,5 @@ mapped_pages:
 
 # Curator and index lifecycle management [ilm]
 
-Beginning with Elasticsearch version 6.6, Elasticsearch has provided [Index Lifecycle Management](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/index-lifecycle-management.md) (ILM) to users with at least a Basic license. ILM provides users with many of the most common index management features as a matter of policy, rather than execution time analysis (which is how Curator works).
+Beginning with Elasticsearch version 6.6, Elasticsearch has provided [Index Lifecycle Management](docs-content://manage-data/lifecycle/index-lifecycle-management.md) (ILM) to users with at least a Basic license. ILM provides users with many of the most common index management features as a matter of policy, rather than execution time analysis (which is how Curator works).
 

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -9,7 +9,7 @@ Curator is periodically published to Docker Hub at [`untergeek/curator`](https:/
 
 Download Curator Docker image:
 
-```
+```sh subs=true
 docker pull untergeek/curator:{{curator_version}}
 ```
 

--- a/docs/reference/faq_partial_delete.md
+++ b/docs/reference/faq_partial_delete.md
@@ -25,7 +25,6 @@ While it may be desirable to have different life-cycles for your data, sometimes
 
 #### Post-script: [_post_script]
 
-Even though it is neither recommended <sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>(http://blog.mikemccandless.com/2011/02/visualizing-lucenes-segment-merges.md) and watch what happens to your segments when you delete data.], nor best practices, it is still possible to perform these search & delete operations yourself, using the [Delete-by-Query API](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/docs-delete-by-query.md). Curator will not be modified to perform operations such as these, however. Curator is meant to manage at the index level, rather than the data level.
+Even though it is neither recommended[¹](#footnote-1) and watch what happens to your segments when you delete data.], nor best practices, it is still possible to perform these search & delete operations yourself, using the [Delete-by-Query API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-delete-by-query). Curator will not be modified to perform operations such as these, however. Curator is meant to manage at the index level, rather than the data level.
 
-<hr>
-
+¹ $$$footnote-1$$$ http://blog.mikemccandless.com/2011/02/visualizing-lucenes-segment-merges.md

--- a/docs/reference/faq_partial_delete.md
+++ b/docs/reference/faq_partial_delete.md
@@ -25,6 +25,6 @@ While it may be desirable to have different life-cycles for your data, sometimes
 
 #### Post-script: [_post_script]
 
-Even though it is neither recommended[¹](#footnote-1) and watch what happens to your segments when you delete data.], nor best practices, it is still possible to perform these search & delete operations yourself, using the [Delete-by-Query API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-delete-by-query). Curator will not be modified to perform operations such as these, however. Curator is meant to manage at the index level, rather than the data level.
+Even though it is neither recommended[¹](#footnote-1), nor best practices, it is still possible to perform these search & delete operations yourself, using the [Delete-by-Query API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-delete-by-query). Curator will not be modified to perform operations such as these, however. Curator is meant to manage at the index level, rather than the data level.
 
-¹ $$$footnote-1$$$ http://blog.mikemccandless.com/2011/02/visualizing-lucenes-segment-merges.md
+¹ $$$footnote-1$$$ There are reasons Elasticsearch does not recommend this, particularly for time-series data. For more information read [http://blog.mikemccandless.com/2011/02/visualizing-lucenes-segment-merges.html](http://blog.mikemccandless.com/2011/02/visualizing-lucenes-segment-merges.html) and watch what happens to your segments when you delete data.

--- a/docs/reference/fe_allocation_type.md
+++ b/docs/reference/fe_allocation_type.md
@@ -20,7 +20,7 @@ This setting is used only when using the [allocated](/reference/filtertype_alloc
 
 The value of this setting must be one of `require`, `include`, or `exclude`.
 
-Read more about these settings in the [Elasticsearch documentation](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/shard-allocation-filtering.html).
+Read more about these settings in [Index-level shard allocation](docs-content://deploy-manage/distributed-architecture/shard-allocation-relocation-recovery/index-level-shard-allocation.md).
 
 The default value for this setting is `require`.
 

--- a/docs/reference/fe_pattern.md
+++ b/docs/reference/fe_pattern.md
@@ -21,7 +21,7 @@ This particular example will match indices following the basic rollover pattern 
 
 For example, given indices `a-000001`, `a-000002`, `a-000003` and `b-000006`, and `b-000007`, the indices will would be matched are `a-000003` and `b-000007`. Indices that do not match the regular expression in `pattern` will be automatically excluded.
 
-This is particularly useful with indices created and managed using the [Rollover API](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/indices-rollover-index.md), as you can select only the active indices with the above example ([`exclude`](/reference/fe_exclude.md) defaults to `False`). Setting [`exclude`](/reference/fe_exclude.md) to `True` with the above example will *remove* the active rollover indices, leaving only those which have been rolled-over.
+This is particularly useful with indices created and managed using the [Rollover API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-rollover), as you can select only the active indices with the above example ([`exclude`](/reference/fe_exclude.md) defaults to `False`). Setting [`exclude`](/reference/fe_exclude.md) to `True` with the above example will *remove* the active rollover indices, leaving only those which have been rolled-over.
 
 While this is perhaps most useful for the aforementioned scenario, it can also be used with age-based indices as well.
 

--- a/docs/reference/fe_unit.md
+++ b/docs/reference/fe_unit.md
@@ -32,11 +32,11 @@ point_of_reference = epoch - ((number of seconds in unit) * unit_count)
 | --- | --- | --- |
 | `seconds` | `1` | One second |
 | `minutes` | `60` | Calculated as 60 seconds |
-| `hours` | `3600` | Calculated as 60 minutes (60*60) |
-| `days` | `86400` | Calculated as 24 hours (24*60*60) |
-| `weeks` | `604800` | Calculated as 7 days (7*24*60*60) |
-| `months` | `2592000` | Calculated as 30 days (30*24*60*60) |
-| `years` | `31536000` | Calculated as 365 days (365*24*60*60) |
+| `hours` | `3600` | Calculated as 60 minutes (`60 * 60`) |
+| `days` | `86400` | Calculated as 24 hours (`24 * 60 * 60`) |
+| `weeks` | `604800` | Calculated as 7 days (`7 * 24 * 60 * 60`) |
+| `months` | `2592000` | Calculated as 30 days (`30 * 24 * 60 * 60`) |
+| `years` | `31536000` | Calculated as 365 days (`365 * 24 * 60 * 60`) |
 
 If [epoch](/reference/fe_epoch.md) is unset, the current time is used. It is possible to set a point of reference in the future by using a negative value for [unit_count](/reference/fe_unit_count.md).
 

--- a/docs/reference/fe_unit_count.md
+++ b/docs/reference/fe_unit_count.md
@@ -32,11 +32,11 @@ point_of_reference = epoch - ((number of seconds in unit) * unit_count)
 | --- | --- | --- |
 | `seconds` | `1` | One second |
 | `minutes` | `60` | Calculated as 60 seconds |
-| `hours` | `3600` | Calculated as 60 minutes (60*60) |
-| `days` | `86400` | Calculated as 24 hours (24*60*60) |
-| `weeks` | `604800` | Calculated as 7 days (7*24*60*60) |
-| `months` | `2592000` | Calculated as 30 days (30*24*60*60) |
-| `years` | `31536000` | Calculated as 365 days (365*24*60*60) |
+| `hours` | `3600` | Calculated as 60 minutes (`60 * 60`) |
+| `days` | `86400` | Calculated as 24 hours (`24 * 60 * 60`) |
+| `weeks` | `604800` | Calculated as 7 days (`7 * 24 * 60 * 60`) |
+| `months` | `2592000` | Calculated as 30 days (`30 * 24 * 60 * 60`) |
+| `years` | `31536000` | Calculated as 365 days (`365 * 24 * 60 * 60`) |
 
 If [epoch](/reference/fe_epoch.md) is unset, the current time is used. It is possible to set a point of reference in the future by using a negative value for unit_count.
 

--- a/docs/reference/filtertype_age.md
+++ b/docs/reference/filtertype_age.md
@@ -20,11 +20,11 @@ This [filtertype](/reference/filtertype.md) will iterate over the actionable lis
 | --- | --- | --- |
 | `seconds` | `1` | One second |
 | `minutes` | `60` | Calculated as 60 seconds |
-| `hours` | `3600` | Calculated as 60 minutes (60*60) |
-| `days` | `86400` | Calculated as 24 hours (24*60*60) |
-| `weeks` | `604800` | Calculated as 7 days (7*24*60*60) |
-| `months` | `2592000` | Calculated as 30 days (30*24*60*60) |
-| `years` | `31536000` | Calculated as 365 days (365*24*60*60) |
+| `hours` | `3600` | Calculated as 60 minutes (`60 * 60`) |
+| `days` | `86400` | Calculated as 24 hours (`24 * 60 * 60`) |
+| `weeks` | `604800` | Calculated as 7 days (`7 * 24 * 60 * 60`) |
+| `months` | `2592000` | Calculated as 30 days (`30 * 24 * 60 * 60`) |
+| `years` | `31536000` | Calculated as 365 days (`365 * 24 * 60 * 60`) |
 
 All calculations are in epoch time, which is the number of seconds elapsed since 1 Jan 1970.  If no [`epoch`](/reference/fe_epoch.md) is specified in the filter, then the current epoch time-which is always UTC-is used as the basis for comparison.
 
@@ -44,7 +44,7 @@ For example, if the time at execution were 2017-04-07T15:00:00Z (UTC), then the 
 
 The time differential would be `3*24*60*60` seconds, which is `259200` seconds. Subtracting this value from `1491577200` gives us `1491318000`, which is 2017-04-04T15:00:00Z (UTC), exactly 3 days in the past.  The `creation_date` of indices or snapshots is compared to this timestamp. If it is `older`, it stays in the actionable list, otherwise it is removed from the actionable list.
 
-::::{admonition} `age` filter vs. `period` filter
+::::{admonition} age filter vs. period filter
 :class: important
 
 The time differential means of calculation can lead to frustration.

--- a/docs/reference/filtertype_count.md
+++ b/docs/reference/filtertype_count.md
@@ -46,7 +46,7 @@ This particular example will match indices following the basic rollover pattern 
 
 For example, given indices `a-000001`, `a-000002`, `a-000003` and `b-000006`, and `b-000007`, the indices will would be matched are `a-000003` and `b-000007`. Indices that do not match the regular expression in `pattern` will be automatically excluded.
 
-This is particularly useful with indices created and managed using the [Rollover API](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/indices-rollover-index.md), as you can select only the active indices with the above example ([`exclude`](/reference/fe_exclude.md) defaults to `False`). Setting [`exclude`](/reference/fe_exclude.md) to `True` with the above example will *remove* the active rollover indices, leaving only those which have been rolled-over.
+This is particularly useful with indices created and managed using the [Rollover API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-rollover), as you can select only the active indices with the above example ([`exclude`](/reference/fe_exclude.md) defaults to `False`). Setting [`exclude`](/reference/fe_exclude.md) to `True` with the above example will *remove* the active rollover indices, leaving only those which have been rolled-over.
 
 While this is perhaps most useful for the aforementioned scenario, it can also be used with age-based indices as well.
 

--- a/docs/reference/filtertype_period.md
+++ b/docs/reference/filtertype_period.md
@@ -102,11 +102,11 @@ The period filter is smart enough to calculate `months` and `years` properly.  *
 | --- | --- | --- |
 | `seconds` | `1` | One second |
 | `minutes` | `60` | Calculated as 60 seconds |
-| `hours` | `3600` | Calculated as 60 minutes (60*60) |
-| `days` | `86400` | Calculated as 24 hours (24*60*60) |
-| `weeks` | `604800` | Calculated as 7 days (7*24*60*60) |
-| `months` | `2592000` | Calculated as 30 days (30*24*60*60) |
-| `years` | `31536000` | Calculated as 365 days (365*24*60*60) |
+| `hours` | `3600` | Calculated as 60 minutes (`60 * 60`) |
+| `days` | `86400` | Calculated as 24 hours (`24 * 60 * 60`) |
+| `weeks` | `604800` | Calculated as 7 days (`7 * 24 * 60 * 60`) |
+| `months` | `2592000` | Calculated as 30 days (`30 * 24 * 60 * 60`) |
+| `years` | `31536000` | Calculated as 365 days (`365 * 24 * 60 * 60`) |
 
 ::::
 

--- a/docs/reference/forcemerge.md
+++ b/docs/reference/forcemerge.md
@@ -24,7 +24,7 @@ Empty values and commented lines will result in the default value, if any, being
 This action performs a forceMerge on the selected indices, merging them to [max_num_segments](/reference/option_mns.md) per shard.
 
 ::::{warning}
-A [`forcemerge`](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/indices-forcemerge.md#indices-forcemerge) should never be executed on an index that is actively receiving data.  It should only ever be performed on indices where no more documents are ever anticipated to be added in the future.
+A [`forcemerge`](https://www.elastic.co/docs/api/doc/elasticsearch/) should never be executed on an index that is actively receiving data.  It should only ever be performed on indices where no more documents are ever anticipated to be added in the future.
 ::::
 
 

--- a/docs/reference/ilm-actions.md
+++ b/docs/reference/ilm-actions.md
@@ -14,12 +14,12 @@ ILM applies policy actions as indices enter time-oriented phases:
 
 The policy actions include:
 
-* [Set Priority](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/ilm-set-priority.md)
-* [Rollover](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/ilm-rollover.md)
-* [Unfollow](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/ilm-unfollow.md)
-* [Allocate](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/ilm-allocate.md)
-* [Read-Only](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/ilm-readonly.md)
-* [Force Merge](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/ilm-forcemerge.md)
-* [Shrink](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/ilm-shrink.md)
-* [Delete](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/ilm-delete.md)
+* [Set Priority](elasticsearch://reference/elasticsearch/index-lifecycle-actions/ilm-set-priority.md)
+* [Rollover](elasticsearch://reference/elasticsearch/index-lifecycle-actions/ilm-rollover.md)
+* [Unfollow](elasticsearch://reference/elasticsearch/index-lifecycle-actions/ilm-unfollow.md)
+* [Allocate](elasticsearch://reference/elasticsearch/index-lifecycle-actions/ilm-allocate.md)
+* [Read-Only](elasticsearch://reference/elasticsearch/index-lifecycle-actions/ilm-readonly.md)
+* [Force Merge](elasticsearch://reference/elasticsearch/index-lifecycle-actions/ilm-forcemerge.md)
+* [Shrink](elasticsearch://reference/elasticsearch/index-lifecycle-actions/ilm-shrink.md)
+* [Delete](elasticsearch://reference/elasticsearch/index-lifecycle-actions/ilm-delete.md)
 

--- a/docs/reference/ilm-and-curator.md
+++ b/docs/reference/ilm-and-curator.md
@@ -14,5 +14,5 @@ Curator and ILM *can* coexist. However, to prevent Curator from accidentally int
 
 Curator can be configured to work with ILM-enabled indices by setting the [`allow_ilm_indices`](/reference/option_allow_ilm.md) option to `true` for any action.
 
-Learn more about Index Lifecycle Management [here](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/index-lifecycle-management.md).
+Learn more in [Index lifecycle management](docs-content://manage-data/lifecycle/index-lifecycle-management.md).
 

--- a/docs/reference/ilm-or-curator.md
+++ b/docs/reference/ilm-or-curator.md
@@ -18,7 +18,7 @@ Starting with version 7.0, Filebeat uses index lifecycle management by default w
 
 You can view and edit the policy in the Index lifecycle policies UI in Kibana. For more information about working with the UI, see [Index lifecyle policies](docs-content://manage-data/lifecycle/index-lifecycle-management.md).
 
-Read more about Filebeat and ILM in [](beats://reference/filebeat/ilm.md).
+Read more about Filebeat and ILM in [Configure index lifecycle management](beats://reference/filebeat/ilm.md).
 
 
 ## Logstash [ilm-logstash]
@@ -32,6 +32,6 @@ Logstash can use [index lifecycle management](docs-content://manage-data/lifecyc
 
 The use of Index Lifecycle Management is controlled by the `ilm_enabled` setting. By default, this will automatically detect whether the Elasticsearch instance supports ILM, and will use it if it is available. `ilm_enabled` can also be set to `true` or `false` to override the automatic detection, or disable ILM.
 
-Read more about Logstash and ILM in [](logstash-docs-md://lsr/plugins-outputs-elasticsearch.md#plugins-outputs-elasticsearch-ilm).
+Read more about Logstash and ILM in [Elasticsearch output plugin](logstash-docs-md://lsr/plugins-outputs-elasticsearch.md#plugins-outputs-elasticsearch-ilm).
 
 

--- a/docs/reference/option_allocation_type.md
+++ b/docs/reference/option_allocation_type.md
@@ -23,7 +23,7 @@ filters:
 
 The value of this setting must be one of `require`, `include`, or `exclude`.
 
-Read more about these settings at [http://www.elastic.co/guide/en/elasticsearch/reference/8.15/shard-allocation-filtering.html](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/shard-allocation-filtering.md)
+Read more about these settings in [Index-level shard allocation](docs-content://deploy-manage/distributed-architecture/shard-allocation-relocation-recovery/index-level-shard-allocation.md).
 
 The default value for this setting is `require`.
 

--- a/docs/reference/option_continue.md
+++ b/docs/reference/option_continue.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # continue_if_exception [option_continue]
 
-::::{admonition} Using `ignore_empty_list` rather than `continue_if_exception`
+::::{admonition} Using ignore_empty_list rather than continue_if_exception
 :class: important
 
 Curator has two general classifications of exceptions: Empty list exceptions, and everything else. The empty list conditions are `curator.exception.NoIndices` and `curator.exception.NoSnapshots`.  The `continue_if_exception` option *only* catches conditions *other* than empty list conditions. In most cases, you will want to use `ignore_empty_list` instead of `continue_if_exception`.

--- a/docs/reference/option_extra_settings.md
+++ b/docs/reference/option_extra_settings.md
@@ -50,7 +50,7 @@ options:
 
 ## [restore](/reference/restore.md) [_restore/curator/docs/reference/elasticsearch/elasticsearch-client-curator/restore.md]
 
-See the [official Elasticsearch Documentation](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/snapshots-restore-snapshot.md).
+See the [official Elasticsearch Documentation](docs-content://deploy-manage/tools/snapshot-and-restore/restore-snapshot.md).
 
 ```yaml
 actions:

--- a/docs/reference/option_ignore.md
+++ b/docs/reference/option_ignore.md
@@ -75,10 +75,10 @@ filters:
 - filtertype: ...
 ```
 
-When the `ignore_unavailable` option is `False` and an index is missing, or if the request is to apply a [static](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/index-modules.md#_static_index_settings) setting and the index is opened, the index setting request will fail. The `ignore_unavailable` option allows these indices to be skipped, when set to `True`.
+When the `ignore_unavailable` option is `False` and an index is missing, or if the request is to apply a [static](elasticsearch://reference/elasticsearch/index-settings/index-modules.md#_static_index_settings) setting and the index is opened, the index setting request will fail. The `ignore_unavailable` option allows these indices to be skipped, when set to `True`.
 
 ::::{note}
-[Dynamic](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/index-modules.md#dynamic-index-settings) index settings can be applied to either open or closed indices.
+[Dynamic](elasticsearch://reference/elasticsearch/index-settings/index-modules.md#dynamic-index-settings) index settings can be applied to either open or closed indices.
 ::::
 
 

--- a/docs/reference/option_max_size.md
+++ b/docs/reference/option_max_size.md
@@ -21,5 +21,5 @@ At least one of [max_age](/reference/option_max_age.md), [max_docs](/reference/o
 ::::
 
 
-The maximum approximate size an index is allowed to be before triggering a rollover.  Sizes must use Elasticsearch approved [human-readable byte units](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/common-options.md). It *must* be nested under `conditions:` There is no default value.  If this condition is specified, it must have a value, or Curator will generate an error.
+The maximum approximate size an index is allowed to be before triggering a rollover.  Sizes must use Elasticsearch approved [human-readable byte units](elasticsearch://reference/elasticsearch/rest-apis/common-options.md). It *must* be nested under `conditions:` There is no default value.  If this condition is specified, it must have a value, or Curator will generate an error.
 

--- a/docs/reference/option_name.md
+++ b/docs/reference/option_name.md
@@ -14,7 +14,7 @@ The value of this setting is the name of the alias, snapshot, or index, dependin
 
 ## date math [_date_math_2]
 
-This setting may be a valid [Elasticsearch date math string](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/api-conventions.md#api-date-math-index-names).
+This setting may be a valid [Elasticsearch date math string](elasticsearch://reference/elasticsearch/rest-apis/api-conventions.md#api-date-math-index-names).
 
 A date math name takes the following form:
 
@@ -89,7 +89,7 @@ options:
   # ...
 ```
 
-or use Elasticsearch [date math](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/api-conventions.md#api-date-math-index-names)
+or use Elasticsearch [date math](elasticsearch://reference/elasticsearch/rest-apis/api-conventions.md#api-date-math-index-names)
 
 ```yaml
 action: create_index

--- a/docs/reference/option_new_index.md
+++ b/docs/reference/option_new_index.md
@@ -29,7 +29,7 @@ A new index name for rollover should still end with a dash followed by an increm
 
 ## date_math [_date_math_3]
 
-This setting may be a valid [Elasticsearch date math string](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/api-conventions.md#api-date-math-index-names).
+This setting may be a valid [Elasticsearch date math string](elasticsearch://reference/elasticsearch/rest-apis/api-conventions.md#api-date-math-index-names).
 
 A date math name takes the following form:
 

--- a/docs/reference/option_refresh.md
+++ b/docs/reference/option_refresh.md
@@ -30,7 +30,7 @@ actions:
 
 Setting `refresh` to `True` will cause all re-indexed indexes to be refreshed. This differs from the Index API’s refresh parameter which causes just the *shard* that received the new data to be refreshed.
 
-Read more about this setting at [http://www.elastic.co/guide/en/elasticsearch/reference/8.15/docs-reindex.html](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/docs-reindex.html)
+Read more about this setting in [the Elasticsearch API documentation](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-reindex).
 
 The default value is `True`.
 

--- a/docs/reference/option_rename_pattern.md
+++ b/docs/reference/option_rename_pattern.md
@@ -47,7 +47,7 @@ actions:
 
 In this configuration, Elasticsearch will capture whatever appears after `index` and put it after `restored_index`.  For example, if I was restoring `index-2017.03.01`, the resulting index would be renamed to `restored_index-2017.03.01`.
 
-Read more about this setting at [http://www.elastic.co/guide/en/elasticsearch/reference/8.15/snapshots-restore-snapshot.html](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/snapshots-restore-snapshot.md)
+Read more about this setting in [Restore a snapshot](docs-content://deploy-manage/tools/snapshot-and-restore/restore-snapshot.md).
 
 There is no default value.
 

--- a/docs/reference/option_rename_replacement.md
+++ b/docs/reference/option_rename_replacement.md
@@ -47,7 +47,7 @@ actions:
 
 In this configuration, Elasticsearch will capture whatever appears after `index` and put it after `restored_index`.  For example, if I was restoring `index-2017.03.01`, the resulting index would be renamed to `restored_index-2017.03.01`.
 
-Read more about this setting at [http://www.elastic.co/guide/en/elasticsearch/reference/8.15/snapshots-restore-snapshot.html](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/snapshots-restore-snapshot.md)
+Read more about this setting in [Restore a snapshot](docs-content://deploy-manage/tools/snapshot-and-restore/restore-snapshot.md).
 
 There is no default value.
 

--- a/docs/reference/option_request_body.md
+++ b/docs/reference/option_request_body.md
@@ -281,7 +281,7 @@ Nearly all scenarios supported by the reindex API are supported in the request_b
 * Versioning
 * Reindexing operation type (for example, create-only)
 
-Read more about these, and more, at [http://www.elastic.co/guide/en/elasticsearch/reference/8.15/docs-reindex.html](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/docs-reindex.html)
+Read more about these, and more, in [the Elasticsearch API documentation](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-reindex).
 
 Notable exceptions include:
 

--- a/docs/reference/option_slices.md
+++ b/docs/reference/option_slices.md
@@ -10,7 +10,7 @@ This setting is only used by the [reindex](/reference/reindex.md) action.
 ::::
 
 
-This setting can speed up reindexing operations by using [Sliced Scroll](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/paginate-search-results.md#slice-scroll) to slice on the \_uid.
+This setting can speed up reindexing operations by using [Sliced Scroll](elasticsearch://reference/elasticsearch/rest-apis/paginate-search-results.md#slice-scroll) to slice on the \_uid.
 
 ```yaml
 actions:

--- a/docs/reference/option_wait_for_active_shards.md
+++ b/docs/reference/option_wait_for_active_shards.md
@@ -14,7 +14,7 @@ This setting determines the number of shard copies that must be active before th
 
 Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
 
-Read [the Elasticsearch documentation](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/docs-index_.md#index-wait-for-active-shards) for more information.
+Read [the Elasticsearch documentation](https://www.elastic.co/docs/api/doc/elasticsearch/) for more information.
 
 ## Reindex [_reindex]
 

--- a/docs/reference/pip.md
+++ b/docs/reference/pip.md
@@ -32,8 +32,8 @@ pip install -U elasticsearch-curator==X.Y.Z
 
 For example:
 
-```
-pip install -U elasticsearch-curator=={{curator_v}}
+```sh subs=true
+pip install -U elasticsearch-curator=={{curator_version}}
 ```
 
 ## System-wide vs. User-only installation [_system_wide_vs_user_only_installation]

--- a/docs/reference/python-source.md
+++ b/docs/reference/python-source.md
@@ -9,8 +9,14 @@ Installing or Curator from source tarball (rather than doing a `git clone`) is a
 
 Download and install Curator from tarball:
 
-1. `wget https://github.com/elastic/curator/archive/v``8.0.17.tar.gz -O elasticsearch-curator.tar.gz`
-2. `pip install elasticsearch-curator.tar.gz`
+1. Run:
+    ```sh subs=true
+    wget https://github.com/elastic/curator/archive/v{{curator_version}}.tar.gz -O elasticsearch-curator.tar.gz
+    ```
+2. Run:
+    ```sh
+    pip install elasticsearch-curator.tar.gz
+    ```
 
  
 

--- a/docs/reference/restore.md
+++ b/docs/reference/restore.md
@@ -105,7 +105,7 @@ actions:
 
 In this case, the number of replicas will be applied to the restored indices.
 
-For more information see the [official Elasticsearch Documentation](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/snapshots-restore-snapshot.md).
+For more information see [Restore a snapshot](docs-content://deploy-manage/tools/snapshot-and-restore/restore-snapshot.md).
 
 
 ## Required settings [_required_settings_9]

--- a/docs/reference/rollover.md
+++ b/docs/reference/rollover.md
@@ -18,7 +18,7 @@ options:
     max_size: 5gb
 ```
 
-This action uses the [Elasticsearch Rollover API](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/indices-rollover-index.md) to create a new index, if any of the described conditions are met.
+This action uses the [Elasticsearch Rollover API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-rollover) to create a new index, if any of the described conditions are met.
 
 ::::{important}
 When choosing `conditions`, **any** one of [max_age](/reference/option_max_age.md), [max_docs](/reference/option_max_docs.md), [max_size](/reference/option_max_size.md), **or any combination of the three** may be used. If multiple are used, then the specified condition for any one of them must be matched for the rollover to occur.
@@ -63,7 +63,7 @@ options:
 
 ## Optional settings [_optional_settings_15]
 
-* [extra_settings](/reference/option_extra_settings.md) No default value.  You can add any acceptable index settings (not mappings) as nested YAML.  See the [Elasticsearch Create Index API documentation](http://www.elastic.co/guide/en/elasticsearch/reference/8.15/indices-create-index.md) for more information.
+* [extra_settings](/reference/option_extra_settings.md) No default value.  You can add any acceptable index settings (not mappings) as nested YAML.  See the [Elasticsearch Create Index API documentation](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-create) for more information.
 * [new_index](/reference/option_new_index.md) Specify a new index name.
 * [timeout_override](/reference/option_timeout_override.md)
 * [continue_if_exception](/reference/option_continue.md)


### PR DESCRIPTION
Fixes various syntax and rendering errors that might include:

* Fixing broken images
* Hardcoding book-level substitution values
* Fixing incorrectly closed blocks (admonitions, tab sets, code blocks, dropdowns etc.)
* Fixing poorly migrated complex tables
* Fixing poorly migrated lists
* Fixing poorly migrated tab sets
* Removing inline text formatting from directive titles where they won't be rendered (for example, inline `code` formatting in dropdown titles)
* Specifying if a version is trying to communicate if a feature was added, deprecated, or coming (for example, during migration `deprecated:[8.15.0]` became `[8.15.0]`, which doesn't give any information about _what_ happened in 8.15.0)
* Fixing nested dropdowns / definition lists
* Fixing poorly migrated footnotes
* Updating references to prerelease `9.0.0` versions