### PR TITLE
license.md: change 2024 -> 2025

### DIFF
--- a/docs/reference/license.md
+++ b/docs/reference/license.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # License [license]
 
-Copyright (c) 2011-2024 Elasticsearch [http://elastic.co](http://elastic.co)
+Copyright (c) 2011-2025 Elasticsearch [http://elastic.co](http://elastic.co)
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 


### PR DESCRIPTION
I have accidentally arrived at this page: https://www.elastic.co/docs/reference/elasticsearch/curator/license and noticed the year range is 2011-2024. I guess it shall end with 2025?