### PR TITLE
[DOCS] Improve number_of_shards option page

### DIFF
--- a/docs/reference/option_number_of_shards.md
+++ b/docs/reference/option_number_of_shards.md
@@ -29,7 +29,7 @@ The value of `number_of_shards` must meet the following criteria:
 
 For example, a source index with 8 primary shards can be shrunk to 4, 2, or 1, and cannot be shrunk to 3 or 5.
 ::::
-  
+  ## number_of_shards example [option-number-of-shards-example]
 ```yaml
 action: shrink
 description: >-


### PR DESCRIPTION
Updated documentation for the number_of_shards option, clarifying its purpose and criteria for usage.

Changes include:
- Moved description to top
- Explicitly stated type, default, and whether it’s optional.
- Added links to shards intro and shard sizing guidance to help with assumed knowledge.
- Clarified scope: relevant to cloud/on-prem, not serverless.