### PR TITLE
Replace placeholder URLs

### DIFF
--- a/docs/reference/configfile.md
+++ b/docs/reference/configfile.md
@@ -79,22 +79,22 @@ Curator can only work with one cluster at a time.  Including clients from multip
 Flow:
 
 ```sh
-hosts: [ "<YOUR_HOST_URL_1>:9200", "<YOUR_HOST_URL_2>:9200" ]
+hosts: [ "<HOST_URL_1>:9200", "<HOST_URL_2>:9200" ]
 ```
 
 Spanning:
 
 ```sh
-hosts: [ "<YOUR_HOST_URL_1>:9200",
-    "<YOUR_HOST_URL_2>:9200" ]
+hosts: [ "<HOST_IP_1>:9200",
+    "<HOST_IP_2>:9200" ]
 ```
 
 Block:
 
 ```sh
 hosts:
-  - <YOUR_HOST_URL_1>:9200
-  - <YOUR_HOST_URL_2>:9200
+  - <HOST_IP_1>:9200
+  - <HOST_IP_2>:9200
 ```
 
 

--- a/docs/reference/configfile.md
+++ b/docs/reference/configfile.md
@@ -79,22 +79,22 @@ Curator can only work with one cluster at a time.  Including clients from multip
 Flow:
 
 ```sh
-hosts: [ "http://10.0.0.1:9200", "http://10.0.0.2:9200" ]
+hosts: [ "<YOUR_HOST_URL_1>:9200", "<YOUR_HOST_URL_2>:9200" ]
 ```
 
 Spanning:
 
 ```sh
-hosts: [ "http://10.0.0.1:9200",
-    "http://10.0.0.2:9200" ]
+hosts: [ "<YOUR_HOST_URL_1>:9200",
+    "<YOUR_HOST_URL_2>:9200" ]
 ```
 
 Block:
 
 ```sh
 hosts:
-  - http://10.0.0.1:9200
-  - http://10.0.0.2:9200
+  - <YOUR_HOST_URL_1>:9200
+  - <YOUR_HOST_URL_2>:9200
 ```
 
 

--- a/docs/reference/configfile.md
+++ b/docs/reference/configfile.md
@@ -79,7 +79,7 @@ Curator can only work with one cluster at a time.  Including clients from multip
 Flow:
 
 ```sh
-hosts: [ "<HOST_URL_1>:9200", "<HOST_URL_2>:9200" ]
+hosts: [ "<HOST_IP_1>:9200", "<HOST_IP_2>:9200" ]
 ```
 
 Spanning:

--- a/docs/reference/ex_reindex.md
+++ b/docs/reference/ex_reindex.md
@@ -114,7 +114,7 @@ actions:
       request_body:
         source:
           remote:
-            host: http://otherhost:9200
+            host: <OTHER_HOST_URL>:9200
             username: myuser
             password: mypass
           index: index1
@@ -148,7 +148,7 @@ actions:
       request_body:
         source:
           remote:
-            host: http://otherhost:9200
+            host: <OTHER_HOST_URL>:9200
             username: myuser
             password: mypass
           index: REINDEX_SELECTION

--- a/docs/reference/option_remote_certificate.md
+++ b/docs/reference/option_remote_certificate.md
@@ -21,7 +21,7 @@ actions:
       request_body:
         source:
           remote:
-            host: https://otherhost:9200
+            host: <OTHER_HOST_URL>:9200
           index: index1
         dest:
           index: index2

--- a/docs/reference/option_remote_client_cert.md
+++ b/docs/reference/option_remote_client_cert.md
@@ -26,7 +26,7 @@ actions:
       request_body:
         source:
           remote:
-            host: https://otherhost:9200
+            host: <OTHER_HOST_URL>:9200
           index: index1
         dest:
           index: index2

--- a/docs/reference/option_remote_client_key.md
+++ b/docs/reference/option_remote_client_key.md
@@ -26,7 +26,7 @@ actions:
       request_body:
         source:
           remote:
-            host: https://otherhost:9200
+            host: <OTHER_HOST_URL>:9200
           index: index1
         dest:
           index: index2

--- a/docs/reference/option_remote_filters.md
+++ b/docs/reference/option_remote_filters.md
@@ -23,7 +23,7 @@ actions:
       request_body:
         source:
           remote:
-            host: https://otherhost:9200
+            host: <OTHER_HOST_URL>:9200
           index: REINDEX_SELECTION
         dest:
           index: index2

--- a/docs/reference/option_remote_url_prefix.md
+++ b/docs/reference/option_remote_url_prefix.md
@@ -24,7 +24,7 @@ actions:
       request_body:
         source:
           remote:
-            host: https://otherhost:9200
+            host: <OTHER_HOST_URL>:9200
           index: index1
         dest:
           index: index2

--- a/docs/reference/option_request_body.md
+++ b/docs/reference/option_request_body.md
@@ -96,7 +96,7 @@ actions:
       request_body:
         source:
           remote:
-            host: http://otherhost:9200
+            host: <OTHER_HOST_URL>:9200
             username: myuser
             password: mypass
           index: index1
@@ -152,7 +152,7 @@ actions:
       request_body:
         source:
           remote:
-            host: http://otherhost:9200
+            host: <OTHER_HOST_URL>:9200
             username: myuser
             password: mypass
           index: REINDEX_SELECTION
@@ -224,7 +224,7 @@ actions:
       request_body:
         source:
           remote:
-            host: http://otherhost:9200
+            host: <OTHER_HOST_URL>:9200
             username: myuser
             password: mypass
           index: REINDEX_SELECTION


### PR DESCRIPTION
## Proposed Changes

In light of finding abuse of dummy links in our docs, this replaces placeholder URLs with non-hostable segments. 

Rel: https://github.com/elastic/docs-content/issues/1799
